### PR TITLE
fix: Resolve backend startup crash due to undefined `env` reference in `server.js`

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -5,7 +5,7 @@ import app from "./app.js";
 dotenv.config(); // must be first
 const PORT = process.env.PORT || 5000;
 
-const mongoUri = env.MONGO_URI || env.MONGODB_URI;
+const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI;
 if (mongoUri) {
   mongoose
     .connect(mongoUri)


### PR DESCRIPTION
## Summary

This PR fixes a critical initialization bug in the Express backend where an incorrect, undefined variable reference caused the server to immediately crash on startup.

## Resolved Issue
Resolves #432 

## Problem

During a recent refactor, line 8 of `backend/server.js` was modified to read the MongoDB connection URI from an `env` object:
`const mongoUri = env.MONGO_URI || env.MONGODB_URI;`

Since `env` is not a defined variable in Node.js (unlike the globally available `process.env`), attempting to start the backend resulted in a fatal `ReferenceError: env is not defined`. This completely broke the backend, preventing it from running or serving any API routes.

## Changes Made

- Replaced the bare `env.MONGO_URI` reference with the correct `process.env.MONGO_URI`.
- Replaced the bare `env.MONGODB_URI` reference with the correct `process.env.MONGODB_URI`.

## Impact

- **Critical Fix:** The backend now boots up successfully without throwing a `ReferenceError`.
- Restores database connectivity by properly accessing the environment variables from the Node.js process.