### PR TITLE
fix(#177,#178,#179,#180): secure chatRoutes.js - restore auth, remove API key log, fix memory leak, block systemPrompt injection

### DIFF
--- a/backend/routers/chatRoutes.js
+++ b/backend/routers/chatRoutes.js
@@ -8,7 +8,6 @@ const router = express.Router();
 // OpenRouter is OpenAI-compatible, so the OpenAI SDK works by pointing at the
 // OpenRouter base URL. The API key is read from the server environment and is
 // never sent to the client.
-console.log(process.env.OPENROUTER_API_KEY);
 const openrouter = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,   // must not be undefined
   baseURL: "https://openrouter.ai/api/v1",
@@ -17,15 +16,6 @@ const openrouter = new OpenAI({
     "X-Title": "Peer Learning AI",
   },
 });
-
-// const openrouter = new OpenAI({
-//   apiKey: process.env.OPENROUTER_API_KEY,
-//   baseURL: "https://openrouter.ai/api/v1",
-//   defaultHeaders: {
-//     "HTTP-Referer": process.env.SITE_URL || "http://localhost:8080",
-//     "X-Title": "Peer Learning AI",
-//   },
-// });
 
 // Allowed models. Requests specifying any other model are rejected to
 // prevent cost escalation via expensive third-party models.
@@ -37,23 +27,46 @@ const ALLOWED_MODELS = new Set([
 // Server-side cap on tokens per request, regardless of what the caller sends.
 const MAX_TOKENS_CAP = 512;
 
+// Maximum length for the server-defined system prompt injected on every request.
+const MAX_SYSTEM_PROMPT_LENGTH = 500;
+
+// Fixed system prompt injected server-side. Callers cannot override this because
+// accepting a caller-supplied systemPrompt verbatim allows full AI persona override
+// and policy bypass. See issue #180.
+const SYSTEM_PROMPT = "You are a helpful peer-learning assistant. Answer questions about coding, study techniques, and academic topics in a clear and supportive way.";
+
 // Simple in-memory rate limiter: max 20 requests per authenticated user per minute.
+// Entries for users whose window has expired are evicted on each request to prevent
+// the Map from growing unboundedly as user count increases (issue #179).
 const requestCounts = new Map();
+const WINDOW_MS = 60 * 1000;
+const MAX_REQUESTS = 20;
+
+// Evict all stale entries whose window has expired.
+// Called before each rate-limit check to keep memory bounded.
+const evictStaleEntries = () => {
+  const now = Date.now();
+  for (const [key, entry] of requestCounts.entries()) {
+    if (now - entry.windowStart >= WINDOW_MS) {
+      requestCounts.delete(key);
+    }
+  }
+};
 
 const rateLimiter = (req, res, next) => {
   const userId = req.user.id;
   const now = Date.now();
-  const windowMs = 60 * 1000;
-  const maxRequests = 20;
+
+  evictStaleEntries();
 
   const entry = requestCounts.get(userId);
 
-  if (!entry || now - entry.windowStart >= windowMs) {
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
     requestCounts.set(userId, { count: 1, windowStart: now });
     return next();
   }
 
-  if (entry.count >= maxRequests) {
+  if (entry.count >= MAX_REQUESTS) {
     return res.status(429).json({
       error: "Too many requests. Please wait before sending more messages.",
     });
@@ -62,12 +75,11 @@ const rateLimiter = (req, res, next) => {
   entry.count += 1;
   next();
 };
-// requireAuth, rateLimiter,
-router.post("/chat",  async (req, res) => {
+
+router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
   try {
     const {
       messages,
-      systemPrompt,
       model = "openai/gpt-3.5-turbo",
       max_tokens,
       temperature = 0.7,
@@ -103,9 +115,13 @@ router.post("/chat",  async (req, res) => {
       MAX_TOKENS_CAP
     );
 
-    const chatMessages = systemPrompt
-      ? [{ role: "system", content: String(systemPrompt) }, ...messages]
-      : messages;
+    // Prepend the fixed server-defined system prompt.
+    // systemPrompt is no longer accepted from the request body to prevent
+    // caller-supplied persona overrides (issue #180).
+    const chatMessages = [
+      { role: "system", content: SYSTEM_PROMPT },
+      ...messages,
+    ];
 
     const response = await openrouter.chat.completions.create({
       model,
@@ -117,9 +133,7 @@ router.post("/chat",  async (req, res) => {
     res.json({ reply: response.choices[0].message.content });
   } catch (error) {
     console.error("Chat route error:", error);
-    res.status(500).json({ error: error.message || "AI request failed" });
-
-    // res.status(500).json({ error: "Failed to get a response from the AI service." });
+    res.status(500).json({ error: "Failed to get a response from the AI service." });
   }
 });
 


### PR DESCRIPTION
## Summary

Fixes four security and reliability issues in `backend/routers/chatRoutes.js`:

- **#177 - Auth/rate-limit middlewares were commented out**: `requireAuth` and `rateLimiter` have been restored on the `POST /chat` route, so unauthenticated requests are rejected.
- **#178 - API key logged in plaintext**: Removed `console.log(process.env.OPENROUTER_API_KEY)` that exposed the secret in server logs.
- **#179 - Unbounded in-memory Map**: Added `evictStaleEntries()` that prunes expired rate-limit windows on every request, preventing the `requestCounts` Map from growing indefinitely.
- **#180 - Caller-controlled systemPrompt injection**: Removed `systemPrompt` from the request body. A fixed server-side `SYSTEM_PROMPT` constant is used instead, eliminating the ability for callers to override the system persona.

## Changes

- `backend/routers/chatRoutes.js`
  - Removed `console.log(process.env.OPENROUTER_API_KEY)`
  - Removed duplicate commented-out OpenAI client block
  - Added `SYSTEM_PROMPT` constant; removed `systemPrompt` from `req.body` destructuring
  - Added `evictStaleEntries()` and called it at the start of `rateLimiter`
  - Changed route declaration to `router.post("/chat", requireAuth, rateLimiter, async ...)`
  - Changed error response to a generic message to avoid leaking internal details

## Test plan

- [ ] `POST /chat` without a valid JWT returns 401
- [ ] `POST /chat` exceeding 20 requests/minute returns 429
- [ ] Server logs contain no trace of the OpenRouter API key on startup
- [ ] Passing a `systemPrompt` field in the request body has no effect on the model prompt
- [ ] Long-running server shows stable Map size under repeated requests

Closes #177
Closes #178
Closes #179
Closes #180