### PR TITLE
Fixes #290: Implement DB insert rate limiting for chat

### DIFF
--- a/supabase/migrations/20260529000005_chat_rate_limiting.sql
+++ b/supabase/migrations/20260529000005_chat_rate_limiting.sql
@@ -1,0 +1,54 @@
+-- Create a robust function to check rate limits for message inserts
+CREATE OR REPLACE FUNCTION check_message_rate_limit()
+RETURNS trigger AS $$
+DECLARE
+  v_message_count INT;
+  v_user_id UUID;
+BEGIN
+  -- Identify the user based on the table structure
+  IF TG_TABLE_NAME = 'messages' THEN
+    v_user_id := NEW.sender_id;
+  ELSIF TG_TABLE_NAME = 'study_room_messages' THEN
+    v_user_id := NEW.profile_id;
+  END IF;
+
+  -- Ensure we have a user_id to check against
+  IF v_user_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  -- Count messages sent by this user in the last 10 seconds across the specific table
+  IF TG_TABLE_NAME = 'messages' THEN
+    SELECT COUNT(*) INTO v_message_count
+    FROM public.messages
+    WHERE sender_id = v_user_id
+    AND created_at > (now() - interval '10 seconds');
+  ELSIF TG_TABLE_NAME = 'study_room_messages' THEN
+    SELECT COUNT(*) INTO v_message_count
+    FROM public.study_room_messages
+    WHERE profile_id = v_user_id
+    AND created_at > (now() - interval '10 seconds');
+  END IF;
+
+  -- Enforce the rate limit: max 5 messages per 10 seconds
+  IF v_message_count >= 5 THEN
+    RAISE EXCEPTION 'Rate limit exceeded: You are sending messages too quickly. Please wait a few seconds.';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Apply the trigger to the messages table
+DROP TRIGGER IF EXISTS check_rate_limit_messages ON public.messages;
+CREATE TRIGGER check_rate_limit_messages
+  BEFORE INSERT ON public.messages
+  FOR EACH ROW
+  EXECUTE FUNCTION check_message_rate_limit();
+
+-- Apply the trigger to the study_room_messages table
+DROP TRIGGER IF EXISTS check_rate_limit_study_room_messages ON public.study_room_messages;
+CREATE TRIGGER check_rate_limit_study_room_messages
+  BEFORE INSERT ON public.study_room_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION check_message_rate_limit();


### PR DESCRIPTION
## Description
This PR resolves the missing database insertion rate limit vulnerability identified in Issue #290. 

### The Problem
Previously, inserting messages via the Supabase PostgREST API relied solely on Row Level Security (RLS). While RLS ensures users can only insert messages on their own behalf, there was no limit on the *rate* of insertion. A malicious authenticated user could easily craft a simple script to spam 10,000+ inserts per minute. Because Supabase API does not apply rate limiting natively to standard inserts, this would severely bloat database storage, exhaust API egress quotas, and potentially increase cloud computing costs dramatically.

### The Solution
To fix this vulnerability, this PR introduces hard rate limiting at the Postgres database level:
1. **Rate Limit Function:** Created a PL/pgSQL function (`check_message_rate_limit`) that intercepts `INSERT` commands. It dynamically calculates the number of messages a user has sent in the last 10 seconds.
2. **Threshold Enforcement:** If a user attempts to insert 5 or more messages within a 10-second rolling window, the function throws a Postgres exception (`RAISE EXCEPTION 'Rate limit exceeded...'`). This immediately blocks the insertion and returns an error response to the client via PostgREST.
3. **Database Triggers:** Applied `BEFORE INSERT` triggers to both the `messages` table (used for Direct Messages) and the `study_room_messages` table (used for group chats). The trigger automatically checks the correct user ID column (`sender_id` vs `profile_id`) depending on the context.

This solution entirely blocks malicious insertion loops without requiring any modifications to frontend logic.

Fixes #290
