### PR TITLE
fix: bootstrap backend server and correct router imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "crypto": "^1.0.1",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.6.0",
+    "express": "^4.21.2",
     "framer-motion": "^11.18.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -1,7 +1,21 @@
-import authRoutes from "./routes/authRoutes.js";
-import chatRoutes from "./routes/chatRoutes.js";
-import matchRoutes from "./routes/matchRoutes.js";  // 👈 ADD THIS
+import express from "express";
+import authRoutes from "./routers/authRoutes.js";
+import chatRoutes from "./routers/chatRoutes.js";
+import matchRoutes from "./routers/matchRoutes.js";
+
+const app = express();
+const port = Number(process.env.PORT) || 3001;
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+	res.status(200).json({ ok: true });
+});
 
 app.use("/api", authRoutes);
-app.use("/api", chatRoutes); 
-app.use("/api/match", matchRoutes); // 👈 ADD THIS
+app.use("/api", chatRoutes);
+app.use("/api/match", matchRoutes);
+
+app.listen(port, () => {
+	console.log(`Backend server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- replace broken backend entrypoint with a proper Express server bootstrap
- fix route imports in `src/backend/server.js` from `./routes/*` to existing `./routers/*`
- initialize `app`, enable JSON parsing, and start listening on `PORT` (default `3001`)
- add a lightweight `/health` endpoint for startup verification
- add `express` dependency in `package.json`

## Why
Issue #173 reports backend startup failure because:
1. `src/backend/server.js` imported routes from a non-existent folder
2. `app.use(...)` was called without creating an Express app

This PR resolves both blockers so the backend entrypoint can boot successfully.

## Validation
- `node --check src/backend/server.js` passes
- `npm run lint` still reports pre-existing unrelated lint issues in frontend files

Closes #173