### PR TITLE
fix(sendEmail): add recipient email and URL validation before sending

### DIFF
--- a/src/backend/utils/sendEmail.js
+++ b/src/backend/utils/sendEmail.js
@@ -1,6 +1,31 @@
 import nodemailer from "nodemailer";
 
+// Basic email format check — catches the most common malformed inputs
+// before a network call is made.
+const isValidEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value));
+
+// Ensure the reset URL uses a safe scheme before embedding it in an email.
+// A javascript: or data: URL would execute in some email clients.
+const isSafeUrl = (value) => {
+  try {
+    const parsed = new URL(String(value));
+    return parsed.protocol === "https:" || parsed.protocol === "http:";
+  } catch {
+    return false;
+  }
+};
+
 export const sendEmail = async (email, url) => {
+  if (!isValidEmail(email)) {
+    throw new Error("sendEmail: the recipient email address is not valid.");
+  }
+
+  if (!isSafeUrl(url)) {
+    throw new Error(
+      "sendEmail: the reset URL must be a valid http or https URL."
+    );
+  }
+
   const emailUser = process.env.EMAIL_USER;
   const emailPass = process.env.EMAIL_PASS;
 
@@ -19,10 +44,14 @@ export const sendEmail = async (email, url) => {
   });
 
   await transporter.sendMail({
-    from: emailUser,
+    from: `"Peer Learning" <${emailUser}>`,
     to: email,
     subject: "Password Reset",
-    html: `<p>Click below to reset password:</p>
-           <a href="${url}">${url}</a>`,
+    html: `
+      <p>You requested a password reset for your Peer Learning account.</p>
+      <p>Click the link below to reset your password. This link is single-use.</p>
+      <p><a href="${url}" style="color:#4f9cf9;">Reset my password</a></p>
+      <p>If you did not request a password reset, you can safely ignore this email.</p>
+    `,
   });
 };


### PR DESCRIPTION
## Description

Closes #319

`sendEmail()` in `src/backend/utils/sendEmail.js` received its `email` and `url` arguments without any validation before forwarding them to nodemailer. A malformed recipient address would be forwarded directly to the SMTP server, which may deliver to the wrong address or throw a cryptic internal error. A non-HTTP URL (e.g. `javascript:` or `data:`) embedded in the reset link could execute in some email clients.

**Improvements:**
1. Added `isValidEmail(value)` to reject obviously malformed email addresses before any network call is made.
2. Added `isSafeUrl(value)` to ensure the reset URL uses `http:` or `https:` only.
3. Improved the email template with a contextual explanation and a safety note for users who did not request a reset.
4. Added a display name to the `from` field (`"Peer Learning" <email>`).

## Related Issue

Closes #319

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `src/backend/utils/sendEmail.js`: added `isValidEmail` and `isSafeUrl` helpers; added validation at the top of the function before environment variable checks; improved the email HTML template; added display name to the `from` field.

## Screenshots / Demo

Not applicable. This is a server-side utility fix.

## Testing Done

1. Call `sendEmail("not-an-email", "https://example.com")`. Confirm it throws `"sendEmail: the recipient email address is not valid."` before making a network call.
2. Call `sendEmail("user@example.com", "javascript:alert(1)")`. Confirm it throws `"sendEmail: the reset URL must be a valid http or https URL."`.
3. Call with valid inputs. Confirm the email is sent with the improved template.

## Checklist

- [x] I have read the CONTRIBUTING.md and followed its guidelines
- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc