### PR TITLE
fix: repair broken password reset flow (localhost URLs and wrong token source)

### DIFF
--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -9,8 +9,10 @@ const ForgotPassword = () => {
     e.preventDefault();
 
     try {
+      // Use window.location.origin so the reset link works in every environment
+      // (localhost, staging, production) without any code change.
       const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: "http://localhost:5173/reset-password",
+        redirectTo: `${window.location.origin}/reset-password`,
       });
 
       if (error) {

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
 
 const ResetPassword = () => {
-  const { token } = useParams();
   const navigate = useNavigate();
 
   const [password, setPassword] = useState("");
@@ -12,28 +12,24 @@ const ResetPassword = () => {
     e.preventDefault();
 
     try {
-      const res = await fetch(
-        `http://localhost:5000/api/reset-password/${token}`,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({ password }),
-        }
-      );
+      // Supabase embeds the recovery token in the URL hash when the user
+      // clicks the reset link (e.g. /reset-password#access_token=...&type=recovery).
+      // The Supabase JS client detects the hash on page load and creates a
+      // short-lived recovery session automatically. Calling updateUser here
+      // uses that session to set the new password without needing to extract
+      // or forward any token manually.
+      const { error } = await supabase.auth.updateUser({ password });
 
-      const data = await res.json();
-      setMessage(data.message);
-
-      // Redirect after success
-      if (res.ok) {
+      if (error) {
+        setMessage(error.message);
+      } else {
+        setMessage("Password updated successfully! Redirecting to login...");
         setTimeout(() => {
           navigate("/login");
         }, 2000);
       }
     } catch (error) {
-      setMessage("Something went wrong");
+      setMessage("Something went wrong. Please request a new reset link.");
     }
   };
 


### PR DESCRIPTION
Fixes #86

## Summary

Three bugs prevented the password reset flow from working in any environment other than a specific local development setup. Two are hardcoded URL fixes. The third is an architectural mismatch between how Supabase delivers the recovery token and how the component tried to read it.

## Bug 1 -- Hardcoded `redirectTo` in `ForgotPassword.jsx`

The `redirectTo` option was hardcoded to `http://localhost:5173/reset-password`. Supabase includes this URL verbatim in the password reset email, so every email sent in staging or production pointed users to a developer machine that nobody else can reach.

**Fix:** Replace the hardcoded string with `window.location.origin`, which resolves to the actual host the app is running on at request time.

```js
// Before
redirectTo: "http://localhost:5173/reset-password"

// After
redirectTo: `${window.location.origin}/reset-password`
```

## Bug 2 + Bug 3 -- Token source mismatch and hardcoded API host in `ResetPassword.jsx`

The component read `const { token } = useParams()` and called `http://localhost:5000/api/reset-password/${token}`. Both halves were wrong.

**On the token:** `supabase.auth.resetPasswordForEmail` delivers the recovery token inside the URL hash as `#access_token=...&type=recovery`, not as a path segment. React Router's `useParams()` reads path segments only, so `token` was always `undefined`. Adding `:token` to the `App.tsx` route (as suggested in the issue) would not have fixed this, because the token never appears in the path.

The Supabase JS client handles the hash automatically: when the page loads and the hash contains `type=recovery`, the client establishes a short-lived recovery session. Calling `supabase.auth.updateUser({ password })` then uses that session to update the password with no manual token extraction needed.

**On the API host:** Even if the path-based token approach had been architecturally correct, `http://localhost:5000/api/reset-password/${token}` would fail in every deployed environment.

**Fix:** Remove `useParams` and the custom `fetch` call. Import the Supabase client and replace the reset logic with `supabase.auth.updateUser({ password })`.

```js
// Before
const { token } = useParams();
const res = await fetch(`http://localhost:5000/api/reset-password/${token}`, { ... });

// After
const { error } = await supabase.auth.updateUser({ password });
```

## Why App.tsx does not need `:token`

The issue proposes adding `:token` to the route in `App.tsx`. This change is not included because it has no effect on the actual problem. Supabase puts the token in the URL hash (`#access_token=...`), and React Router does not parse URL hashes into params. The route `/reset-password` already matches the URL correctly; the bug was entirely in the component logic, not in the route definition.

## End-to-End Flow After This Fix

1. User submits email on `/forgot-password`.
2. `supabase.auth.resetPasswordForEmail` sends an email with a link to `{window.location.origin}/reset-password#access_token=TOKEN&type=recovery`.
3. User clicks the link, lands on `/reset-password`. The Supabase JS client detects the hash and opens a recovery session.
4. User enters a new password and submits.
5. `supabase.auth.updateUser({ password })` applies the new password using the recovery session.
6. User is redirected to `/login`.

## Testing

1. Trigger the forgot-password flow on a non-localhost environment.
2. Confirm the reset email contains a link to the correct domain, not `localhost:5173`.
3. Click the link, enter a new password, and submit.
4. Confirm the password is updated and the user is redirected to login.
5. Confirm login succeeds with the new password.