### PR TITLE
fix(security): conditionally trust proxy headers to prevent X-Forward…

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -9,7 +9,12 @@ import { errorHandler } from "./middlewares/errorHandler.js";
 
 const app = express();
 
-app.set("trust proxy", 1);
+// SECURITY: Only trust proxy if explicitly configured (e.g., when behind Nginx/Cloudflare)
+// This prevents attackers from spoofing their IP via X-Forwarded-For headers
+if (process.env.TRUST_PROXY === "true") {
+  app.set("trust proxy", 1);
+}
+
 app.use(cors({ origin: process.env.FRONTEND_URL || '*' }));
 // Cap incoming JSON body size to 100 KB so a single oversized request
 // cannot exhaust server memory or cause a denial-of-service condition.

--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -17,6 +17,9 @@ const evictStaleEntries = () => {
 setInterval(evictStaleEntries, CLEANUP_INTERVAL_MS);
 
 export const rateLimiter = (req, res, next) => {
+  // If the user is unauthenticated, fallback to req.ip.
+  // Because 'trust proxy' in app.js is conditionally secured, req.ip cannot be spoofed 
+  // via X-Forwarded-For headers unless explicitly allowed by infrastructure.
   const userId = req.user?.id || req.ip;
   const now = Date.now();
 


### PR DESCRIPTION
## Description
This PR resolves a security vulnerability where the backend rate limiter could be bypassed via IP spoofing.
Closes #519 
Previously, `backend/app.js` universally called `app.set("trust proxy", 1)`. If the backend was deployed directly to the web or behind an improperly configured reverse proxy, a malicious user could inject spoofed `X-Forwarded-For` headers. Because `rateLimiter.js` falls back to using `req.ip` for unauthenticated requests, an attacker could trivially rotate their spoofed IPs to bypass the rate limit block and DDoS the server.

### Key Changes
- **Conditional Trust**: `trust proxy` is now only enabled if `process.env.TRUST_PROXY === "true"`. This guarantees the server uses the raw TCP socket IP (`req.ip`) to enforce limits unless explicitly instructed by the infrastructure layer that proxy headers are safe to trust.
- **Documentation**: Added security comments to `rateLimiter.js` to prevent future regressions.

## Type of change
- [x] Security patch (Mitigated Rate Limiter Bypass / DDoS vector)
- [x] Bug fix (non-breaking change which fixes an issue)
