### PR TITLE
Added end-to-end error handling and request cancellation

### DIFF
--- a/src/components/ui/error-banner.tsx
+++ b/src/components/ui/error-banner.tsx
@@ -1,0 +1,36 @@
+import { AlertTriangle, RefreshCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+type ErrorBannerProps = {
+  title: string;
+  description: string;
+  actionLabel?: string;
+  onAction?: () => void;
+};
+
+export function ErrorBanner({ title, description, actionLabel = "Retry", onAction }: ErrorBannerProps) {
+  return (
+    <Card className="border-destructive/30 bg-destructive/5">
+      <CardContent className="flex flex-col gap-4 p-5 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="mt-0.5 rounded-full bg-destructive/10 p-2 text-destructive">
+            <AlertTriangle className="h-4 w-4" />
+          </div>
+          <div className="space-y-1">
+            <p className="font-semibold text-foreground">{title}</p>
+            <p className="text-sm text-muted-foreground">{description}</p>
+          </div>
+        </div>
+
+        {onAction ? (
+          <Button variant="outline" className="gap-2 self-start border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive" onClick={onAction}>
+            <RefreshCcw className="h-4 w-4" />
+            {actionLabel}
+          </Button>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useResources.ts
+++ b/src/hooks/useResources.ts
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
+import { isAbortError, normalizeError, safeSupabaseCall } from "@/lib/http";
 import type { Resource } from "@/types/resource";
 
 type ResourceFilters = {
@@ -13,8 +15,24 @@ export const useResources = (filters?: ResourceFilters) => {
   const [resources, setResources] = useState<Resource[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      abortRef.current?.abort();
+    };
+  }, []);
 
   const fetchResources = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setLoading(true);
     setError(null);
 
@@ -35,16 +53,39 @@ export const useResources = (filters?: ResourceFilters) => {
       query = query.eq("file_type", filters.fileType);
     }
 
-    const { data, error: queryError } = await query;
+    try {
+      const data = await safeSupabaseCall(
+        () => query.abortSignal(controller.signal),
+        { fallbackMessage: "Unable to load resources." },
+      );
 
-    if (queryError) {
-      setError(queryError.message);
-      setResources([]);
-    } else {
+      if (!isMountedRef.current || requestId !== requestIdRef.current || controller.signal.aborted) {
+        return;
+      }
+
       setResources((data || []) as Resource[]);
-    }
+    } catch (caughtError) {
+      if (!isMountedRef.current || requestId !== requestIdRef.current || controller.signal.aborted || isAbortError(caughtError)) {
+        return;
+      }
 
-    setLoading(false);
+      const normalized = normalizeError(caughtError, "Unable to load resources.");
+
+      setError(normalized.message);
+      setResources([]);
+
+      toast({
+        title: "Resource load failed",
+        description: normalized.message,
+        variant: "destructive",
+      });
+    } finally {
+      if (!isMountedRef.current || requestId !== requestIdRef.current || controller.signal.aborted) {
+        return;
+      }
+
+      setLoading(false);
+    }
   }, [filters?.fileType, filters?.search, filters?.tags]);
 
   useEffect(() => {

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,0 +1,132 @@
+type UnknownRecord = Record<string, unknown>;
+
+export type ApiError = {
+  message: string;
+  code?: string;
+  details?: string;
+  status?: number;
+  cause?: unknown;
+};
+
+type AsyncBoundaryOptions = {
+  fallbackMessage?: string;
+  onError?: (error: ApiError) => void;
+};
+
+function getString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null;
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+
+  const name = getString(error.name);
+  const code = getString(error.code);
+
+  return name === "AbortError" || code === "ERR_CANCELED" || code === "ABORT_ERR";
+}
+
+export function normalizeError(error: unknown, fallbackMessage = "Something went wrong"): ApiError {
+  if (typeof error === "string") {
+    return { message: error };
+  }
+
+  if (isRecord(error)) {
+    const message = getString(error.message) || fallbackMessage;
+
+    return {
+      message,
+      code: getString(error.code),
+      details: getString(error.details) || getString(error.hint),
+      status: getNumber(error.status),
+      cause: error.cause,
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message || fallbackMessage,
+      code: getString((error as Error & UnknownRecord).code),
+      details: getString((error as Error & UnknownRecord).details),
+      status: getNumber((error as Error & UnknownRecord).status),
+      cause: error.cause,
+    };
+  }
+
+  return { message: fallbackMessage, cause: error };
+}
+
+export async function withErrorBoundary<T>(
+  task: () => Promise<T>,
+  options: AsyncBoundaryOptions = {},
+): Promise<T> {
+  try {
+    return await task();
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+
+    const normalized = normalizeError(error, options.fallbackMessage);
+    options.onError?.(normalized);
+    throw normalized;
+  }
+}
+
+export async function safeSupabaseCall<T>(
+  request: () => Promise<{ data: T | null; error: unknown }>,
+  options: AsyncBoundaryOptions = {},
+): Promise<T | null> {
+  return withErrorBoundary(async () => {
+    const { data, error } = await request();
+
+    if (error) {
+      throw error;
+    }
+
+    return data;
+  }, options);
+}
+
+async function readResponseBody(response: Response): Promise<string | undefined> {
+  try {
+    const text = await response.text();
+    return text.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function safeFetchJson<T>(
+  input: RequestInfo | URL,
+  init: RequestInit = {},
+  options: AsyncBoundaryOptions = {},
+): Promise<T> {
+  return withErrorBoundary(async () => {
+    const response = await fetch(input, init);
+
+    if (!response.ok) {
+      const responseBody = await readResponseBody(response);
+      const error = new Error(responseBody || `${response.status} ${response.statusText}`) as Error &
+        UnknownRecord;
+
+      error.name = "HttpError";
+      error.status = response.status;
+      error.details = responseBody;
+
+      throw error;
+    }
+
+    return (await response.json()) as T;
+  }, options);
+}

--- a/src/pages/ContributorDashboard.tsx
+++ b/src/pages/ContributorDashboard.tsx
@@ -4,8 +4,14 @@ import StatsCard from "@/components/dashboard/StatsCard";
 import RecentActivity from "@/components/dashboard/RecentActivity";
 import LearningProgress from "@/components/dashboard/LearningProgress";
 import Leaderboard from "@/components/dashboard/Leaderboard";
+import { ErrorBanner } from "@/components/ui/error-banner";
+import { toast } from "@/hooks/use-toast";
+import { normalizeError, safeFetchJson } from "@/lib/http";
 
 function ContributorDashboard() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
   const [stats, setStats] = useState([
     {
       title: "Contributions",
@@ -26,34 +32,41 @@ function ContributorDashboard() {
   ]);
 
   useEffect(() => {
+    const controller = new AbortController();
+    let active = true;
+
     const fetchGitHubData = async () => {
+      setLoading(true);
+      setError(null);
+
       try {
         const repo = "durdana3105/peer-learning";
 
-        // Contributors
-        const contributorsRes = await fetch(
-          `https://api.github.com/repos/${repo}/contributors`
-        );
+        const [contributorsData, prsData, issuesData] = await Promise.all([
+          safeFetchJson<Array<{ contributions: number }>>(
+            `https://api.github.com/repos/${repo}/contributors`,
+            { signal: controller.signal },
+            { fallbackMessage: "Unable to load contributor data." },
+          ),
+          safeFetchJson<{ total_count?: number }>(
+            `https://api.github.com/search/issues?q=repo:${repo}+type:pr`,
+            { signal: controller.signal },
+            { fallbackMessage: "Unable to load pull request data." },
+          ),
+          safeFetchJson<{ total_count?: number }>(
+            `https://api.github.com/search/issues?q=repo:${repo}+type:issue+state:open`,
+            { signal: controller.signal },
+            { fallbackMessage: "Unable to load issue data." },
+          ),
+        ]);
 
-        const contributorsData = await contributorsRes.json();
+        if (!active || controller.signal.aborted) {
+          return;
+        }
 
         const totalContributions = Array.isArray(contributorsData)
-        ? contributorsData.reduce((acc: number, contributor: any) => acc + contributor.contributions, 0)
-        : 0;
-
-        // Pull Requests
-        const prsRes = await fetch(
-          `https://api.github.com/search/issues?q=repo:${repo}+type:pr`
-        );
-
-        const prsData = await prsRes.json();
-
-        // Issues
-        const issuesRes = await fetch(
-          `https://api.github.com/search/issues?q=repo:${repo}+type:issue+state:open`
-        );
-
-        const issuesData = await issuesRes.json();
+          ? contributorsData.reduce((acc: number, contributor) => acc + contributor.contributions, 0)
+          : 0;
 
         setStats([
           {
@@ -74,12 +87,33 @@ function ContributorDashboard() {
           },
         ]);
       } catch (error) {
-        console.error("GitHub Fetch Error:", error);
+        if (!active || controller.signal.aborted) {
+          return;
+        }
+
+        const normalized = normalizeError(error, "Unable to load GitHub contributor data.");
+
+        setError(normalized.message);
+
+        toast({
+          title: "Contributor dashboard unavailable",
+          description: normalized.message,
+          variant: "destructive",
+        });
+      } finally {
+        if (active && !controller.signal.aborted) {
+          setLoading(false);
+        }
       }
     };
 
     fetchGitHubData();
-  }, []);
+
+    return () => {
+      active = false;
+      controller.abort();
+    };
+  }, [retryNonce]);
 
   return (
     <div className="min-h-screen bg-black text-white pt-32 pb-12">
@@ -103,7 +137,22 @@ function ContributorDashboard() {
             Track your real-time GitHub contributions inside the PeerLearn repository.
           </p>
 
+          <p className="mt-3 text-sm text-cyan-300/80">
+            {loading ? "Refreshing GitHub stats..." : "Live repository data is synced from GitHub."}
+          </p>
+
         </div>
+
+        {error ? (
+          <div className="mb-8">
+            <ErrorBanner
+              title="Could not load GitHub stats"
+              description={error}
+              actionLabel="Retry"
+              onAction={() => setRetryNonce((current) => current + 1)}
+            />
+          </div>
+        ) : null}
 
         {/* Welcome Banner */}
         <div className="relative overflow-hidden rounded-3xl border border-cyan-500/20 bg-gradient-to-r from-cyan-500/10 via-blue-500/10 to-purple-500/10 p-8 md:p-10 mb-12">

--- a/src/pages/ResourceHub.tsx
+++ b/src/pages/ResourceHub.tsx
@@ -6,6 +6,7 @@ import ResourceCard from "@/components/resources/ResourceCard";
 import UploadDialog from "@/components/resources/UploadDialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { ErrorBanner } from "@/components/ui/error-banner";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AuthContext } from "@/contexts/AuthContext";
@@ -119,11 +120,12 @@ const ResourceHub = () => {
 
           <section className="lg:col-span-3">
             {error ? (
-              <Card>
-                <CardContent className="p-6">
-                  <p className="text-sm font-medium text-destructive">{error}</p>
-                </CardContent>
-              </Card>
+              <ErrorBanner
+                title="Could not load resources"
+                description={error}
+                actionLabel="Try again"
+                onAction={refetch}
+              />
             ) : loading ? (
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">{renderSkeletons()}</div>
             ) : displayedResources.length === 0 ? (


### PR DESCRIPTION
Centralized async error normalization in http.ts and added a reusable inline error surface in error-banner.tsx. The resources flow now aborts in-flight Supabase queries, ignores stale responses, and reports failures through both toast and inline retry UI in useResources.ts and ResourceHub.tsx.

I also moved the GitHub data fetches in ContributorDashboard.tsx onto AbortController-backed requests through the shared fetch helper, with normalized errors, toast notification, and an inline retry banner. The edited files passed the language-server checks; 

closes #297