### PR TITLE
security(backend): prevent cpu-burn dos in rate limiter with O(1) lru…

### DIFF
--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -20,13 +20,15 @@ export const rateLimiter = (req, res, next) => {
   const userId = req.user?.id || req.ip;
   const now = Date.now();
 
-  if (requestCounts.size >= MAX_ENTRIES) {
-    evictStaleEntries();
-  }
-
-  const entry = requestCounts.get(userId);
+  let entry = requestCounts.get(userId);
 
   if (!entry || now - entry.windowStart >= WINDOW_MS) {
+    if (!entry && requestCounts.size >= MAX_ENTRIES) {
+      const oldestKey = requestCounts.keys().next().value;
+      if (oldestKey !== undefined) {
+        requestCounts.delete(oldestKey);
+      }
+    }
     requestCounts.set(userId, { count: 1, windowStart: now });
     return next();
   }


### PR DESCRIPTION
## Description
This PR resolves a severe self-inflicted Denial of Service (DoS) vulnerability within the custom Rate Limiter middleware (`backend/middlewares/rateLimiter.js`).
Closes #494 
Previously, the rate limiter would attempt to prune its internal Map of 10,000 tracked IPs synchronously on the request hotpath. If an attacker flooded the server with distinct IPs within the 60-second window, all entries would be considered "fresh," meaning the Map would stay at maximum capacity. This forced the server to synchronously iterate over 10,000 items on **every single subsequent incoming request**, completely blocking the Node.js Event Loop and freezing the backend.

### Key Changes
- Removed the `O(N)` synchronous `evictStaleEntries()` loop from the request pipeline.
- Implemented a strict **`O(1)` LRU Eviction Fallback**: When the Map hits 10,000 entries and a new unique IP connects, the middleware now instantly fetches and deletes the oldest entry using `requestCounts.keys().next().value`.
- Because JavaScript Maps preserve insertion order, this guarantees the oldest tracked IP is gracefully dropped in constant time, entirely preventing CPU spikes under volumetric attack loads.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security Fix (Prevents CPU-exhaustion DoS)
- [x] Performance Improvement (O(N) to O(1) hotpath complexity)
