### PR TITLE
Fix: Leaderboard Initial XP Forgery

### DIFF
--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -74,21 +74,14 @@ const Leaderboard = () => {
 
     if (!existingUser) {
 
-      await supabase.from("leaderboard" as any).insert({
-        user_id: user.id,
-
-        username:
+      await (supabase as any).rpc("join_leaderboard", {
+        _username:
           user.user_metadata?.name ||
           user.email?.split("@")[0] ||
           "Anonymous",
 
-        avatar_url:
+        _avatar_url:
           user.user_metadata?.avatar_url || null,
-
-        xp: 0,
-        streak: 1,
-        sessions_joined: 0,
-        badges: ["Beginner"],
       });
     }
   };

--- a/supabase/migrations/20260529000001_secure_leaderboard_join.sql
+++ b/supabase/migrations/20260529000001_secure_leaderboard_join.sql
@@ -1,0 +1,25 @@
+-- Migration: 20260529000001_secure_leaderboard_join.sql
+
+-- 1. Create secure RPC
+CREATE OR REPLACE FUNCTION public.join_leaderboard(_username TEXT, _avatar_url TEXT) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_exists BOOLEAN;
+BEGIN
+  IF v_uid IS NULL THEN RETURN; END IF;
+
+  SELECT EXISTS(SELECT 1 FROM public.leaderboard WHERE user_id = v_uid) INTO v_exists;
+  
+  IF NOT v_exists THEN
+    INSERT INTO public.leaderboard (user_id, username, avatar_url, xp, streak, sessions_joined, badges)
+    VALUES (v_uid, _username, _avatar_url, 0, 1, 0, ARRAY['Beginner']);
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.join_leaderboard(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.join_leaderboard(TEXT, TEXT) TO authenticated;
+
+-- 2. Drop the policy that allowed client-side inserts
+DROP POLICY IF EXISTS "Users can insert own leaderboard row" ON public.leaderboard;


### PR DESCRIPTION
Fixes #227. Replaced the insecure client-side insert on the leaderboard table with a secure join_leaderboard RPC. Dropped the vulnerable insert policy to prevent arbitrary payload submissions.