### PR TITLE
fix(chat): validate temperature parameter before forwarding to OpenRouter

### DIFF
--- a/src/backend/routers/chatRoutes.js
+++ b/src/backend/routers/chatRoutes.js
@@ -96,11 +96,22 @@ router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
       ? [{ role: "system", content: String(systemPrompt) }, ...messages]
       : messages;
 
+    // Validate temperature before forwarding. OpenRouter accepts values in
+    // [0, 2]. Values outside this range are rejected by the upstream API with
+    // a 422 error that surfaces as an opaque 500 to the client. Clamp the
+    // value server-side so the response is always a predictable 400.
+    const tempNum = typeof temperature === "number" ? temperature : parseFloat(temperature);
+    if (Number.isNaN(tempNum) || tempNum < 0 || tempNum > 2) {
+      return res
+        .status(400)
+        .json({ error: "temperature must be a number between 0 and 2 inclusive." });
+    }
+
     const response = await openrouter.chat.completions.create({
       model,
       messages: chatMessages,
       max_tokens: safeMaxTokens,
-      temperature,
+      temperature: tempNum,
     });
 
     res.json({ reply: response.choices[0].message.content });


### PR DESCRIPTION
## Description

Closes #320

`chatRoutes.js` destructured `temperature` from `req.body` with a default of `0.7` but forwarded it to OpenRouter without any bounds check. OpenRouter accepts temperature values in `[0, 2]`. Values outside this range are rejected by the upstream API with a `422 Unprocessable Entity` response, which surfaced as a generic `500 Internal Server Error` to the client, making the actual problem invisible to callers.

**Root cause:** no validation of the `temperature` value before forwarding to the external API.

**Fix:** Added an explicit validation step that coerces the value to a number (guarding against string-typed input), then rejects with `400 Bad Request` and a clear message if the result is `NaN` or outside `[0, 2]`.

## Related Issue

Closes #320

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/backend/routers/chatRoutes.js`: added temperature validation block (NaN check + range check `[0, 2]`) before the `openrouter.chat.completions.create()` call.

## Screenshots / Demo

Not applicable. This is a server-side validation fix.

## Testing Done

1. Send `POST /api/chat` with `{"temperature": 3, ...}`. Confirm `400 temperature must be a number between 0 and 2 inclusive.`
2. Send with `{"temperature": -0.1, ...}`. Confirm `400`.
3. Send with `{"temperature": "abc", ...}`. Confirm `400`.
4. Send with `{"temperature": 0.7, ...}`. Confirm normal AI response.
5. Send with `{"temperature": 0, ...}` and `{"temperature": 2, ...}`. Confirm both succeed (boundary values are valid).

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc