### PR TITLE
fix: add .env.example file and update README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,8 +285,15 @@ npm install
 
 ## 4️⃣ Configure Environment Variables
 
-Create a `.env` file in the root directory and add:
+A `.env.example` file is provided in the root of the repository with all required variable names and placeholder values. Copy it to `.env` before running the project:
 
+```bash
+cp .env.example .env
+```
+
+Then fill in your actual values in `.env`. You can get your Supabase credentials from [https://supabase.com/dashboard](https://supabase.com/dashboard).
+
+Create a `.env` file in the root directory and add:
 ```env
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_anon_key


### PR DESCRIPTION
Closes #363

## Problem
The project required environment variables to run but had no .env.example file. New contributors had no way to know what variables were needed without reading deep into the codebase, increasing onboarding friction significantly.

## Changes Made
- Created `.env.example` file in the root directory with all required environment variables and placeholder values:
  - `VITE_SUPABASE_URL`
  - `VITE_SUPABASE_ANON_KEY`
  - `VITE_SUPABASE_PUBLISHABLE_KEY`
  - `OPENROUTER_API_KEY`
  - `SITE_URL`
  - `VITE_VAPID_PUBLIC_KEY`
  - `EMAIL_USER`
  - `EMAIL_PASS`
- Updated `README.md` "Configure Environment Variables" section to mention the `.env.example` file and added `cp .env.example .env` command with link to Supabase dashboard

## Files Changed
- `.env.example` (new file)
- `README.md`

## Testing
- Fresh clone → copy `.env.example` to `.env` → fill in values → app runs successfully ✅
- No real credentials committed ✅