### PR TITLE
fix: replace array index key with stable msg.id in sessions chat

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -568,13 +568,13 @@ const Sessions = () => {
 
             {/* MESSAGES */}
             <div className="flex-1 overflow-y-auto py-5 space-y-4">
-              {messages.map((msg, index) => {
+              {messages.map((msg) => {
                 const isCurrentUser =
                   msg.user_id === user?.id;
 
                 return (
                   <div
-                    key={index}
+                    key={msg.id}
                     className={`flex ${
                       isCurrentUser
                         ? "justify-end"


### PR DESCRIPTION
## Description

The chat messages in the Sessions page were using the array index as the React key for mapped list items. This can cause issues with React's reconciliation process, leading to unnecessary re-renders and potential state bugs when messages are reordered, filtered, or updated via realtime subscriptions.

## Issue Cause

The `messages.map()` callback was using the second parameter (`index`) as the `key` prop instead of a stable identifier from the data itself.

## What We Did

Changed `key={index}` to `key={msg.id}` in the messages map. The `id` field comes from the Supabase `messages` table primary key, which is guaranteed to be unique and stable across renders. Also removed the unused `index` parameter from the map callback since it is no longer referenced.

## Additional Context

The `messages` state is populated via `.select("*")` on the Supabase `messages` table and through realtime INSERT subscriptions, both of which provide a unique `id` field for every message object.

## Checklist

- [x] Code compiles and runs without errors
- [x] No console warnings about missing keys
- [x] Messages render correctly with stable identity

Fixes #220 