### PR TITLE
fix(#178): remove console.log that leaked OPENROUTER_API_KEY to server logs

### DIFF
--- a/backend/routers/chatRoutes.js
+++ b/backend/routers/chatRoutes.js
@@ -9,7 +9,6 @@ const router = express.Router();
 // OpenRouter is OpenAI-compatible, so the OpenAI SDK works by pointing at the
 // OpenRouter base URL. The API key is read from the server environment and is
 // never sent to the client.
-console.log(process.env.OPENROUTER_API_KEY);
 const openrouter = new OpenAI({
   apiKey: process.env.OPENROUTER_API_KEY,   // must not be undefined
   baseURL: "https://openrouter.ai/api/v1",
@@ -18,15 +17,6 @@ const openrouter = new OpenAI({
     "X-Title": "Peer Learning AI",
   },
 });
-
-// const openrouter = new OpenAI({
-//   apiKey: process.env.OPENROUTER_API_KEY,
-//   baseURL: "https://openrouter.ai/api/v1",
-//   defaultHeaders: {
-//     "HTTP-Referer": process.env.SITE_URL || "http://localhost:8080",
-//     "X-Title": "Peer Learning AI",
-//   },
-// });
 
 // Allowed models. Requests specifying any other model are rejected to
 // prevent cost escalation via expensive third-party models.
@@ -93,8 +83,6 @@ router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
   } catch (error) {
     console.error("Chat route error:", error);
     res.status(500).json({ error: error.message || "AI request failed" });
-
-    // res.status(500).json({ error: "Failed to get a response from the AI service." });
   }
 });
 


### PR DESCRIPTION
## Summary

`console.log(process.env.OPENROUTER_API_KEY)` on line 11 of `chatRoutes.js` printed the secret API key in plain text every time the module was loaded. This exposes the key in any log aggregation system, process manager output, or container log stream.

Also removed the stale commented-out duplicate OpenAI client instantiation block that followed it.

## Changes

- `backend/routers/chatRoutes.js`: removed `console.log(process.env.OPENROUTER_API_KEY)` and the unused commented-out client block.

## Test plan

- [ ] Start the server and confirm no API key appears in stdout/stderr.
- [ ] `POST /chat` with a valid token still receives a valid AI response (the client is still instantiated correctly).

Closes #178