### PR TITLE
Fixes #292 - Enforce Future scheduled_at for Sessions

### DIFF
--- a/supabase/migrations/20260529000006_enforce_future_scheduled_at.sql
+++ b/supabase/migrations/20260529000006_enforce_future_scheduled_at.sql
@@ -1,0 +1,26 @@
+-- Create function to enforce that a session's scheduled_at is in the future
+CREATE OR REPLACE FUNCTION check_future_scheduled_at()
+RETURNS trigger AS $$
+BEGIN
+  -- Only validate if scheduled_at is being inserted or modified
+  IF NEW.scheduled_at IS NOT NULL THEN
+    -- If it's an INSERT, or an UPDATE where scheduled_at actually changed
+    IF TG_OP = 'INSERT' OR (TG_OP = 'UPDATE' AND NEW.scheduled_at IS DISTINCT FROM OLD.scheduled_at) THEN
+      -- To prevent time-travel session creation, scheduled_at must be in the future.
+      -- We allow a small grace period of 5 minutes to account for clock drift.
+      IF NEW.scheduled_at < (now() - interval '5 minutes') THEN
+        RAISE EXCEPTION 'scheduled_at must be in the future';
+      END IF;
+    END IF;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger on the sessions table
+DROP TRIGGER IF EXISTS trg_enforce_future_scheduled_at ON sessions;
+CREATE TRIGGER trg_enforce_future_scheduled_at
+BEFORE INSERT OR UPDATE ON sessions
+FOR EACH ROW
+EXECUTE FUNCTION check_future_scheduled_at();


### PR DESCRIPTION
## Description
Fixes #292 by enforcing a strict validation on `scheduled_at` at the database level. Previously, an attacker could bypass frontend validation and create a session scheduled in the past (e.g., year 1990) via the API, which the system would instantly flag as "completed", allowing malicious users to quickly farm XP and artificially inflate their "completed sessions" metrics.

## Changes Made
- Added a new database migration (`20260529000006_enforce_future_scheduled_at.sql`) that introduces a PL/pgSQL function `check_future_scheduled_at()`.
- Added a `BEFORE INSERT OR UPDATE` trigger on the `sessions` table using the above function.
- The trigger strictly ensures that `scheduled_at` must be in the future (with a 5-minute clock-drift grace period) anytime a session is inserted or its schedule is modified.

## Gamification Protection
This permanently patches the vulnerability where users could exploit the `tick_session_statuses()` chron logic to gain unauthorized XP by time-traveling their sessions into the past.

## GSSoC '26 Guidelines
- PR Title should be: `Fixes #292 - Enforce Future scheduled_at for Sessions`
- The issue is linked so it automatically closes upon merge.
