### PR TITLE
perf(frontend): debounce search input to eliminate network spam and l…

### DIFF
--- a/src/pages/ResourceHub.tsx
+++ b/src/pages/ResourceHub.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { Filter, Upload } from "lucide-react";
 
 import FilterSidebar from "@/components/resources/FilterSidebar";
@@ -19,14 +19,23 @@ const ResourceHub = () => {
   const currentUser = auth?.user ?? null;
 
   const [search, setSearch] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [selectedType, setSelectedType] = useState("all");
   const [savedOnly, setSavedOnly] = useState(false);
   const [isUploadOpen, setIsUploadOpen] = useState(false);
   const [isMobileFiltersOpen, setIsMobileFiltersOpen] = useState(false);
 
+  // Debounce search to prevent network spam on every keystroke
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedSearch(search);
+    }, 500);
+    return () => clearTimeout(handler);
+  }, [search]);
+
   const { resources, loading, error, refetch } = useResources({
-    search,
+    search: debouncedSearch,
     tags: selectedTags,
     fileType: selectedType === "all" || selectedType === "code" ? undefined : selectedType,
     savedOnly,


### PR DESCRIPTION
## Description
This PR resolves a major frontend performance bottleneck and database scaling issue on the Resource Hub page.
Closes #518 
Previously, `src/pages/ResourceHub.tsx` fed the raw `search` state directly into the `useResources` hook. This caused the React component to re-render, abort the previous fetch, and fire off a new network request to Supabase on *every single keystroke*. When users typed out normal words, it aggressively spammed the Supabase API and caused severe layout thrashing.

### Key Changes
- **Debounced State**: Introduced a 500ms `setTimeout` hook to track a `debouncedSearch` variable.
- **Snappy UI, Safe Network**: The input field updates instantly to remain highly responsive, but the heavy network fetch operation is paused until the user stops typing for half a second. Typing a 10-character word now correctly fires 1 database query instead of 10.

## Type of change
- [x] Performance Improvement (Saves database connections and eliminates React render thrashing)
- [x] Bug fix (non-breaking change which fixes an issue)
