### PR TITLE
Fix: Study Room Participant Retention Lock (#407)

### DIFF
--- a/.gssoc/issue-407-summary.md
+++ b/.gssoc/issue-407-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #407
+
+## Issue: Study Room Participant Retention Lock (Missing DELETE Policy)
+
+## Approach
+Created a DELETE Row-Level Security (RLS) policy for the `study_room_participants` table to allow participants to leave, and creators to remove participants.
+
+## Changes Made
+1. Created migration `20260601000003_fix_study_room_participant_delete.sql`.
+2. Created a new `DELETE` policy that allows deleting a participant row if `profile_id = auth.uid()` (the user themselves) or if the authenticated user is the `created_by` owner of the `study_room`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000003_fix_study_room_participant_delete.sql
+++ b/supabase/migrations/20260601000003_fix_study_room_participant_delete.sql
@@ -1,0 +1,11 @@
+-- Fix Issue 407: Study Room Participant Retention Lock (Missing DELETE Policy)
+
+CREATE POLICY "study_room_participants_delete" ON public.study_room_participants
+  FOR DELETE TO authenticated
+  USING (
+    profile_id = auth.uid()
+    OR EXISTS (
+      SELECT 1 FROM public.study_rooms
+      WHERE id = room_id AND created_by = auth.uid()
+    )
+  );


### PR DESCRIPTION
### Description
Fixed a bug where study room participants were permanently locked in a room due to a missing DELETE policy. Added a DELETE policy to `study_room_participants` allowing users to leave rooms and allowing room creators to kick participants out.

### Fixes
Fixes #407

### Type of change
- [x] Bug Fix
- [ ] Security Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
