### PR TITLE
security: Remove exposed Supabase credentials from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Supabase
-VITE_SUPABASE_URL="https://kdqslwlupdvpbmanyorh.supabase.co"
-VITE_SUPABASE_ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtkcXNsd2x1cGR2cGJtYW55b3JoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODAwMjMxMDQsImV4cCI6MjA5NTU5OTEwNH0.OAfVYRrI-ZtIooLZmK4D9iMyLI9AhAv6BEVRyBZxsb0"
-VITE_SUPABASE_PUBLISHABLE_KEY="sb_publishable_2eu9JzrGrsFS2dQcBv_WAw_IpArkWWM"
+VITE_SUPABASE_URL="https://your_supabase_project_url.supabase.co"
+VITE_SUPABASE_ANON_KEY="your_supabase_anon_key"
+VITE_SUPABASE_PUBLISHABLE_KEY="your_supabase_publishable_key"
 
 # OpenRouter AI (server-side only -- must NOT use the VITE_ prefix)
 # Variables prefixed with VITE_ are embedded in the client bundle and are


### PR DESCRIPTION
## Summary

Removes real, active Supabase project credentials from the `.env.example` file and replaces them with generic placeholder values to prevent accidental exposure of sensitive keys.

## Resolved Issue
Resolves #421 

## Problem

The `.env.example` file contained actual Supabase project URLs, Anon Keys, and Publishable Keys instead of template placeholders. Because this repository is public, these credentials were fully exposed to anyone viewing the source code, creating a significant security vulnerability where unauthorized users could potentially read or write data to the production database depending on the Row-Level Security (RLS) policies in place.

## Changes Made

- Replaced `VITE_SUPABASE_URL` with a placeholder `https://your_supabase_project_url.supabase.co`
- Replaced `VITE_SUPABASE_ANON_KEY` with a generic placeholder
- Replaced `VITE_SUPABASE_PUBLISHABLE_KEY` with a generic placeholder

## Impact

- Mitigates immediate ongoing exposure of active database credentials in the template environment file.
- Prevents future contributors from accidentally using or exposing the production keys when setting up their local environments.

---

> [!CAUTION]
> **CRITICAL SECURITY NOTE FOR REPO OWNER:**
> Merging this PR removes the keys from the *current* state of the code, but the old keys are **still visible in the Git history**. You **MUST** log in to the Supabase Dashboard and **rotate (regenerate) the Anon and Publishable keys immediately** to secure the database.