### PR TITLE
Fix: Public Study Rooms Unjoinable via API (#408)

### DIFF
--- a/.gssoc/issue-408-summary.md
+++ b/.gssoc/issue-408-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #408
+
+## Issue: Public Study Rooms Unjoinable via API
+
+## Approach
+Added an INSERT Row-Level Security (RLS) policy to the `study_room_participants` table so users can voluntarily join public study rooms.
+
+## Changes Made
+1. Created migration `20260601000004_fix_study_room_participant_insert.sql`.
+2. Added an `INSERT` policy ensuring the user is inserting their own `profile_id` into a `room_id` that belongs to a public study room (`not is_private`).
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000004_fix_study_room_participant_insert.sql
+++ b/supabase/migrations/20260601000004_fix_study_room_participant_insert.sql
@@ -1,0 +1,11 @@
+-- Fix Issue 408: Public Study Rooms Unjoinable via API
+
+CREATE POLICY "study_room_participants_insert" ON public.study_room_participants
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    profile_id = auth.uid()
+    AND EXISTS (
+      SELECT 1 FROM public.study_rooms
+      WHERE id = room_id AND not is_private
+    )
+  );


### PR DESCRIPTION
### Description
Fixed an issue where public study rooms were unjoinable through the API due to a missing INSERT policy on `study_room_participants`. Added a policy allowing authenticated users to insert themselves into public rooms.

### Fixes
Fixes #408

### Type of change
- [x] Bug Fix
- [ ] Security Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
