### PR TITLE
fix(chat): cap messages array length and individual content size to prevent unbounded token consumption

### DIFF
--- a/src/backend/routers/chatRoutes.js
+++ b/src/backend/routers/chatRoutes.js
@@ -66,19 +66,34 @@ router.post("/chat", requireAuth, rateLimiter, async (req, res) => {
       return res.status(400).json({ error: "A non-empty messages array is required." });
     }
 
-    // Validate each message has the expected shape to avoid sending malformed
-    // requests upstream.
+    // Cap the number of messages in the conversation history. Without this
+    // limit a caller can send an unbounded history and consume a large number
+    // of input tokens per request.
+    const MAX_MESSAGES = 50;
+    if (messages.length > MAX_MESSAGES) {
+      return res.status(400).json({
+        error: `messages array must not exceed ${MAX_MESSAGES} entries.`,
+      });
+    }
+
+    // Validate each message has the expected shape and enforce an individual
+    // content length limit. Without a length cap a single message with very
+    // long text can exhaust the upstream token quota.
+    const MAX_CONTENT_LENGTH = 4000;
     const isValid = messages.every(
       (m) =>
         typeof m === "object" &&
         (m.role === "user" || m.role === "assistant" || m.role === "system") &&
-        typeof m.content === "string"
+        typeof m.content === "string" &&
+        m.content.length <= MAX_CONTENT_LENGTH
     );
 
     if (!isValid) {
       return res
         .status(400)
-        .json({ error: "Each message must have a role (user|assistant|system) and a string content field." });
+        .json({
+          error: `Each message must have a role (user|assistant|system) and a string content field of at most ${MAX_CONTENT_LENGTH} characters.`,
+        });
     }
 
     // Reject unknown models to prevent cost escalation.


### PR DESCRIPTION
## Description

Closes #316

`chatRoutes.js` validated that `messages` was a non-empty array with correctly shaped entries but placed no bound on:

1. The number of messages in the array (`messages.length`).
2. The length of individual `message.content` strings.

A caller could send a 1000-message conversation history or a single message containing 50 000 characters. Both scenarios cause OpenRouter to process a very large number of input tokens and inflate billing on every request.

**Root cause:** missing length validation after the structural check.

**Fix:** Added two constants and two corresponding validation steps:
- `MAX_MESSAGES = 50`: rejects with `400` if the array exceeds 50 entries.
- `MAX_CONTENT_LENGTH = 4000`: integrated into the existing per-message `isValid` check so a message with overlong content is rejected with the same clear `400` response.

## Related Issue

Closes #316

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/backend/routers/chatRoutes.js`:
  - Added `MAX_MESSAGES = 50` constant and a length check after the empty-array guard.
  - Added `MAX_CONTENT_LENGTH = 4000` constant and extended the per-message validation to include `m.content.length <= MAX_CONTENT_LENGTH`.

## Screenshots / Demo

Not applicable. This is a server-side validation fix.

## Testing Done

1. Send `POST /api/chat` with a `messages` array of 51 entries. Confirm `400 messages array must not exceed 50 entries.`
2. Send with a single message whose `content` is 4001 characters. Confirm `400`.
3. Send with 50 messages each with 4000-character content. Confirm the request is accepted.
4. Send a normal short message. Confirm normal AI response.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc