### PR TITLE
docs: Update outdated API documentation in api.md

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,11 +38,11 @@ const sendMessage = async (sessionId: string, content: string, userId: string) =
 
 For operations requiring secure handling of external API keys (e.g., OpenAI/OpenRouter), requests are sent to our custom backend.
 
-### `POST /api/ai/generate-summary`
+### `POST /api/ai/summary`
 
 Generates an AI summary of a chat session.
 
-**Endpoint**: `http://localhost:3000/api/ai/generate-summary`  
+**Endpoint**: `http://localhost:5000/api/ai/summary`  
 **Headers**:
 - `Authorization`: `Bearer <Supabase JWT Token>`
 
@@ -65,4 +65,4 @@ Generates an AI summary of a chat session.
 
 **Security & Rate Limiting**:
 - Requires a valid Supabase JWT token.
-- Protected by `express-rate-limit` to prevent abuse.
+- Protected by a custom, in-house rate limiter middleware (`backend/middlewares/rateLimiter.js`) to prevent abuse.


### PR DESCRIPTION
## Summary

This PR updates `docs/api.md` to accurately reflect the active state of the backend API, removing outdated endpoint paths, incorrect ports, and inaccurate dependency claims.

## Resolved Issue
Resolves #430 

## Problem

The API documentation had drifted from the actual implementation. It was misleading to developers by providing incorrect information on how to interact with the backend AI features. Specifically:
- It referenced a `POST /api/ai/generate-summary` route, but the actual route is `POST /api/ai/summary`.
- It stated the API was hosted at `http://localhost:3000`, which is the Vite frontend port, whereas the Express backend runs on port `5000`.
- It claimed the `express-rate-limit` package was managing rate limiting, when the project actually utilizes a custom, in-house middleware (`rateLimiter.js`).

## Changes Made

- Changed the endpoint path from `/api/ai/generate-summary` to `/api/ai/summary` in both the header and URL string.
- Corrected the base URL port from `3000` to `5000`.
- Updated the "Security & Rate Limiting" section to accurately describe the custom in-house rate limiter middleware.

## Impact

- Prevents developer friction and integration errors when testing or building features that rely on the backend API.
- Ensures the documentation correctly aligns with the current architecture and routing patterns.