### PR TITLE
fix(ai-chat): add Supabase JWT verification and restrict CORS origin

### DIFF
--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2"
 
 const corsHeaders = {
-  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Origin': Deno.env.get('FRONTEND_URL') ?? 'https://peerlearn.app',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
@@ -13,6 +14,31 @@ serve(async (req) => {
   }
 
   try {
+    // Require a valid Supabase JWT before processing the request
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 401 }
+      )
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+    )
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser(
+      authHeader.replace('Bearer ', '')
+    )
+
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 401 }
+      )
+    }
+
     const { prompt } = await req.json()
 
     if (!prompt) {
@@ -37,7 +63,7 @@ serve(async (req) => {
       headers: {
         'Authorization': `Bearer ${openRouterApiKey}`,
         'Content-Type': 'application/json',
-        'HTTP-Referer': 'https://peerlearn.app', // Update with actual prod domain
+        'HTTP-Referer': 'https://peerlearn.app',
         'X-Title': 'Peer Learning AI',
       },
       body: JSON.stringify({


### PR DESCRIPTION
Fixes #142

## Root Cause

The `supabase/functions/ai-chat/index.ts` Edge Function accepted any POST request and forwarded it to OpenRouter without verifying the caller's identity. The `Access-Control-Allow-Origin` header was set to `*`, making the function reachable from any origin without credentials.

## Changes

**`supabase/functions/ai-chat/index.ts`**
- Added `@supabase/supabase-js` import
- Reads the `Authorization: Bearer <token>` header before parsing the request body
- Returns `401 Unauthorized` immediately if the header is missing or the JWT is invalid
- Scopes `Access-Control-Allow-Origin` to `FRONTEND_URL` env var (falls back to `https://peerlearn.app`) instead of the open wildcard

## Testing

1. Call the function without an `Authorization` header and confirm a `401` response.
2. Call the function with a valid Supabase JWT and confirm a normal AI response.
3. Call the function with an expired or tampered token and confirm a `401` response.

---

Could you please add the appropriate GSSoC labels to this PR when you get a chance? It would help with tracking points. Thank you!