### PR TITLE
fix: correct discover page filtering to enable true global search

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -126,8 +126,7 @@ const Discover = () => {
       .map((u) => ({
         ...u,
         score: getMatchScore(u),
-      }))
-      .filter((u) => u.score > 0);
+      }));
 
     // SEARCH
     if (search) {
@@ -149,6 +148,12 @@ const Discover = () => {
           ?.toLowerCase()
           .includes(selectedFilter.toLowerCase())
       );
+    }
+
+    // DEFAULT BUBBLE
+    // If no search and no filter are active, only show recommended peers (score > 0)
+    if (!search && selectedFilter === "All") {
+      matched = matched.filter((u) => u.score > 0);
     }
 
     matched.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Description

**Labels:** `bug`, `logic`, `ux`, `gssoc26`

This PR fixes a severe UX and logical issue on the Discover page where the global search functionality was unintentionally limited to users inside the current user's recommendation subset.

### Related Issues

Resolves #148 

## Labels
`bug`, `logic`, `ux`, `gssoc26`

### The Problem

Previously, the implementation calculated match scores and immediately filtered the dataset using:

```javascript
.filter((u) => u.score > 0)
```

Search queries and category filters were then executed against this already-reduced result set.

Because of this execution order, users who did not share matching learning goals with the current user were removed before search processing began.

This caused several broken behaviors:

- Searching for a specific user by name could return no results despite that user existing on the platform
- Category filters operated only within the recommendation subset
- Users were effectively trapped inside their recommendation bubble
- The global search feature failed its intended purpose

### Technical Fix

Implemented a restructuring of the filtering pipeline.

Changes included:

- Removed the premature `.filter((u) => u.score > 0)` constraint from the initial mapping stage
- Moved recommendation filtering to the final phase of the processing hook
- Wrapped the recommendation constraint behind:

```javascript
if (!search && selectedFilter === "All")
```

This preserves recommendation behavior only for the default browsing state.

### Updated Behavior

#### Default Discover View
When no search query or category filter is active:

- users continue to see recommendation-driven results
- highly relevant peers remain prioritized

#### Active Search or Category Filtering
When search or filtering is enabled:

- recommendation constraints are bypassed
- queries operate against the full eligible user dataset
- users can discover peers outside their recommendation cluster

### Result

The Discover page now supports:

- true platform-wide search
- accurate category filtering
- unrestricted name-based user lookup
- preserved recommendation quality in the default experience