### PR TITLE
Fixes #373: Arbitrary Data Insertion in skills_taxonomy

### DIFF
--- a/supabase/migrations/20260531000003_fix_skills_taxonomy.sql
+++ b/supabase/migrations/20260531000003_fix_skills_taxonomy.sql
@@ -1,0 +1,16 @@
+-- Fix Arbitrary Data Insertion in skills_taxonomy by adding backend format validation
+
+-- Remove any existing invalid data to allow the constraint to be applied
+DELETE FROM public.skills_taxonomy
+WHERE length(name) > 50 
+   OR length(name) < 1 
+   OR name !~ '^[a-zA-Z0-9][a-zA-Z0-9\s\.\-\+\#\/]*$';
+
+-- Add check constraint for format validation
+ALTER TABLE public.skills_taxonomy
+ADD CONSTRAINT skills_taxonomy_name_check
+CHECK (
+  length(name) >= 1 AND 
+  length(name) <= 50 AND
+  name ~ '^[a-zA-Z0-9][a-zA-Z0-9\s\.\-\+\#\/]*$'
+);


### PR DESCRIPTION
This PR fixes issue #373 by adding backend format validation to the \skills_taxonomy\ table. A \CHECK\ constraint has been introduced to limit the maximum length of a skill name to 50 characters, and requires that the skill name contains only valid characters (alphanumeric, spaces, and specific symbols like ., -, +, #, /). Any existing data that violates these rules is removed before the constraint is applied. This prevents arbitrary, unbounded, or offensive data from being inserted by authenticated users.