### PR TITLE
Fix Search Path Poisoning in join_session RPC

### DIFF
--- a/.gssoc/issue-441-summary.md
+++ b/.gssoc/issue-441-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #441
+
+## Issue: Search Path Poisoning in join_session RPC
+
+## Approach
+Add the `SET search_path = public` modifier to the `join_session` RPC function to prevent malicious search path overriding when the function executes with `SECURITY DEFINER` privileges.
+
+## Changes Made
+1. Created migration `20260601000006_fix_join_session_search_path.sql`.
+2. Replaced `join_session` to include `SET search_path = public`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000006_fix_join_session_search_path.sql
+++ b/supabase/migrations/20260601000006_fix_join_session_search_path.sql
@@ -1,0 +1,48 @@
+-- Fix Issue 441: Search Path Poisoning in join_session RPC
+CREATE OR REPLACE FUNCTION public.join_session(p_session_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_seat_limit integer;
+  v_participants integer;
+  v_status text;
+BEGIN
+  -- Validate the session exists and fetch its limits and status, locking the row to prevent race conditions
+  SELECT seat_limit, participants, status INTO v_seat_limit, v_participants, v_status
+  FROM public.sessions
+  WHERE id = p_session_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Session not found.';
+  END IF;
+
+  -- Verify the session's status
+  IF v_status NOT IN ('scheduled', 'live') THEN
+    RAISE EXCEPTION 'Cannot join a session that is %.', v_status;
+  END IF;
+
+  -- Check if seat limit is reached
+  IF v_seat_limit IS NOT NULL AND v_participants >= v_seat_limit THEN
+    RAISE EXCEPTION 'Session is full.';
+  END IF;
+
+  -- Insert the participant
+  BEGIN
+    INSERT INTO public.session_participants (session_id, user_id)
+    VALUES (p_session_id, auth.uid());
+  EXCEPTION WHEN unique_violation THEN
+    -- Already joined
+    RETURN;
+  END;
+
+  -- Increment the participants count
+  UPDATE public.sessions
+  SET participants = participants + 1
+  WHERE id = p_session_id;
+
+END;
+$$;


### PR DESCRIPTION
### Description
Fixed a Search Path Poisoning vulnerability in the `join_session` RPC by explicitly setting `search_path = public` on the `SECURITY DEFINER` function.

### Fixes
Fixes #441

### Type of change
- [x] Security Fix
- [x] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
