### PR TITLE
fix(email): read SMTP credentials from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ SITE_URL=http://localhost:8080
 
 # Browser push notifications
 VITE_VAPID_PUBLIC_KEY=
+
+# Email (Nodemailer / Gmail SMTP)
+# Use a Gmail address and an App Password generated at
+# https://myaccount.google.com/apppasswords (2FA must be enabled on the account).
+EMAIL_USER=your_email@gmail.com
+EMAIL_PASS=your_app_password

--- a/src/backend/utils/sendEmail.js
+++ b/src/backend/utils/sendEmail.js
@@ -1,15 +1,25 @@
 import nodemailer from "nodemailer";
 
 export const sendEmail = async (email, url) => {
+  const emailUser = process.env.EMAIL_USER;
+  const emailPass = process.env.EMAIL_PASS;
+
+  if (!emailUser || !emailPass) {
+    throw new Error(
+      "EMAIL_USER and EMAIL_PASS environment variables must be set before sending email."
+    );
+  }
+
   const transporter = nodemailer.createTransport({
     service: "gmail",
     auth: {
-      user: "your_email@gmail.com",
-      pass: "your_app_password",
+      user: emailUser,
+      pass: emailPass,
     },
   });
 
   await transporter.sendMail({
+    from: emailUser,
     to: email,
     subject: "Password Reset",
     html: `<p>Click below to reset password:</p>


### PR DESCRIPTION
Fixes #113

## Problem

`src/backend/utils/sendEmail.js` created a Nodemailer transporter with the literal strings `"your_email@gmail.com"` and `"your_app_password"` as the Gmail credentials. Every call to `sendEmail()` attempted to authenticate with these placeholder values, which always fails. The password-reset feature was permanently non-functional in every deployed environment.

## Fix

- Read credentials from `process.env.EMAIL_USER` and `process.env.EMAIL_PASS` at runtime
- Throw a descriptive error at call time if either variable is missing, so misconfiguration is immediately visible in server logs rather than surfacing as a silent SMTP auth failure
- Add an explicit `from` field to `sendMail` so the sender address is consistent with the authenticated account
- Document both variables in `.env.example` with setup instructions for Gmail App Passwords

## Setup

1. Enable 2-Step Verification on your Gmail account
2. Generate an App Password at https://myaccount.google.com/apppasswords
3. Set `EMAIL_USER` to your Gmail address and `EMAIL_PASS` to the generated App Password in your `.env` file

## Testing

- With `EMAIL_USER` and `EMAIL_PASS` set to valid credentials: password reset email is delivered
- With either variable unset: throws `Error: EMAIL_USER and EMAIL_PASS environment variables must be set...` instead of attempting auth with empty values