### PR TITLE
Fix: Broken Access Control on whiteboard_states (#405)

### DIFF
--- a/.gssoc/issue-405-summary.md
+++ b/.gssoc/issue-405-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #405
+
+## Issue: Broken Access Control on whiteboard_states
+
+## Approach
+Replaced the loosely defined Row-Level Security (RLS) policies on the `whiteboard_states` table with strict policies enforcing study room membership and privacy settings.
+
+## Changes Made
+1. Created migration `20260601000001_fix_whiteboard_states_access.sql`.
+2. Dropped the old RLS policies that only validated `auth.uid() IS NOT NULL`.
+3. Created new `SELECT`, `INSERT`, and `UPDATE` policies that verify whether the `room_id` corresponds to a public room, a room created by the user, or a room where the user is an active participant in `study_room_participants`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000001_fix_whiteboard_states_access.sql
+++ b/supabase/migrations/20260601000001_fix_whiteboard_states_access.sql
@@ -1,0 +1,61 @@
+-- Fix broken access control on whiteboard_states (Issue #405)
+DROP POLICY IF EXISTS "Users can view whiteboard states" ON public.whiteboard_states;
+DROP POLICY IF EXISTS "Users can insert whiteboard states" ON public.whiteboard_states;
+DROP POLICY IF EXISTS "Users can update whiteboard states" ON public.whiteboard_states;
+
+CREATE POLICY "Users can view whiteboard states"
+ON public.whiteboard_states
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.study_rooms 
+    WHERE id = room_id 
+    AND (
+      not is_private 
+      OR created_by = auth.uid() 
+      OR EXISTS (
+        SELECT 1 FROM public.study_room_participants 
+        WHERE room_id = study_rooms.id AND profile_id = auth.uid()
+      )
+    )
+  )
+);
+
+CREATE POLICY "Users can insert whiteboard states"
+ON public.whiteboard_states
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.study_rooms 
+    WHERE id = room_id 
+    AND (
+      not is_private 
+      OR created_by = auth.uid() 
+      OR EXISTS (
+        SELECT 1 FROM public.study_room_participants 
+        WHERE room_id = study_rooms.id AND profile_id = auth.uid()
+      )
+    )
+  )
+);
+
+CREATE POLICY "Users can update whiteboard states"
+ON public.whiteboard_states
+FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.study_rooms 
+    WHERE id = room_id 
+    AND (
+      not is_private 
+      OR created_by = auth.uid() 
+      OR EXISTS (
+        SELECT 1 FROM public.study_room_participants 
+        WHERE room_id = study_rooms.id AND profile_id = auth.uid()
+      )
+    )
+  )
+);


### PR DESCRIPTION
### Description
Fixed a broken access control vulnerability where any authenticated user could view, modify, or insert whiteboard canvas states for any study room (including private rooms). The new policies enforce `study_rooms` privacy settings and participant access.

### Fixes
Fixes #405

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
