### PR TITLE
fix: Remove excessive Supabase network logging in frontend client

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -13,20 +13,5 @@ export const supabase = createClient<Database>(
       persistSession: true,
       autoRefreshToken: true,
     },
-    global: {
-      fetch: async (...args: Parameters<typeof fetch>) => {
-        console.log("SUPABASE REQUEST:", args[0]);
-
-        const response = await fetch(...args);
-
-        console.log(
-          "SUPABASE RESPONSE:",
-          response.status,
-          response.url
-        );
-
-        return response;
-      },
-    },
   }
 );


### PR DESCRIPTION
## Summary

Removes the global `fetch` override from the Supabase client initialization, stopping it from logging every single database request and response to the browser console.

## Resolved Issue
Resolves #425 

## Problem

The frontend Supabase client was configured with a custom `global: { fetch: ... }` interceptor that executed synchronous `console.log` statements for every incoming and outgoing network request. 

This created several issues in production:
1. **Console Noise:** Flooded the browser DevTools with massive amounts of noise, making it incredibly difficult for developers to spot actual errors or relevant application logs.
2. **Security/Privacy Risk:** Exposed all database API endpoint patterns, query parameters, and underlying database structural details to any user who opened the browser console.
3. **Performance Overhead:** Intercepting the global fetch implementation to perform synchronous I/O operations (logging) added unnecessary overhead to every database interaction.

## Changes Made

- Deleted the `global: { fetch: ... }` override block from the `createClient` configuration object in `src/integrations/supabase/client.ts`.
- Restored the Supabase client to rely entirely on the native, highly optimized browser `fetch` API without interference.

## Impact

- Database queries now execute silently.
- Significant reduction in browser console spam.
- Improved client-side performance and better obfuscation of internal API details.