### PR TITLE
perf(dashboard): extract clock into isolated component to prevent glo…

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -36,17 +36,8 @@ interface Session {
   date?: string;
 }
 
-
-const Dashboard = () => {
-  const { user, loading } = useAuth();
-  const { currentMode } = useRole();
-  const navigate = useNavigate();
-
-  const [profile, setProfile] = useState<Profile | null>(null);
+const Clock = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
-  const [recommendedPeers, setRecommendedPeers] = useState<any[]>([]);
-  const [upcomingSessions, setUpcomingSessions] = useState<any[]>([]);
-  const [leaderboard, setLeaderboard] = useState<any[]>([]);
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -55,6 +46,23 @@ const Dashboard = () => {
 
     return () => clearInterval(interval);
   }, []);
+
+  return (
+    <p className="mt-3 text-sm text-slate-400">
+      {currentTime.toLocaleTimeString()}
+    </p>
+  );
+};
+
+const Dashboard = () => {
+  const { user, loading } = useAuth();
+  const { currentMode } = useRole();
+  const navigate = useNavigate();
+
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [recommendedPeers, setRecommendedPeers] = useState<any[]>([]);
+  const [upcomingSessions, setUpcomingSessions] = useState<any[]>([]);
+  const [leaderboard, setLeaderboard] = useState<any[]>([]);
 
   const displayName =
     profile?.name?.trim() ||
@@ -247,9 +255,7 @@ const Dashboard = () => {
                 👋
               </h1>
 
-              <p className="mt-3 text-sm text-slate-400">
-                {currentTime.toLocaleTimeString()}
-              </p>
+              <Clock />
 
               <p className="mt-4 text-lg text-slate-300/80">
                 Continue your learning journey today.


### PR DESCRIPTION
## Description
This PR resolves a critical React performance bug causing severe CPU thrashing on the Dashboard page.
Closes #510 
Previously, `src/pages/Dashboard.tsx` utilized a `setInterval` hook at the absolute top level of the component to update a `currentTime` state every 1000ms. Because React re-renders the entire component tree when top-level state changes, this forced heavy, unmemoized child components (like `AnalyticsCharts` and `RecommendationPanel`) to needlessly recalculate and re-render 60 times a minute.

### Key Changes
- **Isolated State**: Extracted the clock logic into an isolated, dedicated `<Clock />` component.
- **Render Protection**: The parent `Dashboard` no longer tracks the time state, allowing it (and its heavy children) to remain completely static and performant while the tiny clock component ticks independently.

## Type of change
- [x] Performance Improvement (Eliminated O(N) render thrashing and CPU spikes)
- [x] Bug fix (non-breaking change which fixes an issue)
