### PR TITLE
Fix Taxonomy Pollution in skills_taxonomy

### DIFF
--- a/.gssoc/issue-446-summary.md
+++ b/.gssoc/issue-446-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #446
+
+## Issue: Taxonomy Pollution (Broken RLS on skills_taxonomy)
+
+## Approach
+Replaced the overly permissive `INSERT` policy on `skills_taxonomy` with one that restricts insertion exclusively to admin users, utilizing the `public.has_role(auth.uid(), 'admin')` helper.
+
+## Changes Made
+1. Created migration `20260601000010_fix_skills_taxonomy_rls.sql`.
+2. Added check `public.has_role(auth.uid(), 'admin')` for `skills_taxonomy` `INSERT`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000010_fix_skills_taxonomy_rls.sql
+++ b/supabase/migrations/20260601000010_fix_skills_taxonomy_rls.sql
@@ -1,0 +1,11 @@
+-- Fix Issue 446: Taxonomy Pollution (Broken RLS on skills_taxonomy)
+
+DROP POLICY IF EXISTS "Authenticated users can insert skills" ON public.skills_taxonomy;
+
+CREATE POLICY "Admins can insert skills"
+ON public.skills_taxonomy
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  public.has_role(auth.uid(), 'admin')
+);


### PR DESCRIPTION
### Description
Fixed a major logic flaw where `skills_taxonomy` was open to arbitrary insertions by any authenticated user by restricting it to `admin` only.

### Fixes
Fixes #446

### Type of change
- [x] Security Fix
- [x] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
