### PR TITLE
Fix Search Path Poisoning in invite_to_study_room RPC

### DIFF
--- a/.gssoc/issue-442-summary.md
+++ b/.gssoc/issue-442-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #442
+
+## Issue: Search Path Poisoning in invite_to_study_room RPC
+
+## Approach
+Add the `SET search_path = public` modifier to the `invite_to_study_room` RPC function.
+
+## Changes Made
+1. Created migration `20260601000007_fix_invite_to_study_room_search_path.sql`.
+2. Replaced `invite_to_study_room` to include `SET search_path = public`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000007_fix_invite_to_study_room_search_path.sql
+++ b/supabase/migrations/20260601000007_fix_invite_to_study_room_search_path.sql
@@ -1,0 +1,35 @@
+-- Fix Issue 442: Search Path Poisoning in invite_to_study_room RPC
+CREATE OR REPLACE FUNCTION invite_to_study_room(p_room_id UUID, p_user_email TEXT)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_room_creator UUID;
+  v_invitee_id UUID;
+BEGIN
+  -- Verify the caller is the creator
+  SELECT created_by INTO v_room_creator
+  FROM public.study_rooms
+  WHERE id = p_room_id;
+
+  IF v_room_creator != auth.uid() THEN
+    RAISE EXCEPTION 'Only the room creator can invite participants';
+  END IF;
+
+  -- Find the invitee by email (case-insensitive)
+  SELECT id INTO v_invitee_id
+  FROM auth.users
+  WHERE lower(email) = lower(p_user_email);
+
+  IF v_invitee_id IS NULL THEN
+    RAISE EXCEPTION 'User with this email not found';
+  END IF;
+
+  -- Insert into participants
+  INSERT INTO public.study_room_participants (room_id, profile_id)
+  VALUES (p_room_id, v_invitee_id)
+  ON CONFLICT DO NOTHING;
+END;
+$$;


### PR DESCRIPTION
### Description
Fixed a Search Path Poisoning vulnerability in the `invite_to_study_room` RPC by explicitly setting `search_path = public` on the `SECURITY DEFINER` function.

### Fixes
Fixes #442

### Type of change
- [x] Security Fix
- [x] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
