### PR TITLE
Fix: IDOR Force-Accepting Peer Connections (#404)

### DIFF
--- a/.gssoc/issue-404-summary.md
+++ b/.gssoc/issue-404-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #404
+
+## Issue: IDOR: Force-Accepting Peer Connections
+
+## Approach
+Updated the INSERT Row-Level Security (RLS) policy on the `peer_connections` table to strictly enforce that the initial `status` of any new connection request must be `'pending'`.
+
+## Changes Made
+1. Created migration `20260531000010_fix_peer_connections_insert_status.sql`.
+2. Modified the "Users can insert own connection requests" policy. 
+3. Appended `AND status = 'pending'` to the `WITH CHECK` clause to prevent malicious users from forcibly establishing connections by injecting `status = 'accepted'` during creation.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260531000010_fix_peer_connections_insert_status.sql
+++ b/supabase/migrations/20260531000010_fix_peer_connections_insert_status.sql
@@ -1,0 +1,9 @@
+-- Fix IDOR: Force-Accepting Peer Connections on Insert
+-- Ensure users can only create peer connections with a 'pending' status
+
+DROP POLICY IF EXISTS "Users can insert own connection requests" ON public.peer_connections;
+CREATE POLICY "Users can insert own connection requests"
+ON public.peer_connections
+FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = sender_id AND status = 'pending');


### PR DESCRIPTION
### Description
Fixed an IDOR vulnerability where malicious users could force-accept peer connection requests upon creation. The INSERT RLS policy on the `peer_connections` table now restricts the `status` column to `'pending'`, preventing users from bypassing the receiver's consent.

### Fixes
Fixes #404

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
