### PR TITLE
Fix: Denial of Service via system_config (Missing RLS) (#400)

### DIFF
--- a/.gssoc/issue-400-summary.md
+++ b/.gssoc/issue-400-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #400
+
+## Issue: Denial of Service via system_config (Missing RLS)
+
+## Approach
+Enable Row-Level Security on the `public.system_config` table to prevent any unauthorized modification (inserts/updates/deletes) by authenticated or anonymous clients.
+
+## Changes to Make
+1. Created a new migration file `20260531000006_secure_system_config.sql`.
+2. Added `ALTER TABLE public.system_config ENABLE ROW LEVEL SECURITY;`.
+3. Added comments explaining why no policies are needed (default deny blocks all client access, while postgres bypasses RLS for background jobs).
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260531000006_secure_system_config.sql
+++ b/supabase/migrations/20260531000006_secure_system_config.sql
@@ -1,0 +1,7 @@
+-- Enable Row-Level Security on the system_config table
+ALTER TABLE public.system_config ENABLE ROW LEVEL SECURITY;
+
+-- No policies are added because we want to completely deny all client access 
+-- (both authenticated and anonymous) to this internal configuration table.
+-- The postgres/service_role users bypass RLS automatically and will still be able
+-- to access and modify this table (e.g. for the tick_session_statuses job).


### PR DESCRIPTION
### Description
Fixed a Denial of Service vulnerability (Missing RLS) on the `system_config` table. Enabled Row-Level Security on `public.system_config` to prevent any unauthorized modification (inserts/updates/deletes) by authenticated or anonymous clients.

### Fixes
Fixes #400

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature
- [ ] Documentation Update

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
