### PR TITLE
Fix: Missing Admin and Update Policies on mentors Table (#409)

### DIFF
--- a/.gssoc/issue-409-summary.md
+++ b/.gssoc/issue-409-summary.md
@@ -1,0 +1,13 @@
+# Fix Plan for Issue #409
+
+## Issue: Missing Admin and Update Policies on mentors Table
+
+## Approach
+Introduced necessary UPDATE policies for regular users, and comprehensive SELECT/UPDATE policies for administrators using the `has_role('admin')` function.
+
+## Changes Made
+1. Created migration `20260601000005_fix_mentors_admin_update.sql`.
+2. Added "Users can update own mentor applications" policy for regular users.
+3. Added "Admins can view all mentor applications" and "Admins can update all mentor applications" policies utilizing the `public.has_role()` RPC to properly authorize administrators.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000005_fix_mentors_admin_update.sql
+++ b/supabase/migrations/20260601000005_fix_mentors_admin_update.sql
@@ -1,0 +1,20 @@
+-- Fix Issue 409: Missing Admin and Update Policies on mentors Table
+
+CREATE POLICY "Users can update own mentor applications"
+ON public.mentors
+FOR UPDATE
+TO authenticated
+USING (user_id = auth.uid())
+WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Admins can view all mentor applications"
+ON public.mentors
+FOR SELECT
+TO authenticated
+USING (public.has_role(auth.uid(), 'admin'));
+
+CREATE POLICY "Admins can update all mentor applications"
+ON public.mentors
+FOR UPDATE
+TO authenticated
+USING (public.has_role(auth.uid(), 'admin'));


### PR DESCRIPTION
### Description
Fixed access control omissions on the `mentors` table where users could not update their own applications and admins completely lacked access via the standard API. Added user update policies and administrator select/update policies.

### Fixes
Fixes #409

### Type of change
- [x] Security Fix
- [x] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
