### PR TITLE
fix: prevent DNS error on Google OAuth when Supabase env vars are missing

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -1,16 +1,22 @@
 import { createClient } from "@supabase/supabase-js";
 import type { Database } from "./types";
 
-const SUPABASE_URL =
-  import.meta.env.VITE_SUPABASE_URL || "https://placeholder.supabase.co";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
 const SUPABASE_PUBLISHABLE_KEY =
   import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY ||
-  "placeholder-key";
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+
+const isMisconfigured =
+  !SUPABASE_URL ||
+  SUPABASE_URL.includes("placeholder") ||
+  !SUPABASE_PUBLISHABLE_KEY ||
+  SUPABASE_PUBLISHABLE_KEY.includes("placeholder");
+
+export const supabaseMisconfigured = isMisconfigured;
 
 export const supabase = createClient<Database>(
-  SUPABASE_URL,
-  SUPABASE_PUBLISHABLE_KEY,
+  isMisconfigured ? "https://placeholder.supabase.co" : SUPABASE_URL,
+  isMisconfigured ? "placeholder-key" : SUPABASE_PUBLISHABLE_KEY,
   {
     auth: {
       storage: localStorage,

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,3 +1,4 @@
+import { supabase, supabaseMisconfigured } from "@/integrations/supabase/client";
 import { useState } from "react";
 import { Link, useNavigate, Navigate } from "react-router-dom";
 import { motion } from "framer-motion";
@@ -10,7 +11,6 @@ import { Checkbox } from "@/components/ui/checkbox";
 
 import { useAuth } from "@/contexts/useAuth";
 import { useToast } from "@/hooks/use-toast";
-import { supabase } from "@/lib/supabase";
 
 type Errors = {
   email?: string;
@@ -72,21 +72,31 @@ const Login = () => {
   };
 
   const handleGoogleLogin = async () => {
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: {
-        redirectTo: `${window.location.origin}/dashboard`,
-      },
+  if (supabaseMisconfigured) {
+    toast({
+      title: "Not configured",
+      description:
+        "Supabase environment variables are not set. Ask the project owner to configure VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.",
+      variant: "destructive",
     });
+    return;
+  }
 
-    if (error) {
-      toast({
-        title: "Google login failed",
-        description: error.message,
-        variant: "destructive",
-      });
-    }
-  };
+  const { error } = await supabase.auth.signInWithOAuth({
+    provider: "google",
+    options: {
+      redirectTo: `${window.location.origin}/dashboard`,
+    },
+  });
+
+  if (error) {
+    toast({
+      title: "Google login failed",
+      description: error.message,
+      variant: "destructive",
+    });
+  }
+};
 
   if (loading) {
     return (


### PR DESCRIPTION
## Problem
Clicking "Continue with Google" redirected to an unreachable Supabase 
URL (placeholder.supabase.co), causing DNS_PROBE_FINISHED_NXDOMAIN.

## Root Cause
VITE_SUPABASE_URL was falling back to "https://placeholder.supabase.co" 
when the env variable was not set in Vercel.

## Fix
- Added a `supabaseMisconfigured` flag in client.ts to detect missing env vars
- In Login.tsx, `handleGoogleLogin` now checks this flag before calling OAuth
- If misconfigured, shows a descriptive toast error instead of redirecting

## Files Changed
- src/integrations/supabase/client.ts
- src/pages/Login.tsx

<img width="1917" height="960" alt="image" src="https://github.com/user-attachments/assets/888bb2b7-edae-45a2-8c1b-797ced3d34f5" />
