### PR TITLE
fix(server): add body size limit, 404 handler, and centralised error handler

### DIFF
--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -11,7 +11,9 @@ const app = express();
 const port = Number(process.env.PORT) || 3001;
 
 app.set("trust proxy", 1);
-app.use(express.json());
+// Cap incoming JSON body size to 100 KB so a single oversized request
+// cannot exhaust server memory or cause a denial-of-service condition.
+app.use(express.json({ limit: "100kb" }));
 
 app.get("/health", (_req, res) => {
 	res.status(200).json({ ok: true });
@@ -34,6 +36,21 @@ if (mongoUri) {
 app.use("/api", authRoutes);
 app.use("/api", chatRoutes);
 app.use("/api/match", matchRoutes);
+
+// 404 handler for unmatched routes
+app.use((_req, res) => {
+  res.status(404).json({ error: "Route not found" });
+});
+
+// Centralised error handler. Avoids leaking stack traces to clients in
+// production while still surfacing a helpful message in development.
+// eslint-disable-next-line no-unused-vars
+app.use((err, _req, res, _next) => {
+  const status = err.status ?? 500;
+  const message =
+    process.env.NODE_ENV === "production" ? "Internal server error" : err.message;
+  res.status(status).json({ error: message });
+});
 
 app.listen(port, () => {
 	console.log(`Backend server listening on port ${port}`);


### PR DESCRIPTION
## Description

Closes #318

`src/backend/server.js` had no incoming request body size limit on `express.json()`. A request containing a very large JSON payload could exhaust server memory before any route handler ran, making the server unresponsive. There was also no 404 handler for unmatched routes (callers received an empty response) and no centralised error handler (unhandled errors could leak stack traces to clients in production).

**Changes:**
1. Added `{ limit: '100kb' }` to `express.json()` to cap incoming body size.
2. Added a 404 handler that returns `{ error: 'Route not found' }`.
3. Added a four-argument error handler that returns a generic message in production and the actual error message in development environments.

## Related Issue

Closes #318

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/backend/server.js`: added `{ limit: '100kb' }` to `express.json()`, added a 404 catch-all handler, and added a centralised error-handling middleware.

## Screenshots / Demo

Not applicable. This is a server configuration fix.

## Testing Done

1. Start the server with `node src/backend/server.js`.
2. Send a `POST` request to `/api/chat` with a JSON body larger than 100 KB. Confirm `413 Payload Too Large` is returned.
3. Send a `GET` request to `/api/nonexistent`. Confirm `404 { error: 'Route not found' }`.
4. Trigger a route error (e.g. by throwing in a middleware). Confirm the error handler returns `500 { error: ... }` without a stack trace.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc