### PR TITLE
Fix: Hardcoded Expensive GPT-4 Model Selection

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -11,7 +11,7 @@ export const askAI = async (req, res) => {
           Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
         },
         body: JSON.stringify({
-          model: "openai/gpt-4",
+          model: "openai/gpt-4o-mini",
           messages: [
             {
               role: "system",
@@ -62,7 +62,7 @@ export const generateSessionSummary = async (req, res) => {
           Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
         },
         body: JSON.stringify({
-          model: "openai/gpt-4",
+          model: "openai/gpt-4o-mini",
           messages: [
             {
               role: "system",

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -716,6 +716,7 @@ const [summaryLoading, setSummaryLoading] =
                         })}
                       </p>
                     </div>
+                  </div>
                 );
               })}
 


### PR DESCRIPTION
Fixes #245. Updated askAI and generateSessionSummary endpoints to use the much cheaper openai/gpt-4o-mini model, reducing API costs while maintaining response quality.