### PR TITLE
Fix: No Pagination on Global Users/Profiles Query

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -87,12 +87,14 @@ const Chat = () => {
           .from("profiles")
           .select("*")
           .neq("id", currentUser.id)
-          .order("name", { ascending: true }),
+          .order("name", { ascending: true })
+          .limit(100),
         supabase
           .from("users")
           .select("*")
           .neq("id", currentUser.id)
-          .order("name", { ascending: true }),
+          .order("name", { ascending: true })
+          .limit(100),
       ]);
 
       const mergedUsers = mergeUsers(
@@ -127,12 +129,14 @@ const Chat = () => {
             .select("*")
             .neq("id", currentUser.id)
             .order("name", { ascending: true })
+            .limit(100)
             .then(({ data: profileData }) => {
               void supabase
                 .from("users")
                 .select("*")
                 .neq("id", currentUser.id)
                 .order("name", { ascending: true })
+                .limit(100)
                 .then(({ data: userData }) => {
                   setUsers(
                     mergeUsers((profileData ?? []) as Profile[], (userData ?? []) as UserRow[])


### PR DESCRIPTION
Fixes #248. Added .limit(100) to the Supabase queries fetching profiles and users in the Chat component. This prevents the client from attempting to fetch the entire database table at once, mitigating massive database loads, high bandwidth usage, and browser crashes as the platform grows.