### PR TITLE
[Security][Level 3] fix(#176): add auth, rate limiting, and question cap to POST /api/ai/ask

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -1,7 +1,20 @@
+// Maximum number of characters allowed in a single question.
+// Keeps token consumption bounded and prevents single-request API credit drain.
+const MAX_QUESTION_LENGTH = 2000;
 
 export const askAI = async (req, res) => {
   try {
     const { question } = req.body;
+
+    if (!question || typeof question !== "string" || question.trim().length === 0) {
+      return res.status(400).json({ error: "A non-empty question is required." });
+    }
+
+    if (question.length > MAX_QUESTION_LENGTH) {
+      return res.status(400).json({
+        error: `Question must not exceed ${MAX_QUESTION_LENGTH} characters.`,
+      });
+    }
 
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
       method: "POST",
@@ -10,10 +23,10 @@ export const askAI = async (req, res) => {
         "Authorization": `Bearer ${process.env.OPENROUTER_API_KEY}`
       },
       body: JSON.stringify({
-        model: "openai/gpt-4", // you can swap models later
+        model: "openai/gpt-4",
         messages: [
           { role: "system", content: "You are an AI peer mentor for students. Answer questions about coding, AI, DSA, and roadmaps in a supportive, clear, and approachable way." },
-          { role: "user", content: question }
+          { role: "user", content: question.trim() }
         ]
       })
     });

--- a/backend/routers/aiRoutes.js
+++ b/backend/routers/aiRoutes.js
@@ -1,7 +1,47 @@
 import express from "express";
 import { askAI } from "../controllers/aiController.js";
+import { requireAuth } from "../middlewares/requireAuth.js";
 
 const router = express.Router();
-router.post("/ask", askAI);
+
+// Simple in-memory rate limiter: max 10 requests per authenticated user per minute.
+// Entries whose window has expired are evicted on each check to keep memory bounded.
+const aiRequestCounts = new Map();
+const AI_WINDOW_MS = 60 * 1000;
+const AI_MAX_REQUESTS = 10;
+
+const evictStaleEntries = () => {
+  const now = Date.now();
+  for (const [key, entry] of aiRequestCounts.entries()) {
+    if (now - entry.windowStart >= AI_WINDOW_MS) {
+      aiRequestCounts.delete(key);
+    }
+  }
+};
+
+const aiRateLimiter = (req, res, next) => {
+  const userId = req.user.id;
+  const now = Date.now();
+
+  evictStaleEntries();
+
+  const entry = aiRequestCounts.get(userId);
+
+  if (!entry || now - entry.windowStart >= AI_WINDOW_MS) {
+    aiRequestCounts.set(userId, { count: 1, windowStart: now });
+    return next();
+  }
+
+  if (entry.count >= AI_MAX_REQUESTS) {
+    return res.status(429).json({
+      error: "Too many requests. Please wait before sending more AI questions.",
+    });
+  }
+
+  entry.count += 1;
+  next();
+};
+
+router.post("/ask", requireAuth, aiRateLimiter, askAI);
 
 export default router;


### PR DESCRIPTION
## Summary

Fixes #176

`POST /api/ai/ask` had no authentication and no rate limiting. Any anonymous caller could send unlimited requests to OpenRouter with `openai/gpt-4`, fully draining the project's API budget.

## Changes

**`backend/routers/aiRoutes.js`**
- Imported `requireAuth` from the existing auth middleware
- Added a per-user in-memory rate limiter (`aiRateLimiter`) - max 10 requests per user per minute
- Stale entries are evicted before each check (Map stays memory-bounded)
- Route is now `router.post("/ask", requireAuth, aiRateLimiter, askAI)`

**`backend/controllers/aiController.js`**
- Added `MAX_QUESTION_LENGTH = 2000` character cap
- Requests with `question.length > 2000` are rejected with 400 before hitting OpenRouter
- Added input validation (`typeof question !== "string"`, empty check)

## Before / After

```
Before: curl -X POST /api/ai/ask -d '{"question":"...1MB..."}' -> 200 (no auth needed)
After:  curl -X POST /api/ai/ask -d '{"question":"..."}' -> 401 (no auth token)
        With token + long question -> 400 (exceeds 2000 chars)
        With token + 11th request in 60s -> 429 (rate limited)
```

Could you please add the relevant GSSoC labels to this PR? Thank you!