### PR TITLE
fix: Remove redundant auth calls and duplicate Supabase filters in Chatbot.jsx

### DIFF
--- a/src/components/Chatbot.jsx
+++ b/src/components/Chatbot.jsx
@@ -23,22 +23,13 @@ export default function Chatbot() {
   // Load only the current user's chat messages
   useEffect(() => {
     const loadChats = async () => {
-
-      const { data: { user } } = await supabase.auth.getUser();
-      if (!user) return;
-
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.user) return;
-
 
       const { data } = await supabase
         .from("chat_messages")
         .select("*")
-
-        .eq("user_id", user.id)
-
         .eq("user_id", session.user.id)
-
         .order("created_at", { ascending: true });
 
       if (data) setMessages(data);
@@ -49,10 +40,6 @@ export default function Chatbot() {
   // SEND MESSAGE
   const sendMessage = async () => {
     if (!input.trim()) return;
-
-
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
 
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.user) return;
@@ -77,32 +64,17 @@ export default function Chatbot() {
         content: msg.text,
       }));
       const res = await fetch(`${API_BASE_URL}/api/ai/ask`, {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/json",
-    Authorization: `Bearer ${session.access_token}`, // still pass session for user auth
-  },
-  body: JSON.stringify({
-    messages: formattedMessages,
-    systemPrompt: systemPrompt.content,
-    model: "openai/gpt-4", 
-  }),
-});
-
-      // Route the request through the backend so the API key stays server-side.
-      // Include the session token so the backend can authenticate the request.
-      // const res = await fetch("/api/chat", {
-      //   method: "POST",
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //     Authorization: `Bearer ${session.access_token}`,
-      //   },
-      //   body: JSON.stringify({
-      //     messages: formattedMessages,
-      //     systemPrompt: systemPrompt.content,
-      //     model: "openai/gpt-3.5-turbo",
-      //   }),
-      // });
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${session.access_token}`,
+        },
+        body: JSON.stringify({
+          messages: formattedMessages,
+          systemPrompt: systemPrompt.content,
+          model: "openai/gpt-4",
+        }),
+      });
 
       const data = await res.json();
 


### PR DESCRIPTION
## Summary

Cleans up merge artifacts in `Chatbot.jsx` that caused redundant network requests and dead code.

## Resolved Issue
Resolves #420 

## Problem

The `Chatbot.jsx` component had leftover code from a previous merge where two branches' auth approaches were concatenated instead of resolved:

1. **Dual auth calls** — Both `supabase.auth.getUser()` and `supabase.auth.getSession()` were called back-to-back in `loadChats` and `sendMessage`. Only one is needed since `getSession()` provides both `session.user` (for the user ID) and `session.access_token` (for the Authorization header).

2. **Duplicate `.eq()` filter** — The `loadChats` query chained `.eq("user_id", user.id)` and `.eq("user_id", session.user.id)` on the same column. Both resolve to the same value, making one completely redundant.

3. **Commented-out dead code** — A 14-line commented-out alternative `fetch()` call to `/api/chat` was left in the `sendMessage` function.

4. **Broken indentation** — The `fetch()` call body was flush-left instead of properly indented inside the `try` block (artifact of the merge).

## Changes Made

- Replaced dual `getUser()` + `getSession()` calls with a single `getSession()` call in both `loadChats` and `sendMessage`
- Removed the duplicate `.eq("user_id", ...)` filter in the chat messages query
- Deleted the commented-out alternative fetch block (lines 92–105)
- Fixed indentation of the `fetch()` call to match the surrounding code

## Impact

- **−2 unnecessary Supabase network requests** per chat load and per message send
- **−28 lines** of dead/redundant code (230 → 202 lines)
- No functional behavior change — the component works exactly the same way