### PR TITLE
Fix: Secure Typing Indicator with Realtime Authorization

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -238,7 +238,9 @@ const Chat = () => {
       .subscribe();
 
     const typingChannel = supabase
-      .channel(`chat-typing-${[currentUser.id, selectedUser.id].sort().join("-")}`)
+      .channel(`chat-typing-${[currentUser.id, selectedUser.id].sort().join("-")}`, {
+        config: { private: true },
+      })
       .on("broadcast", { event: "typing" }, ({ payload }) => {
         if (payload.senderId !== selectedUser.id) return;
 
@@ -270,7 +272,9 @@ const Chat = () => {
     if (!currentUser?.id || !selectedUser?.id) return;
 
     await supabase
-      .channel(`chat-typing-${[currentUser.id, selectedUser.id].sort().join("-")}`)
+      .channel(`chat-typing-${[currentUser.id, selectedUser.id].sort().join("-")}`, {
+        config: { private: true },
+      })
       .send({
         type: "broadcast",
         event: "typing",

--- a/supabase/migrations/20260529000004_secure_typing_indicator.sql
+++ b/supabase/migrations/20260529000004_secure_typing_indicator.sql
@@ -1,0 +1,22 @@
+-- Secure the chat-typing Realtime Broadcasts by enforcing private channel RLS
+
+ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Restrict typing channel access" ON realtime.messages;
+CREATE POLICY "Restrict typing channel access"
+ON realtime.messages
+FOR ALL
+TO authenticated
+USING (
+  realtime.topic() LIKE 'chat-typing-%'
+  AND realtime.topic() LIKE '%' || auth.uid()::text || '%'
+)
+WITH CHECK (
+  realtime.topic() LIKE 'chat-typing-%'
+  AND realtime.topic() LIKE '%' || auth.uid()::text || '%'
+  AND (realtime.messages.payload->'payload'->>'senderId') = auth.uid()::text
+);
+
+-- Note: We also allow other private channels to be created in the future, 
+-- but we must explicitly allow them if they use private: true.
+-- Currently, only chat-typing is using private: true.


### PR DESCRIPTION
Fixes #252. Upgraded the typing broadcast channel to a private channel and added a Postgres migration to enforce Row Level Security on the \ealtime.messages\ table. This ensures users can only broadcast typing statuses if their \uth.uid()\ matches the \senderId\ and they are authorized to use the channel, preventing typing indicator spoofing attacks.