### PR TITLE
fix(#179): evict stale rate-limiter entries to prevent Map memory leak

### DIFF
--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -1,19 +1,38 @@
+const WINDOW_MS = 60 * 1000;
+const MAX_REQUESTS = 20;
+
+// requestCounts tracks the active rate-limit window for each authenticated user.
+// Without periodic cleanup the Map grows without bound: every user that ever
+// sends a request adds an entry that is never removed, which is a slow memory
+// leak in a long-running Node.js process.
 export const requestCounts = new Map();
+
+// evictStaleEntries removes entries whose time window has already expired.
+// Called before each limiter check so the Map stays bounded to only users
+// who are currently within an active window.
+const evictStaleEntries = () => {
+  const now = Date.now();
+  for (const [key, entry] of requestCounts.entries()) {
+    if (now - entry.windowStart >= WINDOW_MS) {
+      requestCounts.delete(key);
+    }
+  }
+};
 
 export const rateLimiter = (req, res, next) => {
   const userId = req.user.id;
   const now = Date.now();
-  const windowMs = 60 * 1000;
-  const maxRequests = 20;
+
+  evictStaleEntries();
 
   const entry = requestCounts.get(userId);
 
-  if (!entry || now - entry.windowStart >= windowMs) {
+  if (!entry || now - entry.windowStart >= WINDOW_MS) {
     requestCounts.set(userId, { count: 1, windowStart: now });
     return next();
   }
 
-  if (entry.count >= maxRequests) {
+  if (entry.count >= MAX_REQUESTS) {
     return res.status(429).json({
       error: "Too many requests. Please wait before sending more messages.",
     });


### PR DESCRIPTION
## Summary

The `requestCounts` Map in `chatRoutes.js` accumulated one entry per unique authenticated user and never released them. On a long-running server this causes steady heap growth proportional to the number of distinct users who have ever sent a chat request.

Added an `evictStaleEntries()` helper that iterates the Map and deletes entries whose rate-limit window (60 s) has already expired. It is called at the start of every `rateLimiter` invocation, so expired entries are cleaned up on each request without any separate background timer.

## Changes

- `backend/routers/chatRoutes.js`:
  - Extracted `WINDOW_MS` and `MAX_REQUESTS` as named constants.
  - Added `evictStaleEntries()` function.
  - Called `evictStaleEntries()` at the top of `rateLimiter`.

## Test plan

- [ ] After a quiet period (> 1 min), issue a new chat request and verify the Map contains only the current user's entry.
- [ ] Rate limiting still correctly rejects users who exceed 20 requests per minute.
- [ ] No regression in normal chat flow.

Closes #179