### PR TITLE
fix: search input writes to message state instead of search state in Sessions.tsx

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -345,13 +345,7 @@ const [summaryLoading, setSummaryLoading] =
             placeholder="Search sessions..."
             value={search}
             onChange={(e) => {
-            setMessage(e.target.value);
-
-            setIsTyping(true);
-
-            setTimeout(() => {
-              setIsTyping(false);
-            }, 1500);
+            setSearch(e.target.value);
           }}
             className="w-full bg-white/5 border border-white/10 backdrop-blur-xl rounded-2xl py-4 pl-14 pr-4 outline-none focus:border-cyan-400 transition"
           />


### PR DESCRIPTION
## Description

The search input in Sessions.tsx contains a critical copy-paste bug: its onChange handler writes to the `message` state variable (`setMessage(e.target.value)`) instead of the `search` state variable (`setSearch(...)`). Every keystroke in the search box corrupts the chat message input and the session search filtering never works.

Fixes #234:
- Search filtering completely dead (filtering effect always receives empty string)
- Chat message input corrupted by search keystrokes
- Typing indicator fires incorrectly for search keystrokes

## Type of change

- Bug fix (non-breaking change which fixes an issue where search writes to wrong state)
- Code quality (removes dead typing-indicator logic from search handler)

## Root Cause Analysis

`src/pages/Sessions.tsx:348` (before fix):

```tsx
onChange={(e) => {
  setMessage(e.target.value);  // BUG: writes to `message` state instead of `search`
  setIsTyping(true);
  setTimeout(() => {
    setIsTyping(false);
  }, 1500);
}}
```

The `search` state (line 53) is declared alongside `setSearch`, but the onChange calls `setMessage` (line 45). The useEffect at lines 96-114 that filters sessions based on `search` always receives an empty string because `search` is never updated by the input.

## Changes Made

1. **Line 348**: Changed `setMessage(e.target.value)` to `setSearch(e.target.value)`
2. **Lines 350-354**: Removed `setIsTyping(true)` and associated setTimeout -- the typing indicator is meant for the chat message input, not search keystrokes

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| Type in search box | Search filtering dead, chat input corrupted | Search filters correctly, chat input untouched |
| Typing indicator | Fires on every search keystroke | Only fires on chat message changes |

## Checklist

- [x] Code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Search filtering works correctly after fix