### PR TITLE
Two UI/UX regressions were haunting the /contributor-dashboard route:

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -28,6 +28,7 @@ import {
   Trophy,
   Shield,
   Moon,
+  Users,
 } from "lucide-react";
 
 import { supabase } from "@/integrations/supabase/client";
@@ -125,6 +126,26 @@ const Navbar = () => {
           to: "/",
           label: "Home",
           icon: BookOpen,
+        },
+        {
+          to: "/#features",
+          label: "Features",
+          icon: Compass,
+        },
+        {
+          to: "/#community",
+          label: "Communities",
+          icon: Users,
+        },
+        {
+          to: "/contributor-dashboard",
+          label: "Contributor Dashboard",
+          icon: LayoutDashboard,
+        },
+        {
+          to: "/#faq",
+          label: "FAQ",
+          icon: MessageCircle,
         },
       ];
 
@@ -313,7 +334,7 @@ const Navbar = () => {
 
               <Link to="/signup">
 
-                <Button className="rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 text-white hover:opacity-90">
+                <Button className="rounded-xl bg-gradient-to-r from-green-500 to-emerald-600 text-white hover:opacity-90">
 
                   Sign Up
 
@@ -410,7 +431,7 @@ const Navbar = () => {
 
                 <Link to="/signup">
 
-                  <Button className="w-full rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600">
+                  <Button className="w-full rounded-xl bg-gradient-to-r from-green-500 to-emerald-600">
 
                     Sign Up
 


### PR DESCRIPTION
🐛 The Problem
Two UI/UX regressions were haunting the /contributor-dashboard route:

The Vanishing Navbar — When an unauthenticated user navigated to the Contributor Dashboard, the navbar went ghost mode — all navigation links (Features, Communities, FAQ) disappeared into thin air, leaving only a lonely "Home" link behind. Not a great look for discoverability.

🎨 The Rogue Blue Button — The "Sign Up" CTA button was wearing a bright blue outfit (cyan-500 → blue-600) instead of dressing in the site's established green/dark accent palette. It stood out like a sore thumb against the rest of the design system.

✅ The Fix

🧭 Navbar — Full Navigation Restored for Public Pages
The unauthenticated navLinks array was expanded from a single "Home" entry to a complete set of landing-page navigation links.

Now, visitors exploring the Contributor Dashboard can seamlessly navigate back to any section of the landing page — no dead ends, no confusion.

🎨 CTA Button — Green is the New Blue
The "Sign Up" button gradient was updated from cyan-500 → blue-600 to green-500 → emerald-600 across both desktop and mobile navbar views, bringing it in line with the site's established green/dark accent color scheme.

🧪 How to Verify
Open the app without logging in
Click "Contributor Dashboard" in the navbar
✅ Confirm the navbar still shows Home, Features, Communities, Contributor Dashboard, FAQ
✅ Confirm the Sign Up button uses a green gradient, not blue
Test on mobile — open the hamburger menu and verify the same fixes apply