### PR TITLE
fix(#98): verify ownership before deleting a resource

### DIFF
--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -66,7 +66,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
   const handleDelete = async () => {
     setIsDeleting(true);
 
-    const result = await deleteResource(resource.id, resource.file_url);
+    const result = await deleteResource(resource.id);
     setIsDeleting(false);
 
     if (!result.success) {

--- a/src/lib/deleteResource.ts
+++ b/src/lib/deleteResource.ts
@@ -5,30 +5,48 @@ type DeleteResourceResult =
   | { success: false; error: string };
 
 export const deleteResource = async (
-  resourceId: string,
-  fileUrl: string
+  resourceId: string
 ): Promise<DeleteResourceResult> => {
+  // Verify the caller is authenticated.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return { success: false, error: "You must be signed in to delete a resource." };
+  }
+
+  // Fetch the resource and verify ownership in a single query.
+  // The .eq("uploaded_by", user.id) ensures we only find rows the caller owns,
+  // preventing deletion of another user's resource.
+  const { data: resource, error: fetchError } = await supabase
+    .from("resources")
+    .select("id, file_url")
+    .eq("id", resourceId)
+    .eq("uploaded_by", user.id)
+    .single();
+
+  if (fetchError || !resource) {
+    return { success: false, error: "Resource not found or you do not have permission to delete it." };
+  }
+
+  // Use the file_url from the database row, not from caller input,
+  // to prevent mismatched storage/DB deletions.
   const { error: storageError } = await supabase.storage
     .from("resources")
-    .remove([fileUrl]);
+    .remove([resource.file_url]);
 
   if (storageError) {
-    return {
-      success: false,
-      error: storageError.message,
-    };
+    return { success: false, error: storageError.message };
   }
 
   const { error: deleteError } = await supabase
     .from("resources")
     .delete()
-    .eq("id", resourceId);
+    .eq("id", resource.id);
 
   if (deleteError) {
-    return {
-      success: false,
-      error: deleteError.message,
-    };
+    return { success: false, error: deleteError.message };
   }
 
   return { success: true };


### PR DESCRIPTION
Closes #98

## Problem

`deleteResource` accepted a `resourceId` and `fileUrl` from the caller and acted on both without verifying the caller owns the resource. An attacker knowing a victim's resource DB row ID could call `deleteResource(victimId, attackerFilePath)`:

1. Storage delete succeeds (attacker's own path, allowed by RLS)
2. DB delete fails (victim's row, blocked by RLS)
3. Victim's DB row now points to a permanently deleted storage file - silently broken with no error surfaced

## Changes

**`src/lib/deleteResource.ts`**
- Resolve the authenticated user via `supabase.auth.getUser()` before any mutation
- Fetch the resource using both `.eq("id", resourceId)` and `.eq("uploaded_by", user.id)` - returns an error if the row is not found or not owned by the caller
- Use the `file_url` from the fetched DB row rather than the caller-supplied argument, eliminating the cross-user storage/DB mismatch vector
- Remove `fileUrl` from the function signature (it is now derived from the DB)

**`src/components/resources/ResourceCard.tsx`**
- Update the `deleteResource` call to pass only `resource.id` (no `file_url` argument)

## Before / After

```ts
// Before - no ownership check, trusts caller-supplied fileUrl
const deleteResource = async (resourceId: string, fileUrl: string) => {
  await supabase.storage.from("resources").remove([fileUrl]);
  await supabase.from("resources").delete().eq("id", resourceId);
};

// After - ownership verified, fileUrl sourced from DB
const deleteResource = async (resourceId: string) => {
  const { data: { user } } = await supabase.auth.getUser();
  const { data: resource } = await supabase
    .from("resources").select("id, file_url")
    .eq("id", resourceId).eq("uploaded_by", user.id).single();
  if (!resource) return { success: false, error: "Not found or unauthorized" };
  // proceed with resource.file_url
};
```