### PR TITLE
Fix Broken Chat Initialization (Missing INSERT Policies)

### DIFF
--- a/.gssoc/issue-447-summary.md
+++ b/.gssoc/issue-447-summary.md
@@ -1,0 +1,12 @@
+# Fix Plan for Issue #447
+
+## Issue: Broken Chat Initialization (Missing INSERT Policy on conversations)
+
+## Approach
+Added the missing `INSERT` policies to both `conversations` and `conversation_participants` tables, enabling users to create new chat sessions. The participant policy specifically ensures users can only add themselves or others to conversations they are actively a part of.
+
+## Changes Made
+1. Created migration `20260601000011_fix_chat_initialization.sql`.
+2. Added `INSERT` policies for `conversations` and `conversation_participants`.
+
+*This file was auto-generated for GSSoC 2026 compliance.*

--- a/supabase/migrations/20260601000011_fix_chat_initialization.sql
+++ b/supabase/migrations/20260601000011_fix_chat_initialization.sql
@@ -1,0 +1,24 @@
+-- Fix Issue 447: Missing INSERT Policy on conversations and conversation_participants
+
+-- Allow authenticated users to create conversations
+DROP POLICY IF EXISTS "Users can insert conversations" ON public.conversations;
+CREATE POLICY "Users can insert conversations"
+ON public.conversations
+FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+-- Allow users to add themselves or others to conversations they are creating or already part of
+DROP POLICY IF EXISTS "Users can insert conversation participants" ON public.conversation_participants;
+CREATE POLICY "Users can insert conversation participants"
+ON public.conversation_participants
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  user_id = auth.uid() 
+  OR EXISTS (
+    SELECT 1 FROM public.conversation_participants cp 
+    WHERE cp.conversation_id = conversation_id 
+    AND cp.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
### Description
Fixed broken direct messaging functionality by adding missing `INSERT` policies to the `conversations` and `conversation_participants` tables. This restores the ability for users to initialize new chats via the API.

### Fixes
Fixes #447

### Type of change
- [x] Bug Fix
- [ ] Feature

### GSSoC 2026
This PR is submitted as part of GSSoC 2026.
