### PR TITLE
Fix: Lack of Rate Limiting on AI Summary Generator

### DIFF
--- a/backend/routers/aiRoutes.js
+++ b/backend/routers/aiRoutes.js
@@ -18,6 +18,6 @@ router.post("/ask", requireAuth, rateLimiter, askAI);
 /**
  * Session summary generator (new feature)
  */
-router.post("/generate-summary", generateSessionSummary);
+router.post("/generate-summary", rateLimiter, generateSessionSummary);
 
 export default router;


### PR DESCRIPTION
Fixes #255. Added the \ateLimiter\ middleware to the \/generate-summary\ route in \ackend/routers/aiRoutes.js\ to prevent bots or malicious users from spamming requests and draining the project's OpenRouter API credits.