### PR TITLE
Fix: No Pagination on Study Sessions

### DIFF
--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -76,7 +76,8 @@ const [summaryLoading, setSummaryLoading] =
         .select("*")
         .order("created_at", {
           ascending: false,
-        });
+        })
+        .limit(50);
 
       if (error) {
         console.log(error);


### PR DESCRIPTION
Fixes #251. Appended \.limit(50)\ to the \supabase.from('sessions')\ query on the Sessions page to prevent the client from requesting all historical and future sessions at once, preventing memory bloat and improving UI render times.