### PR TITLE
fix(rls): restrict sessions INSERT to verified mentors, remove NULL bypass

### DIFF
--- a/supabase/migrations/20260527000003_fix_sessions_rls_mentor_only.sql
+++ b/supabase/migrations/20260527000003_fix_sessions_rls_mentor_only.sql
@@ -1,0 +1,20 @@
+-- Restrict session creation to verified mentors only.
+-- The original INSERT policy was:
+--   WITH CHECK (mentor_id IS NULL OR mentor_id = auth.uid())
+-- The IS NULL branch allowed any authenticated user to create sessions by
+-- passing mentor_id: null, making the mentor check meaningless.
+-- Resolves issue #145.
+
+DROP POLICY IF EXISTS "Authenticated users can create sessions" ON public.sessions;
+
+CREATE POLICY "Mentors can create sessions"
+ON public.sessions
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  mentor_id = auth.uid()
+  AND EXISTS (
+    SELECT 1 FROM public.profiles
+    WHERE id = auth.uid() AND is_mentor = true
+  )
+);


### PR DESCRIPTION
Fixes #145

## Root Cause

The sessions table INSERT policy in `20260518_app_bootstrap_and_notifications.sql` used `WITH CHECK (mentor_id IS NULL OR mentor_id = auth.uid())`. The `IS NULL` branch let any authenticated user create a session by passing `mentor_id: null`, so non-mentors and learners could flood the sessions feed with invalid entries.

## Changes

**`supabase/migrations/20260527000003_fix_sessions_rls_mentor_only.sql`**
- Drops the original `"Authenticated users can create sessions"` policy
- Creates `"Mentors can create sessions"` which requires both:
  - `mentor_id = auth.uid()` (caller must own the session)
  - `EXISTS (SELECT 1 FROM profiles WHERE id = auth.uid() AND is_mentor = true)` (caller must be a verified mentor)

The `profiles.is_mentor` column is already present from the role_management migration.

## Testing

1. Attempt to create a session as a non-mentor user and confirm it is rejected.
2. Attempt to create a session with `mentor_id: null` and confirm it is rejected.
3. Create a session as a verified mentor with the correct `mentor_id` and confirm it succeeds.

---

Could you please add the appropriate GSSoC labels to this PR when you get a chance? It would help with tracking points. Thank you!