### PR TITLE
fix: Prevent crash when GitHub API rate‑limit is exceeded

### DIFF
--- a/src/components/dashboard/Leaderboard.tsx
+++ b/src/components/dashboard/Leaderboard.tsx
@@ -23,7 +23,7 @@ function Leaderboard() {
       </h2>
 
       <div className="space-y-5">
-        {contributors.slice(0, 5).map((user, index) => (
+        {(Array.isArray(contributors) ? contributors.slice(0, 5) : []).map((user, index) => (
           <div
             key={user.login}
             className="flex items-center justify-between bg-zinc-800/70 rounded-2xl px-5 py-5 border border-zinc-700 hover:border-cyan-500/30 transition-all"

--- a/src/pages/ContributorDashboard.tsx
+++ b/src/pages/ContributorDashboard.tsx
@@ -37,11 +37,9 @@ function ContributorDashboard() {
 
         const contributorsData = await contributorsRes.json();
 
-        const totalContributions = contributorsData.reduce(
-          (acc: number, contributor: any) =>
-            acc + contributor.contributions,
-          0
-        );
+        const totalContributions = Array.isArray(contributorsData)
+        ? contributorsData.reduce((acc: number, contributor: any) => acc + contributor.contributions, 0)
+        : 0;
 
         // Pull Requests
         const prsRes = await fetch(
@@ -72,7 +70,7 @@ function ContributorDashboard() {
           },
           {
             title: "Contributors",
-            value: contributorsData.length || 0,
+            value: Array.isArray(contributorsData) ? contributorsData.length : 0,
           },
         ]);
       } catch (error) {


### PR DESCRIPTION
**Summary**

This PR adds defensive checks around the GitHub API calls used in the **Contributor Dashboard** and **Leaderboard** components. When the unauthenticated GitHub API rate limit is hit, the API returns an error object rather than the expected array. Previously the code called `.reduce()` and `.slice()` on that object, causing a runtime `TypeError` and a white‑screen crash.

**Changes**
- `src/pages/ContributorDashboard.tsx`
  - Guard `contributorsData` with `Array.isArray` before using `.reduce()`.
  - Guard the “Contributors” stat with the same check, falling back to `0`.
- `src/components/dashboard/Leaderboard.tsx`
  - Guard the `contributors` array before slicing; fallback to an empty array.
  
**Why it matters**
- Prevents the entire UI from crashing when the GitHub rate limit is exceeded.
- Provides graceful degradation (showing empty data or `0` values) while still logging the error for debugging.
- Low‑risk, isolated change touching only two files; no new dependencies or styling modifications.

Closes #126 

**Labels**
`bug`, `level:intermediate`, `quality:exceptional`
