### PR TITLE
Fix: XP Forgery via Infinite RPC Calls (#402)

### DIFF
--- a/.gssoc/issue-402-summary.md
+++ b/.gssoc/issue-402-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #402
+
+## Issue: XP Forgery via Infinite RPC Calls (Missing Rate Limiting)
+
+## Approach
+Introduced rate limiting inside the `award_activity_xp` RPC to prevent users from spamming the function infinitely to farm XP.
+
+## Changes Made
+1. Created migration `20260531000008_fix_award_activity_xp_rate_limit.sql`.
+2. Created a new table `public.user_activity_log` to track daily activities by user.
+3. Updated `award_activity_xp` to check `user_activity_log` and enforce daily limits (e.g. 1 daily login, 3 session joins, 5 mentor helps) before awarding XP.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260531000008_fix_award_activity_xp_rate_limit.sql
+++ b/supabase/migrations/20260531000008_fix_award_activity_xp_rate_limit.sql
@@ -1,0 +1,54 @@
+-- Create a table to track user activities for rate limiting
+CREATE TABLE IF NOT EXISTS public.user_activity_log (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE,
+    activity_type TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Enable RLS
+ALTER TABLE public.user_activity_log ENABLE ROW LEVEL SECURITY;
+
+-- No policies needed because this is only accessed by SECURITY DEFINER RPCs
+
+CREATE OR REPLACE FUNCTION public.award_activity_xp(_activity_type TEXT) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$
+DECLARE
+  v_uid UUID := auth.uid();
+  v_xp_to_award INT;
+  v_activity_count INT;
+BEGIN
+  IF v_uid IS NULL THEN RETURN; END IF;
+
+  -- Enforce rate limits per day to prevent XP forgery/manipulation
+  SELECT count(*) INTO v_activity_count
+  FROM public.user_activity_log
+  WHERE user_id = v_uid 
+    AND activity_type = _activity_type 
+    AND created_at >= date_trunc('day', now());
+
+  IF _activity_type = 'daily_login' AND v_activity_count >= 1 THEN
+    RETURN;
+  ELSIF _activity_type = 'session_join' AND v_activity_count >= 3 THEN
+    RETURN;
+  ELSIF _activity_type = 'mentor_help' AND v_activity_count >= 5 THEN
+    RETURN;
+  ELSIF v_activity_count >= 10 THEN
+    -- Fallback limit for any other activity
+    RETURN;
+  END IF;
+
+  CASE _activity_type
+    WHEN 'session_join' THEN v_xp_to_award := 50;
+    WHEN 'mentor_help' THEN v_xp_to_award := 100;
+    WHEN 'daily_login' THEN v_xp_to_award := 20;
+    ELSE v_xp_to_award := 10;
+  END CASE;
+
+  -- Log the activity
+  INSERT INTO public.user_activity_log (user_id, activity_type) VALUES (v_uid, _activity_type);
+
+  -- Call the existing internal function to update the ledger safely
+  PERFORM public.increment_user_xp(v_xp_to_award);
+END;
+$$;


### PR DESCRIPTION
### Description
Fixed XP forgery vulnerability where users could infinitely call `award_activity_xp` to gain XP and manipulate the leaderboard. Introduced `user_activity_log` to track XP awards and added daily rate limits for each activity type.

### Fixes
Fixes #402

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
