### PR TITLE
Fix: Race Condition in Streak Restoration (TOCTOU) (#403)

### DIFF
--- a/.gssoc/issue-403-summary.md
+++ b/.gssoc/issue-403-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #403
+
+## Issue: Race Condition in Streak Restoration (TOCTOU)
+
+## Approach
+Used row-level locking (`FOR UPDATE`) on the `profiles` table to prevent race conditions when checking and deducting points during streak restoration.
+
+## Changes Made
+1. Created migration `20260531000009_fix_restore_streak_race_condition.sql`.
+2. Updated the `restore_user_streak` RPC to lock the profile row (`FOR UPDATE`) in the initial SELECT statement.
+3. This ensures that concurrent requests will wait and read the properly decremented points balance, fully mitigating the TOCTOU vulnerability.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260531000009_fix_restore_streak_race_condition.sql
+++ b/supabase/migrations/20260531000009_fix_restore_streak_race_condition.sql
@@ -1,0 +1,62 @@
+-- Fix Race Condition (TOCTOU) in restore_user_streak by adding FOR UPDATE lock
+
+CREATE OR REPLACE FUNCTION public.restore_user_streak()
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid := auth.uid();
+  v_current_streak integer;
+  v_previous_streak integer;
+  v_points integer;
+  v_restoration_used boolean;
+  v_restoration_date date;
+  v_new_streak integer;
+  v_today date := current_date;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RETURN json_build_object('success', false, 'message', 'Not authenticated');
+  END IF;
+
+  -- Use FOR UPDATE to lock the row and prevent concurrent requests from bypassing the points cost
+  SELECT streak, previous_streak, points, restoration_used_today, restoration_date
+  INTO v_current_streak, v_previous_streak, v_points, v_restoration_used, v_restoration_date
+  FROM public.profiles
+  WHERE id = v_user_id
+  FOR UPDATE;
+
+  -- Check if already restored today
+  IF v_restoration_used AND v_restoration_date = v_today THEN
+    RETURN json_build_object('success', false, 'message', 'Streak already restored today');
+  END IF;
+
+  -- Check if previous streak is actually higher
+  IF v_previous_streak <= v_current_streak THEN
+    RETURN json_build_object('success', false, 'message', 'No higher previous streak to restore');
+  END IF;
+
+  -- Check points (costs 100 XP)
+  IF COALESCE(v_points, 0) < 100 THEN
+    RETURN json_build_object('success', false, 'message', 'Not enough XP (100 required)');
+  END IF;
+
+  -- Perform restoration
+  v_new_streak := v_previous_streak + 1; -- Restore the old streak + today's login
+
+  UPDATE public.profiles
+  SET 
+    streak = v_new_streak,
+    previous_streak = 0, -- Consume the previous streak
+    points = points - 100,
+    restoration_used_today = true,
+    restoration_date = v_today
+  WHERE id = v_user_id;
+
+  RETURN json_build_object(
+    'success', true, 
+    'message', 'Streak successfully restored!', 
+    'newStreak', v_new_streak
+  );
+END;
+$$;


### PR DESCRIPTION
### Description
Fixed a Race Condition (TOCTOU) vulnerability in the streak restoration feature. Added row-level locking (`FOR UPDATE`) to the `restore_user_streak` RPC to ensure point deductions are atomic and cannot be bypassed via concurrent requests.

### Fixes
Fixes #403

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
