### PR TITLE
fix(rls): remove NULL bypass from chat_messages and mentors ownership policies

### DIFF
--- a/supabase/migrations/20260527000002_fix_rls_null_bypass_chat_mentors.sql
+++ b/supabase/migrations/20260527000002_fix_rls_null_bypass_chat_mentors.sql
@@ -1,0 +1,41 @@
+-- Fix RLS NULL bypass in chat_messages and mentors tables.
+-- The original policies contained "user_id IS NULL OR user_id = auth.uid()"
+-- which let any authenticated user insert rows with a NULL owner and then
+-- read all ownerless rows, defeating ownership enforcement.
+-- Resolves issue #144.
+
+-- Enforce NOT NULL at the schema level so the RLS check is the last line of
+-- defence, not the only one.
+ALTER TABLE public.chat_messages ALTER COLUMN user_id SET NOT NULL;
+ALTER TABLE public.mentors ALTER COLUMN user_id SET NOT NULL;
+
+-- Recreate the chat_messages policies without the IS NULL branch.
+DROP POLICY IF EXISTS "Users can read own chat messages" ON public.chat_messages;
+CREATE POLICY "Users can read own chat messages"
+ON public.chat_messages
+FOR SELECT
+TO authenticated
+USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS "Users can insert own chat messages" ON public.chat_messages;
+CREATE POLICY "Users can insert own chat messages"
+ON public.chat_messages
+FOR INSERT
+TO authenticated
+WITH CHECK (user_id = auth.uid());
+
+-- Recreate the mentors INSERT policy without the IS NULL branch.
+DROP POLICY IF EXISTS "Users can insert mentor applications" ON public.mentors;
+CREATE POLICY "Users can insert mentor applications"
+ON public.mentors
+FOR INSERT
+TO authenticated
+WITH CHECK (user_id = auth.uid());
+
+-- Fix the mentors SELECT policy for the same reason.
+DROP POLICY IF EXISTS "Users can view own mentor applications" ON public.mentors;
+CREATE POLICY "Users can view own mentor applications"
+ON public.mentors
+FOR SELECT
+TO authenticated
+USING (user_id = auth.uid());


### PR DESCRIPTION
Fixes #144

## Root Cause

Two tables had RLS policies with `user_id IS NULL OR user_id = auth.uid()`. The `IS NULL` branch allowed any authenticated user to insert ownerless rows (`user_id = NULL`) and then read them all back via the SELECT policy, bypassing ownership enforcement completely.

## Changes

**`supabase/migrations/20260527000002_fix_rls_null_bypass_chat_mentors.sql`**
- `ALTER TABLE chat_messages ALTER COLUMN user_id SET NOT NULL` - prevents NULL from reaching RLS at the schema level
- `ALTER TABLE mentors ALTER COLUMN user_id SET NOT NULL` - same
- Recreates `chat_messages` SELECT and INSERT policies with `user_id = auth.uid()` only
- Recreates `mentors` INSERT and SELECT policies with `user_id = auth.uid()` only

## Testing

1. Attempt to insert a `chat_messages` row with `user_id: null` and confirm it is rejected.
2. Insert a `chat_messages` row with the caller's own `user_id` and confirm it succeeds.
3. Confirm a second authenticated user cannot read the first user's chat messages.

---

Could you please add the appropriate GSSoC labels to this PR when you get a chance? It would help with tracking points. Thank you!