### PR TITLE
perf(backend): cache openai client in chatController to prevent conne…

### DIFF
--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -4,12 +4,16 @@ import { HttpError } from "../utils/httpError.js";
 
 dotenv.config();
 
+let openRouterInstance = null;
+
 const getOpenRouterClient = () => {
+  if (openRouterInstance) return openRouterInstance;
+
   if (!process.env.OPENROUTER_API_KEY) {
     return null;
   }
 
-  return new OpenAI({
+  openRouterInstance = new OpenAI({
     apiKey: process.env.OPENROUTER_API_KEY,
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders: {
@@ -17,6 +21,8 @@ const getOpenRouterClient = () => {
       "X-Title": "Peer Learning AI",
     },
   });
+
+  return openRouterInstance;
 };
 
 const SYSTEM_PROMPT =


### PR DESCRIPTION
## Description
This PR resolves a significant performance bottleneck in the backend by fixing connection churn within the Chat Controller (`backend/controllers/chatController.js`).
Closes #495 
Previously, the `getOpenRouterClient()` helper function executed `new OpenAI(...)` on every single incoming AI chat request. Re-instantiating the entire OpenAI Node SDK client per-request causes massive garbage collection pauses, memory bloat, and connection initialization latency, severely impacting API throughput under heavy load.

### Key Changes
- Refactored `getOpenRouterClient` to use a Singleton Pattern.
- The heavy `new OpenAI(...)` initialization is now only called once for the entire lifecycle of the Node server.
- Subsequent chat requests seamlessly reuse the cached `openRouterInstance`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance Improvement (Reduced API overhead & memory usage)
