### PR TITLE
Fix: Resolve massive direct message spoofing RLS vulnerability (#163)

### DIFF
--- a/supabase/migrations/20260528000000_fix_messages_spoofing_vulnerability.sql
+++ b/supabase/migrations/20260528000000_fix_messages_spoofing_vulnerability.sql
@@ -1,0 +1,28 @@
+-- Migration: Fix massive direct message spoofing vulnerability
+-- This perfectly resolves the issue where users could spoof `sender_id` 
+-- in direct messages by exploiting the `OR` condition in the previous policy.
+
+-- Drop the overly permissive and vulnerable policy
+DROP POLICY IF EXISTS "Authenticated users can send session messages" ON public.messages;
+
+-- Secure Policy for Direct Messages (1-on-1)
+-- Enforces that for any DM, the sender_id MUST be the authenticated user.
+CREATE POLICY "Users can insert direct messages"
+ON public.messages
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  session_id IS NULL 
+  AND sender_id = auth.uid()
+);
+
+-- Secure Policy for Session Messages (Public Study Rooms)
+-- Enforces that for session chats, the user_id MUST be the authenticated user.
+CREATE POLICY "Users can insert session messages"
+ON public.messages
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  session_id IS NOT NULL 
+  AND user_id = auth.uid()
+);


### PR DESCRIPTION
## Description
This PR addresses a critical backend security flaw in the Row Level Security (RLS) policies of the `messages` table. 

Previously, the `INSERT` policy used an `OR` condition (`user_id = auth.uid() OR sender_id = auth.uid()`). A malicious user could exploit this by appending a valid `user_id` to their request, which bypassed the `sender_id` check, allowing them to perfectly spoof direct messages from any other user (including mentors or admins) to any receiver.

### Changes Made:
- **Separated RLS Logic**: Dropped the vulnerable combined policy and replaced it with two perfectly scoped policies.
- **Secured Direct Messages**: DMs (`session_id IS NULL`) now strictly verify that `sender_id = auth.uid()`.
- **Secured Session Messages**: Public study room chats (`session_id IS NOT NULL`) now strictly verify that `user_id = auth.uid()`.

These changes perfectly close the spoofing loophole while keeping all frontend UI and public session chat functionality completely undisturbed.

## Related Issues
- Resolves #163 

## Labels
`bug`, `backend`, `security`, `database`, `rls`