### PR TITLE
fix: proxy OpenRouter requests through backend to prevent API key exposure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,12 @@ VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 VITE_SUPABASE_PUBLISHABLE_KEY=
 
-# OpenRouter AI
-VITE_OPENROUTER_API_KEY=
+# OpenRouter AI (server-side only -- must NOT use the VITE_ prefix)
+# Variables prefixed with VITE_ are embedded in the client bundle and are
+# visible to anyone who inspects the page source or network requests.
+# This key is read by the Express backend only and never reaches the browser.
+OPENROUTER_API_KEY=
+SITE_URL=http://localhost:8080
 
 # Browser push notifications
 VITE_VAPID_PUBLIC_KEY=

--- a/src/backend/routers/chatRoutes.js
+++ b/src/backend/routers/chatRoutes.js
@@ -3,34 +3,62 @@ import OpenAI from "openai";
 
 const router = express.Router();
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+// OpenRouter is OpenAI-compatible, so the OpenAI SDK works by pointing at the
+// OpenRouter base URL. The API key is read from the server environment and is
+// never sent to the client.
+const openrouter = new OpenAI({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: "https://openrouter.ai/api/v1",
+  defaultHeaders: {
+    "HTTP-Referer": process.env.SITE_URL || "http://localhost:8080",
+    "X-Title": "Peer Learning AI",
+  },
 });
 
 router.post("/chat", async (req, res) => {
   try {
-    const { message } = req.body;
+    const {
+      messages,
+      systemPrompt,
+      model = "openai/gpt-3.5-turbo",
+      max_tokens = 512,
+      temperature = 0.7,
+    } = req.body;
 
-    const response = await openai.chat.completions.create({
-      model: "gpt-4.1-mini",
-      messages: [
-        {
-          role: "system",
-          content: "You are a helpful AI tutor for coding and peer learning.",
-        },
-        {
-          role: "user",
-          content: message,
-        },
-      ],
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return res.status(400).json({ error: "A non-empty messages array is required." });
+    }
+
+    // Validate each message has the expected shape to avoid sending malformed
+    // requests upstream.
+    const isValid = messages.every(
+      (m) =>
+        typeof m === "object" &&
+        (m.role === "user" || m.role === "assistant" || m.role === "system") &&
+        typeof m.content === "string"
+    );
+
+    if (!isValid) {
+      return res
+        .status(400)
+        .json({ error: "Each message must have a role (user|assistant|system) and a string content field." });
+    }
+
+    const chatMessages = systemPrompt
+      ? [{ role: "system", content: String(systemPrompt) }, ...messages]
+      : messages;
+
+    const response = await openrouter.chat.completions.create({
+      model,
+      messages: chatMessages,
+      max_tokens,
+      temperature,
     });
 
-    res.json({
-      reply: response.choices[0].message.content,
-    });
+    res.json({ reply: response.choices[0].message.content });
   } catch (error) {
-    console.error(error);
-    res.status(500).json({ error: "Something went wrong" });
+    console.error("Chat route error:", error);
+    res.status(500).json({ error: "Failed to get a response from the AI service." });
   }
 });
 

--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -9,9 +9,6 @@ export default function Chatbot() {
 
   const chatEndRef = useRef(null);
 
-  // ✅ use env variable
-const API_KEY = import.meta.env.VITE_OPENROUTER_API_KEY;
-
   const systemPrompt = {
     role: "system",
     content:
@@ -57,25 +54,22 @@ const API_KEY = import.meta.env.VITE_OPENROUTER_API_KEY;
         content: msg.text,
       }));
 
-      const res = await fetch(
-        "https://openrouter.ai/api/v1/chat/completions",
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${API_KEY}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            model: "openai/gpt-3.5-turbo",
-            messages: [...formattedMessages, systemPrompt],
-          }),
-        }
-      );
+      // Route the request through the backend so the API key stays server-side.
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: formattedMessages,
+          systemPrompt: systemPrompt.content,
+          model: "openai/gpt-3.5-turbo",
+        }),
+      });
 
       const data = await res.json();
 
-      const botReply =
-        data?.choices?.[0]?.message?.content || "No response 😅";
+      const botReply = data?.reply || "No response 😅";
 
       const botMsg = { role: "assistant", text: botReply };
 

--- a/src/components/FloatingAI.tsx
+++ b/src/components/FloatingAI.tsx
@@ -41,45 +41,20 @@ const FloatingAI = () => {
     setLoading(true);
 
     try {
-      const response = await fetch(
-        "https://openrouter.ai/api/v1/chat/completions",
-        {
-          method: "POST",
-
-          headers: {
-            Authorization: `Bearer ${import.meta.env.VITE_OPENROUTER_API_KEY}`,
-
-            "Content-Type":
-              "application/json",
-
-            "HTTP-Referer":
-              "http://localhost:5173",
-
-            "X-Title":
-              "Peer Learning AI",
-          },
-
-          body: JSON.stringify({
-            model:
-              "openai/gpt-3.5-turbo",
-
-            messages: [
-              {
-                role: "user",
-                content: prompt,
-              },
-            ],
-
-            max_tokens: 150,
-
-            temperature: 0.7,
-          }),
-        }
-      );
+      // Route the request through the backend so the API key stays server-side.
+      const response = await fetch("/api/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: prompt }],
+          max_tokens: 150,
+          temperature: 0.7,
+        }),
+      });
 
       const data = await response.json();
-
-      console.log(data);
 
       // ERROR HANDLING
       if (data.error) {
@@ -87,8 +62,7 @@ const FloatingAI = () => {
           ...prev,
           {
             role: "assistant",
-            content:
-              data.error.message,
+            content: data.error,
           },
         ]);
 
@@ -97,10 +71,7 @@ const FloatingAI = () => {
         return;
       }
 
-      const aiReply =
-        data?.choices?.[0]?.message
-          ?.content ||
-        "AI could not respond 😔";
+      const aiReply = data?.reply || "AI could not respond 😔";
 
       // AI MESSAGE
       setMessages((prev) => [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,14 @@ export default defineConfig(({ mode }) => ({
     hmr: {
       overlay: false,
     },
+    // Forward /api requests to the Express backend during development so the
+    // OpenRouter API key stays on the server and is never included in the bundle.
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
   },
   plugins: [react(), mode === "development" && componentTagger()].filter(Boolean),
   resolve: {


### PR DESCRIPTION
Fixes #85

## Root Cause

Vite embeds every environment variable prefixed with `VITE_` directly into the compiled JavaScript bundle. `VITE_OPENROUTER_API_KEY` was being read in both `Chatbot.jsx` and `FloatingAI.tsx` and placed verbatim into the `Authorization` request header sent from the browser. Any visitor could:

- Open DevTools and read the key from the Network tab
- Search the production JS assets for the key string
- Replay the request with the stolen key to exhaust the developer's quota

## Changes

### `src/backend/routers/chatRoutes.js`

Replaced the OpenAI-direct implementation with an OpenRouter proxy. The `openai` package already supports OpenRouter via its `baseURL` option, so no new dependency is needed. The API key is now read from `process.env.OPENROUTER_API_KEY` (no `VITE_` prefix) and stays in the server process.

Added input validation to reject malformed payloads before they reach the upstream API:
- Messages array must be non-empty
- Each message must have a valid `role` and a string `content`

The route accepts `messages`, `systemPrompt`, `model`, `max_tokens`, and `temperature` so both chat components can share the same endpoint.

### `src/components/Chatbot.jsx`

Removed the `VITE_OPENROUTER_API_KEY` constant. The `sendMessage` function now posts to `/api/chat` with the message history and system prompt in the request body. The `Authorization` header is no longer present in any client-originated request.

### `src/components/FloatingAI.tsx`

Same fix. Removed `import.meta.env.VITE_OPENROUTER_API_KEY` from the fetch headers and replaced the direct OpenRouter call with a POST to `/api/chat`.

### `vite.config.ts`

Added a dev-server proxy rule that forwards `/api/*` to the Express backend on port 3001. During development the Vite dev server transparently relays the request, so the frontend never needs to know the backend's address and CORS is not an issue.

### `.env.example`

Replaced `VITE_OPENROUTER_API_KEY` with `OPENROUTER_API_KEY` and added a comment explaining why the `VITE_` prefix must never be used for private credentials. Added `SITE_URL` for the `HTTP-Referer` header forwarded to OpenRouter.

## Architecture After This Fix

```
Browser
  POST /api/chat  {messages, systemPrompt}
       |
Vite proxy (dev) / reverse proxy (prod)
       |
Express backend
  reads OPENROUTER_API_KEY from process.env
  POST https://openrouter.ai/api/v1/chat/completions
       Authorization: Bearer <key>  (server to server, never visible to browser)
       |
  returns { reply: "..." }
       |
Browser renders reply
```

## Testing

1. Start the Express backend: the server should read `OPENROUTER_API_KEY` from its `.env` file.
2. Start the Vite dev server: `npm run dev`.
3. Open the chat UI and send a message.
4. In DevTools, inspect the outgoing network requests. No request should target `openrouter.ai` directly from the browser. The only AI-related request should be `POST /api/chat` with no `Authorization` header.
5. Search the compiled JS bundle for the key string: it must not appear.
6. Verify the AI replies arrive as expected through the proxy.