### PR TITLE
Fix: Client-Side XP Forgery (Privilege Escalation)

### DIFF
--- a/src/hooks/useAwardXP.ts
+++ b/src/hooks/useAwardXP.ts
@@ -18,10 +18,8 @@ export const useAwardXP = () => {
 
       const xpToAward = getXPForActivity(activity);
 
-      // Securely delegate to the ledger-backed RPC function.
-      // This completely solves the race condition and updates both the profiles
-      // and leaderboard tables atomically.
-      const { error: rpcError } = await (supabase as any).rpc("increment_user_xp", { _amount: xpToAward });
+      // Delegate to the activity-based secure RPC to prevent client-side XP forgery
+      const { error: rpcError } = await (supabase as any).rpc("award_activity_xp", { _activity_type: activity });
 
       if (rpcError) throw rpcError;
 

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -85,6 +85,35 @@ const Sessions = () => {
     fetchSessions();
   }, []);
 
+  // USER ACTIVITY TRACKER
+  useEffect(() => {
+    let idleTimer: any;
+
+    const handleActivity = () => {
+      setUserStatus("Active");
+
+      clearTimeout(idleTimer);
+
+      idleTimer = setTimeout(() => {
+        setUserStatus("Idle");
+      }, 15000);
+    };
+
+    window.addEventListener("mousemove", handleActivity);
+    window.addEventListener("keydown", handleActivity);
+    window.addEventListener("click", handleActivity);
+
+    handleActivity();
+
+    return () => {
+      clearTimeout(idleTimer);
+
+      window.removeEventListener("mousemove", handleActivity);
+      window.removeEventListener("keydown", handleActivity);
+      window.removeEventListener("click", handleActivity);
+    };
+  }, []);
+
   // FILTER SESSIONS
   useEffect(() => {
     let filtered = sessions;
@@ -611,46 +640,6 @@ const Sessions = () => {
 
               <div ref={messagesEndRef} />
             </div>
-
-          // USER ACTIVITY TRACKER
-                useEffect(() => {
-                  let idleTimer: any;
-
-                  const handleActivity = () => {
-                    setUserStatus("Active");
-
-                    clearTimeout(idleTimer);
-
-                    idleTimer = setTimeout(() => {
-                      setUserStatus("Idle");
-                    }, 15000);
-                  };
-
-                  window.addEventListener("mousemove", handleActivity);
-                  window.addEventListener("keydown", handleActivity);
-                  window.addEventListener("click", handleActivity);
-
-                  handleActivity();
-
-                  return () => {
-                    clearTimeout(idleTimer);
-
-                    window.removeEventListener(
-                      "mousemove",
-                      handleActivity
-                    );
-
-                    window.removeEventListener(
-                      "keydown",
-                      handleActivity
-                    );
-
-                    window.removeEventListener(
-                      "click",
-                      handleActivity
-                    );
-                  };
-                }, []);
 
            {/* TYPING INDICATOR */}
             {isTyping && (

--- a/supabase/migrations/20260529000000_fix_xp_forgery.sql
+++ b/supabase/migrations/20260529000000_fix_xp_forgery.sql
@@ -1,0 +1,30 @@
+-- Migration: 20260529000000_fix_xp_forgery.sql
+-- Description: Revoke direct access to increment_user_xp and introduce a secure award_activity_xp RPC.
+
+-- 1. Revoke the direct XP increment function from authenticated users
+REVOKE EXECUTE ON FUNCTION public.increment_user_xp(INT) FROM authenticated;
+
+-- 2. Create the new secure RPC that looks up XP by activity
+CREATE OR REPLACE FUNCTION public.award_activity_xp(_activity_type TEXT) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_xp_to_award INT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN; END IF;
+
+  CASE _activity_type
+    WHEN 'session_join' THEN v_xp_to_award := 50;
+    WHEN 'mentor_help' THEN v_xp_to_award := 100;
+    WHEN 'daily_login' THEN v_xp_to_award := 20;
+    ELSE v_xp_to_award := 10;
+  END CASE;
+
+  -- Call the existing internal function to update the ledger safely
+  PERFORM public.increment_user_xp(v_xp_to_award);
+END;
+$$;
+
+-- 3. Grant access to the new secure RPC
+REVOKE ALL ON FUNCTION public.award_activity_xp(TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.award_activity_xp(TEXT) TO authenticated;


### PR DESCRIPTION
Fixes #225. This PR introduces a secure server-side RPC (award_activity_xp) that calculates XP based on the activity type rather than trusting the client-provided amount. It also revokes direct execution access to increment_user_xp from authenticated users to prevent arbitrary XP grants.