### PR TITLE
fix(#177): restore requireAuth and rateLimiter on POST /chat route

### DIFF
--- a/backend/routers/chatRoutes.js
+++ b/backend/routers/chatRoutes.js
@@ -62,8 +62,7 @@ const rateLimiter = (req, res, next) => {
   entry.count += 1;
   next();
 };
-// requireAuth, rateLimiter,
-router.post("/chat",  async (req, res) => {
+router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
   try {
     const {
       messages,


### PR DESCRIPTION
## Summary

The `requireAuth` and `rateLimiter` middlewares on the `POST /chat` route were accidentally commented out, leaving the endpoint accessible to unauthenticated callers at unlimited request rates.

This change restores both middlewares so that:
- Only authenticated users (valid JWT) can reach the handler.
- The existing 20 requests/minute per-user cap is enforced.

## Changes

- `backend/routers/chatRoutes.js`: removed the `// requireAuth, rateLimiter,` comment line and added both middlewares back to the route declaration.

## Test plan

- [ ] `POST /chat` without a valid `Authorization: Bearer <token>` header returns 401.
- [ ] `POST /chat` with a valid token succeeds normally.
- [ ] Sending more than 20 requests within a minute returns 429.

Closes #177