### PR TITLE
Fix: Missing Database-Level Message Length Constraints

### DIFF
--- a/supabase/migrations/20260529000002_add_message_length_constraints.sql
+++ b/supabase/migrations/20260529000002_add_message_length_constraints.sql
@@ -1,0 +1,9 @@
+-- Add CHECK constraint to limit message content length in messages table
+ALTER TABLE public.messages
+ADD CONSTRAINT messages_content_length_check
+CHECK (length(content) <= 2000);
+
+-- Add CHECK constraint to limit message content length in study_room_messages table
+ALTER TABLE public.study_room_messages
+ADD CONSTRAINT study_room_messages_content_length_check
+CHECK (length(content) <= 2000);


### PR DESCRIPTION
Fixes #247. Added check constraints to the messages and study_room_messages tables to limit message content to 2000 characters at the database level. This prevents attackers from bypassing frontend validations and causing storage exhaustion/client crashes via large payloads.