### PR TITLE
fix(frontend): resolve profile creation race condition during login b…

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState, ReactNode, useCallback } from "react";
+import { createContext, useEffect, useState, ReactNode, useCallback, useRef } from "react";
 import { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -20,12 +20,15 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [needsOnboarding, setNeedsOnboarding] = useState(false);
+  const isCreatingProfile = useRef(false);
 
   /**
    * Ensures user profile exists in database without overwriting existing data
    */
   const ensureProfileExists = useCallback(async (user: User) => {
+    if (isCreatingProfile.current) return;
     try {
+      isCreatingProfile.current = true;
       const profileData = {
         id: user.id,
         is_mentor: false,
@@ -53,6 +56,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       }
     } catch (err) {
       console.error("Unexpected error while creating profile:", err);
+    } finally {
+      setTimeout(() => {
+        isCreatingProfile.current = false;
+      }, 1000);
     }
   }, []);
 


### PR DESCRIPTION
## Description
This PR resolves a race condition bug inside `src/contexts/AuthContext.tsx` that occurred during user authentication.
Closes #497 
Previously, when a user successfully logged in, two concurrent React hooks triggered simultaneously (`initializeSession` and the `onAuthStateChange` listener). Both pipelines invoked the `ensureProfileExists` function without coordination, resulting in two duplicate `upsert` queries hitting the Supabase database at the exact same millisecond. This caused intermittent row-locking conflicts and wasted bandwidth.

### Key Changes
- Introduced an `isCreatingProfile` mutual exclusion lock using a React `useRef`.
- When `ensureProfileExists` is called, it checks the lock; if it's currently active, the concurrent caller instantly bails out, preventing duplicate execution.
- The lock safely resets itself via a `finally` block with a 1-second decay timeout.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance Improvement (Saves database queries and bandwidth)
