### PR TITLE
Fix: Patch infinite XP farming loophole in Session video toggles

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -49,6 +49,9 @@ const Sessions = () => {
   const [isVideoActive, setIsVideoActive] = useState(false);
 
   const messagesEndRef = useRef<any>(null);
+  
+  // Track sessions that have already granted XP to prevent infinite farming
+  const awardedSessions = useRef<Set<string>>(new Set());
 
   // FETCH SESSIONS
   useEffect(() => {
@@ -416,7 +419,11 @@ const Sessions = () => {
                 <button 
                   onClick={() => {
                     setIsVideoActive(true);
-                    awardXP({ activity: 'session_join' });
+                    // Prevent infinite XP farming loophole
+                    if (!awardedSessions.current.has(selectedSession.id)) {
+                      awardXP({ activity: 'session_join' });
+                      awardedSessions.current.add(selectedSession.id);
+                    }
                   }}
                   className="flex items-center gap-2 bg-gradient-to-r from-cyan-400 to-purple-500 text-black px-4 py-2 rounded-2xl font-bold hover:opacity-90 transition"
                 >


### PR DESCRIPTION
## Description
This PR addresses a critical logic flaw in `Sessions.tsx` where users could infinitely farm XP by repeatedly clicking the "Join Video" and "Leave Video" buttons on the frontend. Because the `awardXP` function was tied directly to the `onClick` handler without any state verification, every click registered as a new "session joined" event, spamming the backend ledger with unearned points.

### Changes Made:
- **Session Tracking**: Introduced a `useRef<Set<string>>` to track the `session_id`s that the user has already joined during their current browser session.
- **Exploit Prevention**: Wrapped the `awardXP({ activity: 'session_join' })` call in a conditional block that verifies the user hasn't already been awarded points for the currently selected session.

This perfectly stops the exploit while keeping the exact same UI and layout behavior for the end-user.

## Related Issues
- Resolves #186 

## Labels
`bug`, `frontend`, `gamification`, `security`