### PR TITLE
Fixes #283: Realtime Channel Private Message Leak

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -207,6 +207,25 @@ const Chat = () => {
 
     loadMessages();
 
+    const handleNewMessage = (payload: any) => {
+      const nextMessage = payload.new as ChatMessage;
+      const belongsToOpenChat =
+        (nextMessage.sender_id === currentUser.id &&
+          nextMessage.receiver_id === selectedUser.id) ||
+        (nextMessage.sender_id === selectedUser.id &&
+          nextMessage.receiver_id === currentUser.id);
+
+      if (!belongsToOpenChat) return;
+
+      setMessages((previous) => {
+        if (previous.some((message) => message.id === nextMessage.id)) {
+          return previous;
+        }
+
+        return [...previous, nextMessage];
+      });
+    };
+
     const messageChannel = supabase
       .channel(`chat-messages-${currentUser.id}-${selectedUser.id}`)
       .on(
@@ -215,25 +234,19 @@ const Chat = () => {
           event: "INSERT",
           schema: "public",
           table: "messages",
+          filter: `receiver_id=eq.${currentUser.id}`,
         },
-        (payload) => {
-          const nextMessage = payload.new as ChatMessage;
-          const belongsToOpenChat =
-            (nextMessage.sender_id === currentUser.id &&
-              nextMessage.receiver_id === selectedUser.id) ||
-            (nextMessage.sender_id === selectedUser.id &&
-              nextMessage.receiver_id === currentUser.id);
-
-          if (!belongsToOpenChat) return;
-
-          setMessages((previous) => {
-            if (previous.some((message) => message.id === nextMessage.id)) {
-              return previous;
-            }
-
-            return [...previous, nextMessage];
-          });
-        }
+        handleNewMessage
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "messages",
+          filter: `sender_id=eq.${currentUser.id}`,
+        },
+        handleNewMessage
       )
       .subscribe();
 

--- a/supabase/migrations/20260529000004_fix_messages_realtime_leak.sql
+++ b/supabase/migrations/20260529000004_fix_messages_realtime_leak.sql
@@ -1,0 +1,21 @@
+-- Fix Realtime Leak by strictly scoping messages table RLS
+
+DROP POLICY IF EXISTS "Authenticated users can read session messages" ON public.messages;
+DROP POLICY IF EXISTS "Users can read their direct messages" ON public.messages;
+
+-- Create strict policies separating direct messages and session messages
+CREATE POLICY "Users can read their direct messages"
+ON public.messages
+FOR SELECT
+TO authenticated
+USING (
+  (session_id IS NULL AND (sender_id = auth.uid() OR receiver_id = auth.uid()))
+);
+
+CREATE POLICY "Users can read session messages"
+ON public.messages
+FOR SELECT
+TO authenticated
+USING (
+  (session_id IS NOT NULL)
+);


### PR DESCRIPTION
## Description
This PR addresses the security vulnerability where private chat messages are filtered purely on the client side (Issue #283).

### Changes:
- Added a new database migration to explicitly enforce RLS on the \messages\ table for direct messaging versus session chat.
- Refactored \src/pages/Chat.tsx\ to subscribe to the Supabase Realtime channel using \ilter\ parameters (\sender_id\ and \eceiver_id\) so that irrelevant messages are filtered server-side rather than sent to the client.

According to GSSoC 2026 guidelines, this PR ensures data privacy and significantly reduces websocket payload exposure.

Fixes #283