### PR TITLE
fix(security): enable RLS and add policies on study_rooms tables

### DIFF
--- a/supabase/migrations/20260526000001_study_rooms_rls.sql
+++ b/supabase/migrations/20260526000001_study_rooms_rls.sql
@@ -1,0 +1,48 @@
+-- Enable Row Level Security on study_rooms and study_room_messages.
+-- The tables were created in 20260518120000_study_rooms_mvp.sql without
+-- RLS enabled and with no policies defined. In Supabase, a table without
+-- RLS is fully accessible to anyone holding the project anon key, including
+-- unauthenticated visitors.
+
+ALTER TABLE public.study_rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.study_room_messages ENABLE ROW LEVEL SECURITY;
+
+-- study_rooms policies
+
+-- Any authenticated user can browse available rooms.
+CREATE POLICY "study_rooms_select" ON public.study_rooms
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Any authenticated user can create a room, but only as themselves.
+CREATE POLICY "study_rooms_insert" ON public.study_rooms
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = created_by);
+
+-- Only the room creator can rename or modify their room.
+CREATE POLICY "study_rooms_update" ON public.study_rooms
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = created_by)
+  WITH CHECK (auth.uid() = created_by);
+
+-- Only the room creator can delete their room.
+CREATE POLICY "study_rooms_delete" ON public.study_rooms
+  FOR DELETE TO authenticated
+  USING (auth.uid() = created_by);
+
+-- study_room_messages policies
+
+-- Any authenticated user can read messages in any room.
+CREATE POLICY "study_room_messages_select" ON public.study_room_messages
+  FOR SELECT TO authenticated
+  USING (true);
+
+-- Any authenticated user can post a message, but only attributed to themselves.
+CREATE POLICY "study_room_messages_insert" ON public.study_room_messages
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = profile_id);
+
+-- Only the message author can delete their own message.
+CREATE POLICY "study_room_messages_delete" ON public.study_room_messages
+  FOR DELETE TO authenticated
+  USING (auth.uid() = profile_id);


### PR DESCRIPTION
Fixes #112

## Problem

`supabase/migrations/20260518120000_study_rooms_mvp.sql` created `study_rooms` and `study_room_messages` without calling `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and without defining any policies. In Supabase, a table without RLS enabled is fully accessible to anyone holding the project `anon` key, including unauthenticated visitors, with no restrictions on reads, inserts, updates, or deletes.

## Fix

New migration `20260526000001_study_rooms_rls.sql` enables RLS on both tables and adds minimal least-privilege policies:

**study_rooms**
| Operation | Who |
|---|---|
| SELECT | Any authenticated user |
| INSERT | Authenticated user, only as themselves (`created_by = auth.uid()`) |
| UPDATE | Only the room creator |
| DELETE | Only the room creator |

**study_room_messages**
| Operation | Who |
|---|---|
| SELECT | Any authenticated user |
| INSERT | Authenticated user, only attributed to themselves (`profile_id = auth.uid()`) |
| DELETE | Only the message author |

A new migration is used rather than modifying the original file so that teams with the migration already applied can run the fix without re-creating the tables.

## Testing

- Unauthenticated request to `study_rooms`: rejected with `401`/`403`
- Authenticated user reading rooms or messages: allowed
- Authenticated user inserting a room with `created_by` set to their own `uid`: allowed
- Authenticated user inserting a room with someone else's `uid` as `created_by`: rejected by policy
- Authenticated user deleting another user's room or message: rejected by policy