### PR TITLE
fix(#180): replace caller-supplied systemPrompt with a fixed server-side constant

### DIFF
--- a/backend/routers/chatRoutes.js
+++ b/backend/routers/chatRoutes.js
@@ -38,11 +38,17 @@ const ALLOWED_MODELS = new Set([
 // Server-side cap on tokens per request, regardless of what the caller sends.
 const MAX_TOKENS_CAP = 512;
 
+// Fixed system prompt prepended to every conversation server-side.
+// Callers cannot override this via the request body, which prevents
+// prompt injection attacks that would let them alter the assistant persona
+// or bypass content guidelines.
+const SYSTEM_PROMPT =
+  "You are a helpful peer-learning assistant. Answer questions about coding, study techniques, and academic topics in a clear and supportive way.";
+
 router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
   try {
     const {
       messages,
-      systemPrompt,
       model = "openai/gpt-3.5-turbo",
       max_tokens,
       temperature = 0.7,
@@ -78,9 +84,7 @@ router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
       MAX_TOKENS_CAP
     );
 
-    const chatMessages = systemPrompt
-      ? [{ role: "system", content: String(systemPrompt) }, ...messages]
-      : messages;
+    const chatMessages = [{ role: "system", content: SYSTEM_PROMPT }, ...messages];
 
     const response = await openrouter.chat.completions.create({
       model,


### PR DESCRIPTION
## Summary

The `POST /chat` handler accepted a `systemPrompt` field from the request body and passed it verbatim as the system message to the model. This allowed any authenticated caller to override the application's system persona, enabling prompt injection attacks (e.g. bypassing content guidelines or impersonating a different service).

Introduced a `SYSTEM_PROMPT` constant defined server-side and always prepended to the message array. The `systemPrompt` field is no longer read from `req.body`, so client-supplied values have no effect.

## Changes

- `backend/routers/chatRoutes.js`:
  - Added `SYSTEM_PROMPT` constant.
  - Removed `systemPrompt` from the `req.body` destructuring.
  - Replaced the conditional `systemPrompt ? [...] : messages` expression with a fixed prepend of `SYSTEM_PROMPT`.

## Test plan

- [ ] `POST /chat` with a `systemPrompt` field in the body returns a response using the server-defined persona, not the caller-supplied one.
- [ ] Normal chat requests (no `systemPrompt` field) work as expected.
- [ ] Attempts to jailbreak via `systemPrompt` are silently ignored.

Closes #180