### PR TITLE
Fix: Broken Access Control on whiteboard_events (#406)

### DIFF
--- a/.gssoc/issue-406-summary.md
+++ b/.gssoc/issue-406-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #406
+
+## Issue: Broken Access Control on whiteboard_events
+
+## Approach
+Implemented strict Row-Level Security (RLS) policies on the `whiteboard_events` table to ensure that whiteboard drawing events are confined to valid study room participants.
+
+## Changes Made
+1. Created migration `20260601000002_fix_whiteboard_events_access.sql`.
+2. Replaced the simplistic `auth.uid() IS NOT NULL` checks with complex policies.
+3. Users can only `SELECT` and `INSERT` drawing events for a `room_id` if the room is public, they are the creator, or they belong to the `study_room_participants` table for that room.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000002_fix_whiteboard_events_access.sql
+++ b/supabase/migrations/20260601000002_fix_whiteboard_events_access.sql
@@ -1,0 +1,41 @@
+-- Fix broken access control on whiteboard_events (Issue #406)
+DROP POLICY IF EXISTS "read whiteboard events" ON public.whiteboard_events;
+DROP POLICY IF EXISTS "insert whiteboard events" ON public.whiteboard_events;
+
+CREATE POLICY "read whiteboard events"
+ON public.whiteboard_events
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM public.study_rooms 
+    WHERE id = room_id 
+    AND (
+      not is_private 
+      OR created_by = auth.uid() 
+      OR EXISTS (
+        SELECT 1 FROM public.study_room_participants 
+        WHERE room_id = study_rooms.id AND profile_id = auth.uid()
+      )
+    )
+  )
+);
+
+CREATE POLICY "insert whiteboard events"
+ON public.whiteboard_events
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.study_rooms 
+    WHERE id = room_id 
+    AND (
+      not is_private 
+      OR created_by = auth.uid() 
+      OR EXISTS (
+        SELECT 1 FROM public.study_room_participants 
+        WHERE room_id = study_rooms.id AND profile_id = auth.uid()
+      )
+    )
+  )
+);


### PR DESCRIPTION
### Description
Fixed a broken access control vulnerability that allowed any authenticated user to intercept, read, or inject whiteboard drawing events for any study room. Applied restrictive RLS policies aligning with study room privacy settings.

### Fixes
Fixes #406

### Type of change
- [x] Security Fix
- [ ] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
