### PR TITLE
fix(security): restrict profiles UPDATE policy to block privileged column writes

### DIFF
--- a/supabase/migrations/20260526000002_profiles_update_column_restriction.sql
+++ b/supabase/migrations/20260526000002_profiles_update_column_restriction.sql
@@ -1,0 +1,39 @@
+-- Restrict the profiles UPDATE policy to prevent self-assignment of privileged fields.
+--
+-- The existing "profiles_update" policy (20260518_role_management.sql) and
+-- "Users can update own profile" policy (20260403063915_adc67827...sql) both
+-- only check USING (auth.uid() = id) with no WITH CHECK clause and no column
+-- restrictions. This allows any authenticated user to overwrite every column
+-- in their own row, including is_mentor, points, rating, badges, and
+-- sessions_completed, by calling the Supabase client directly.
+--
+-- Fix: drop all permissive UPDATE policies and recreate with a WITH CHECK
+-- expression that locks the five privileged columns to their current database
+-- values. Users can still update editable profile fields (name, bio,
+-- avatar_url, skills, interests, teach_subjects, learn_subjects) but cannot
+-- modify server-managed fields.
+
+DROP POLICY IF EXISTS "profiles_update" ON public.profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+
+CREATE POLICY "profiles_update" ON public.profiles
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = id)
+  WITH CHECK (
+    auth.uid() = id
+    AND is_mentor IS NOT DISTINCT FROM (
+      SELECT is_mentor FROM public.profiles WHERE id = auth.uid()
+    )
+    AND points IS NOT DISTINCT FROM (
+      SELECT points FROM public.profiles WHERE id = auth.uid()
+    )
+    AND rating IS NOT DISTINCT FROM (
+      SELECT rating FROM public.profiles WHERE id = auth.uid()
+    )
+    AND badges IS NOT DISTINCT FROM (
+      SELECT badges FROM public.profiles WHERE id = auth.uid()
+    )
+    AND sessions_completed IS NOT DISTINCT FROM (
+      SELECT sessions_completed FROM public.profiles WHERE id = auth.uid()
+    )
+  );


### PR DESCRIPTION
Fixes #111

## Problem

The `profiles` UPDATE policies in the existing migrations only checked `USING (auth.uid() = id)` with no `WITH CHECK` clause. This allowed any authenticated user to overwrite every column in their own row by calling the Supabase client directly, including:

- `is_mentor` - self-assign mentor status
- `points` - inflate leaderboard score
- `rating` - self-award rating
- `badges` - self-award badges
- `sessions_completed` - falsify activity metrics

## Fix

New migration `20260526000002_profiles_update_column_restriction.sql`:

1. Drops both legacy UPDATE policies (`"profiles_update"` from `20260518_role_management.sql` and `"Users can update own profile"` from the initial profiles migration)
2. Recreates `"profiles_update"` with a `WITH CHECK` clause that compares each privileged column in the incoming row against its current database value using `IS NOT DISTINCT FROM`

```sql
WITH CHECK (
  auth.uid() = id
  AND is_mentor IS NOT DISTINCT FROM (SELECT is_mentor FROM public.profiles WHERE id = auth.uid())
  AND points   IS NOT DISTINCT FROM (SELECT points   FROM public.profiles WHERE id = auth.uid())
  AND rating   IS NOT DISTINCT FROM (SELECT rating   FROM public.profiles WHERE id = auth.uid())
  AND badges   IS NOT DISTINCT FROM (SELECT badges   FROM public.profiles WHERE id = auth.uid())
  AND sessions_completed IS NOT DISTINCT FROM (SELECT sessions_completed FROM public.profiles WHERE id = auth.uid())
)
```

If any of the five protected columns differs from the stored value, the update is rejected with a policy violation. Editable columns (`name`, `bio`, `avatar_url`, `skills`, `interests`, `teach_subjects`, `learn_subjects`) are unaffected.

`IS NOT DISTINCT FROM` is used instead of `=` to handle `NULL` values correctly.

## Testing

- User updating `name` or `bio`: allowed
- User sending `{ is_mentor: true }` via Supabase client: rejected by policy
- User sending `{ points: 9999 }`: rejected by policy
- Server-side function (SECURITY DEFINER) updating `is_mentor`: bypasses RLS as intended