### PR TITLE
fix(#99): scope chatbot messages to the authenticated user

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -20,12 +20,16 @@ export default function Chatbot() {
     chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
-  // ✅ Load chats
+  // Load only the current user's chat messages
   useEffect(() => {
     const loadChats = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user) return;
+
       const { data } = await supabase
         .from("chat_messages")
         .select("*")
+        .eq("user_id", session.user.id)
         .order("created_at", { ascending: true });
 
       if (data) setMessages(data);
@@ -33,13 +37,18 @@ export default function Chatbot() {
     loadChats();
   }, []);
 
-  // 🔥 SEND MESSAGE
+  // SEND MESSAGE
   const sendMessage = async () => {
     if (!input.trim()) return;
 
-    const userMsg = { role: "user", text: input };
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user) return;
 
-    // ✅ fix stale state
+    const userId = session.user.id;
+
+    // Store user_id so each message is scoped to the authenticated user.
+    const userMsg = { role: "user", text: input, user_id: userId };
+
     const updatedMessages = [...messages, userMsg];
 
     setMessages(updatedMessages);
@@ -55,10 +64,12 @@ export default function Chatbot() {
       }));
 
       // Route the request through the backend so the API key stays server-side.
+      // Include the session token so the backend can authenticate the request.
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
         },
         body: JSON.stringify({
           messages: formattedMessages,
@@ -71,9 +82,9 @@ export default function Chatbot() {
 
       const botReply = data?.reply || "No response 😅";
 
-      const botMsg = { role: "assistant", text: botReply };
+      const botMsg = { role: "assistant", text: botReply, user_id: userId };
 
-      // ✅ smoother typing (chunked)
+      // Smoother typing effect (chunked rendering)
       let currentText = "";
       const chunkSize = 3;
 
@@ -82,7 +93,7 @@ export default function Chatbot() {
       for (let i = 0; i < botReply.length; i += chunkSize) {
         currentText += botReply.slice(i, i + chunkSize);
 
-        await new Promise((res) => setTimeout(res, 20));
+        await new Promise((resolve) => setTimeout(resolve, 20));
 
         setMessages((prev) => {
           const updated = [...prev];

--- a/supabase/migrations/20260525_fix_chat_messages_rls.sql
+++ b/supabase/migrations/20260525_fix_chat_messages_rls.sql
@@ -1,0 +1,25 @@
+-- Remove the "user_id IS NULL" escape hatch from the chat_messages RLS policies.
+--
+-- The previous policies used:
+--   using (user_id is null or user_id = auth.uid())
+-- Because every message was inserted without a user_id, every row matched
+-- "user_id IS NULL", making the entire table readable by every authenticated
+-- user. The matching insert policy also accepted null user_id rows, so any
+-- authenticated user could write unscoped messages.
+--
+-- The Chatbot component now always inserts with user_id = auth.uid(), so the
+-- escape hatch is no longer needed and is removed here.
+
+drop policy if exists "Users can read own chat messages" on public.chat_messages;
+create policy "Users can read own chat messages"
+on public.chat_messages
+for select
+to authenticated
+using (user_id = auth.uid());
+
+drop policy if exists "Users can insert own chat messages" on public.chat_messages;
+create policy "Users can insert own chat messages"
+on public.chat_messages
+for insert
+to authenticated
+with check (user_id = auth.uid());


### PR DESCRIPTION
Closes #99

## Problem

Three compounding issues caused every user to see every other user's private chat history:

1. **No user_id on insert:** Messages were stored with `user_id = null`
2. **RLS escape hatch:** The select/insert policies used `user_id IS NULL OR user_id = auth.uid()`, so every null-owner row was readable by every authenticated user
3. **No user filter on SELECT:** The chatbot loaded all rows with no `.eq("user_id", ...)` filter, returning the full table on open

## Changes

**`src/components/Chatbot.jsx`**
- Resolve the Supabase session before any DB operation
- Include `user_id: session.user.id` on every insert (user and assistant messages)
- Add `.eq("user_id", session.user.id)` to the SELECT query so only the current user's history is loaded
- Pass `Authorization: Bearer <access_token>` header on the `/api/chat` fetch so the backend auth middleware (added in #97/#103) can validate the request

**`supabase/migrations/20260525_fix_chat_messages_rls.sql`** (new migration)
- Drop and recreate both RLS policies replacing `user_id is null or user_id = auth.uid()` with the strict `user_id = auth.uid()`

## Migration

```sql
-- select policy
using (user_id = auth.uid());

-- insert policy
with check (user_id = auth.uid());
```

Apply via `supabase db push` or the Supabase dashboard SQL editor.