### PR TITLE
fix(FloatingAI): include Authorization header on POST /api/chat requests

### DIFF
--- a/src/components/FloatingAI.tsx
+++ b/src/components/FloatingAI.tsx
@@ -42,10 +42,16 @@ const FloatingAI = () => {
 
     try {
       // Route the request through the backend so the API key stays server-side.
+      // The /api/chat endpoint is protected by requireAuth middleware.
+      // Without a Bearer token every request is rejected with 401 Unauthorized.
+      // Retrieve the session token from localStorage using the same pattern
+      // used by SuggestedPartners.tsx and other components in this project.
+      const token = localStorage.getItem("token");
       const response = await fetch("/api/chat", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
           messages: [{ role: "user", content: prompt }],


### PR DESCRIPTION
## Description

Closes #317

`FloatingAI.tsx` called `POST /api/chat` with only a `Content-Type` header. The route is protected by `requireAuth` middleware which immediately returns `401 Unauthorized` when no valid `Bearer` token is present. This meant every AI request from the floating widget silently failed with a 401 before reaching OpenRouter, and the UI displayed the error message from the JSON response instead of an AI reply.

**Root cause:** the `Authorization` header was missing from the `fetch` call.

**Fix:** Retrieve the session token from `localStorage.getItem("token")` using the same pattern already used by `SuggestedPartners.tsx` and other components in the project that call protected endpoints, then include it as `Authorization: Bearer <token>` in the fetch headers.

## Related Issue

Closes #317

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/components/FloatingAI.tsx`: added `Authorization: Bearer <token>` to the `fetch` headers in `sendMessage()`, reading the token from `localStorage.getItem("token")`. The header is conditionally spread so it is omitted when no token is present (graceful degradation).

## Screenshots / Demo

Not applicable. The fix restores normal AI responses in the floating widget, which was previously showing a 401 error message.

## Testing Done

1. Sign in to the app so a valid token is present in `localStorage`.
2. Open the floating AI widget and send a message.
3. Confirm an AI response is returned (not a 401 error).
4. Sign out (token removed from localStorage).
5. Open the widget and send a message.
6. Confirm a 401 or auth-required message is shown (expected behavior for unauthenticated users).

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc