### PR TITLE
fix(auth): implement real password reset flow (fixes #174)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "framer-motion": "^11.18.2",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.462.0",
+    "mongoose": "^8.18.0",
     "next-themes": "^0.3.0",
     "nodemailer": "^8.0.5",
     "openai": "^6.34.0",

--- a/src/backend/controllers/authController.js
+++ b/src/backend/controllers/authController.js
@@ -1,27 +1,119 @@
+import bcrypt from "bcryptjs";
+import crypto from "crypto";
+import User from "../models/User.js";
+import { sendEmail } from "../utils/sendEmail.js";
+
 export const forgotPassword = async (req, res) => {
   try {
+    const { email } = req.body;
+
+    if (!email) {
+      return res.status(400).json({
+        success: false,
+        message: "Email is required",
+      });
+    }
+
+    const normalizedEmail = String(email).trim().toLowerCase();
+    const user = await User.findOne({ email: normalizedEmail });
+
+    if (!user) {
+      return res.status(200).json({
+        success: true,
+        message:
+          "If an account with that email exists, a password reset link has been sent.",
+      });
+    }
+
+    const rawResetToken = crypto.randomBytes(32).toString("hex");
+    const hashedResetToken = crypto
+      .createHash("sha256")
+      .update(rawResetToken)
+      .digest("hex");
+
+    user.resetPasswordToken = hashedResetToken;
+    user.resetPasswordExpire = Date.now() + 15 * 60 * 1000;
+    await user.save({ validateBeforeSave: false });
+
+    const frontendBaseUrl =
+      process.env.PASSWORD_RESET_BASE_URL ||
+      process.env.FRONTEND_URL ||
+      process.env.CLIENT_URL ||
+      `${req.protocol}://${req.get("host")}`;
+    const resetUrl = `${frontendBaseUrl.replace(/\/$/, "")}/reset-password?token=${rawResetToken}`;
+
+    try {
+      await sendEmail(user.email, resetUrl);
+    } catch (mailError) {
+      user.resetPasswordToken = undefined;
+      user.resetPasswordExpire = undefined;
+      await user.save({ validateBeforeSave: false });
+
+      return res.status(500).json({
+        success: false,
+        message: "Unable to send reset email. Please try again later.",
+      });
+    }
+
     res.status(200).json({
       success: true,
-      message: "Forgot password endpoint working",
+      message:
+        "If an account with that email exists, a password reset link has been sent.",
     });
   } catch (error) {
     res.status(500).json({
       success: false,
-      message: "Server Error",
+      message: error.message || "Server Error",
     });
   }
 };
 
 export const resetPassword = async (req, res) => {
   try {
+    const { token } = req.params;
+    const { password } = req.body;
+
+    if (!token || !password) {
+      return res.status(400).json({
+        success: false,
+        message: "Token and new password are required",
+      });
+    }
+
+    if (String(password).length < 6) {
+      return res.status(400).json({
+        success: false,
+        message: "Password must be at least 6 characters long",
+      });
+    }
+
+    const hashedToken = crypto.createHash("sha256").update(token).digest("hex");
+
+    const user = await User.findOne({
+      resetPasswordToken: hashedToken,
+      resetPasswordExpire: { $gt: Date.now() },
+    });
+
+    if (!user) {
+      return res.status(400).json({
+        success: false,
+        message: "Reset token is invalid or has expired",
+      });
+    }
+
+    user.password = await bcrypt.hash(password, 10);
+    user.resetPasswordToken = undefined;
+    user.resetPasswordExpire = undefined;
+    await user.save();
+
     res.status(200).json({
       success: true,
-      message: "Reset password endpoint working",
+      message: "Password has been reset successfully",
     });
   } catch (error) {
     res.status(500).json({
       success: false,
-      message: "Server Error",
+      message: error.message || "Server Error",
     });
   }
 };


### PR DESCRIPTION
## Summary
- replace stubbed `forgotPassword` with a real flow that:
  - validates email input
  - looks up the user by email
  - generates a cryptographically secure reset token
  - stores only the SHA-256 hashed token with an expiry window
  - sends reset email via existing `sendEmail` utility
  - rolls back token fields if email dispatch fails
- replace stubbed `resetPassword` with a real flow that:
  - validates token and password input
  - verifies hashed token and expiry against stored values
  - hashes the new password with `bcryptjs`
  - clears reset token fields after successful reset
- add missing `mongoose` dependency used by `src/backend/models/User.js`

## Why
Issue #174 reported that both password reset endpoints always returned success without performing any actual reset behavior.

## Validation
- Checked diagnostics for edited files: no file-level errors.
- Ran lint command; it still reports many existing repo-wide lint issues unrelated to this change.

## Notes
- Reset URL is built from `PASSWORD_RESET_BASE_URL`, fallback `FRONTEND_URL`, fallback `CLIENT_URL`, then request host.
