### PR TITLE
fix: add Row Level Security to study rooms and messages tables

### DIFF
--- a/supabase/migrations/20260518120000_study_rooms_mvp.sql
+++ b/supabase/migrations/20260518120000_study_rooms_mvp.sql
@@ -15,6 +15,46 @@ CREATE TABLE study_room_messages (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT timezone('utc'::text, now()) NOT NULL
 );
 
+-- Enable Row Level Security
+ALTER TABLE study_rooms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE study_room_messages ENABLE ROW LEVEL SECURITY;
+
+-- Study rooms: anyone can read, only creator can modify/delete
+CREATE POLICY "Anyone can read study rooms"
+ON study_rooms FOR SELECT TO authenticated
+USING (true);
+
+CREATE POLICY "Users can create study rooms"
+ON study_rooms FOR INSERT TO authenticated
+WITH CHECK (created_by = auth.uid());
+
+CREATE POLICY "Only creator can update study room"
+ON study_rooms FOR UPDATE TO authenticated
+USING (created_by = auth.uid())
+WITH CHECK (created_by = auth.uid());
+
+CREATE POLICY "Only creator can delete study room"
+ON study_rooms FOR DELETE TO authenticated
+USING (created_by = auth.uid());
+
+-- Messages: anyone can read in any room, only author can modify
+CREATE POLICY "Anyone can read room messages"
+ON study_room_messages FOR SELECT TO authenticated
+USING (true);
+
+CREATE POLICY "Users can send room messages"
+ON study_room_messages FOR INSERT TO authenticated
+WITH CHECK (profile_id = auth.uid());
+
+CREATE POLICY "Author can update own message"
+ON study_room_messages FOR UPDATE TO authenticated
+USING (profile_id = auth.uid())
+WITH CHECK (profile_id = auth.uid());
+
+CREATE POLICY "Author can delete own message"
+ON study_room_messages FOR DELETE TO authenticated
+USING (profile_id = auth.uid());
+
 -- Turn on Realtime for both tables
 ALTER PUBLICATION supabase_realtime ADD TABLE study_rooms;
 ALTER PUBLICATION supabase_realtime ADD TABLE study_room_messages;


### PR DESCRIPTION
## Description

Fixes #333

The `study_rooms` and `study_room_messages` tables were created with **no Row Level Security**. No `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` and no access policies. This means any authenticated user can perform any CRUD operation on any room or any message.

**What an attacker can do:**
- Delete every study room on the platform
- Read all private room discussions
- Post messages impersonating other users (by setting a fake `profile_id`)
- Modify or delete any existing message

## Changes Made

### `supabase/migrations/20260518120000_study_rooms_mvp.sql`

Enabled RLS and added 8 policies:

**For `study_rooms`:**
- Anyone can read rooms
- Only authenticated users can create (with their own `created_by`)
- Only the creator can update or delete their room

**For `study_room_messages`:**
- Anyone can read messages in any room
- Only authenticated users can send (with their own `profile_id`)
- Only the author can update or delete their own message

## Verification

- [x] Authenticated user can create a room -- succeeds
- [x] Different user cannot delete someone else's room -- blocked by RLS
- [x] User can only send messages with their own `profile_id` -- enforced
- [x] Any authenticated user can read rooms and messages -- preserved

## Type of Change

- [x] **Bug fix** -- missing authorization layer, tables were unprotected
- [x] **Security** -- prevents data deletion, manipulation, and impersonation