### PR TITLE
perf(frontend): refactor useResourceInteractions to batch requests an…

### DIFF
--- a/src/hooks/useResourceInteractions.ts
+++ b/src/hooks/useResourceInteractions.ts
@@ -1,42 +1,49 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 
-export const useResourceInteractions = (resourceId: string, userId: string | null | undefined) => {
-  const queryClient = useQueryClient();
-
-  const { data: vote, isLoading: isLoadingVote } = useQuery({
-    queryKey: ["resource_vote", resourceId, userId],
+// Global cache hooks for bulk fetching
+const useAllUserVotes = (userId: string | null | undefined) => {
+  return useQuery({
+    queryKey: ["all_resource_votes", userId],
     queryFn: async () => {
-      if (!userId) return null;
+      if (!userId) return [];
       const { data, error } = await supabase
         .from("resource_votes")
-        .select("vote_type")
-        .eq("resource_id", resourceId)
-        .eq("user_id", userId)
-        .maybeSingle();
-      
+        .select("resource_id, vote_type")
+        .eq("user_id", userId);
       if (error) throw error;
-      return data?.vote_type ?? null;
+      return data || [];
     },
     enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
   });
+};
 
-  const { data: isSaved, isLoading: isLoadingSaved } = useQuery({
-    queryKey: ["resource_saved", resourceId, userId],
+const useAllUserSaves = (userId: string | null | undefined) => {
+  return useQuery({
+    queryKey: ["all_saved_resources", userId],
     queryFn: async () => {
-      if (!userId) return false;
+      if (!userId) return [];
       const { data, error } = await supabase
         .from("saved_resources")
         .select("resource_id")
-        .eq("resource_id", resourceId)
-        .eq("user_id", userId)
-        .maybeSingle();
-        
+        .eq("user_id", userId);
       if (error) throw error;
-      return !!data;
+      return data || [];
     },
     enabled: !!userId,
+    staleTime: 5 * 60 * 1000,
   });
+};
+
+export const useResourceInteractions = (resourceId: string, userId: string | null | undefined) => {
+  const queryClient = useQueryClient();
+
+  const { data: allVotes, isLoading: isLoadingVotes } = useAllUserVotes(userId);
+  const { data: allSaves, isLoading: isLoadingSaves } = useAllUserSaves(userId);
+
+  const vote = allVotes?.find(v => v.resource_id === resourceId)?.vote_type ?? null;
+  const isSaved = allSaves?.some(s => s.resource_id === resourceId) ?? false;
 
   const toggleVoteMutation = useMutation({
     mutationFn: async (voteType: 1 | -1 | null) => {
@@ -56,7 +63,7 @@ export const useResourceInteractions = (resourceId: string, userId: string | nul
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["resource_vote", resourceId, userId] });
+      queryClient.invalidateQueries({ queryKey: ["all_resource_votes", userId] });
     },
   });
 
@@ -78,14 +85,14 @@ export const useResourceInteractions = (resourceId: string, userId: string | nul
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["resource_saved", resourceId, userId] });
+      queryClient.invalidateQueries({ queryKey: ["all_saved_resources", userId] });
     },
   });
 
   return {
     vote,
     isSaved,
-    isLoading: isLoadingVote || isLoadingSaved,
+    isLoading: isLoadingVotes || isLoadingSaves,
     toggleVote: toggleVoteMutation.mutateAsync,
     toggleSave: toggleSaveMutation.mutateAsync,
   };


### PR DESCRIPTION
## Description
This PR resolves a massive frontend network bottleneck where rendering the Resource Hub triggered an N+1 query waterfall.
CLoses #520 
Previously, `src/hooks/useResourceInteractions.ts` was tightly scoped to a single `resourceId`. Because it was invoked inside the `ResourceCard` component, rendering a page with 20 cards caused React Query to mount 20 instances of the hook simultaneously, instantly firing 40 parallel database queries to Supabase. This rapidly exhausted connection limits and caused severe network stuttering.

### Key Changes
- **DataLoader Batching Pattern**: Restructured the hook to implement a global caching strategy (`useAllUserVotes` and `useAllUserSaves`).
- **Query Deduplication**: React Query now automatically deduplicates the hooks. When 20 cards render, they all request the identical cache key, which React Query batches into exactly **one** API request. The individual cards now securely filter the global array in memory, dropping network load from 40 queries down to 2!

## Type of change
- [x] Performance Improvement (Eliminates N+1 query problem)
- [x] Refactoring (React Query global caching)
