### PR TITLE
Fixes #368: IDOR / Connection Spoofing in peer_connections

### DIFF
--- a/supabase/migrations/20260531000000_fix_peer_connections_idor.sql
+++ b/supabase/migrations/20260531000000_fix_peer_connections_idor.sql
@@ -1,0 +1,12 @@
+-- Fix IDOR / Connection Spoofing in peer_connections
+-- Prevent authenticated and anonymous users from updating sender_id and receiver_id
+REVOKE UPDATE ON public.peer_connections FROM authenticated, anon;
+GRANT UPDATE (status, updated_at) ON public.peer_connections TO authenticated, anon;
+
+-- Restrict the update policy so only the receiver can accept/reject the connection
+DROP POLICY IF EXISTS "Users can update own connections" ON public.peer_connections;
+CREATE POLICY "Users can update own connections"
+ON public.peer_connections
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = receiver_id);


### PR DESCRIPTION
This PR fixes issue #368 by restricting the UPDATE policy on the peer_connections table so that only the receiver can update it. Furthermore, it explicitly revokes UPDATE privileges on the sender_id and receiver_id columns so that they cannot be forged.