### PR TITLE
fix: add missing contact and privacy policy routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,6 +53,8 @@ const PublicPortfolio = React.lazy(() => import("./pages/PublicPortfolio"));
 const ResourceHub = React.lazy(() => import("@/pages/ResourceHub"));
 const StudyRooms = React.lazy(() => import("./components/StudyRooms"));
 const Room = React.lazy(() => import("./components/Room"));
+const Contact = React.lazy(() => import("./pages/Contact"));
+const PrivacyPolicy = React.lazy(() => import("./pages/privacy"));
 
 const queryClient = new QueryClient();
 
@@ -99,6 +101,8 @@ function AppContent() {
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/become-mentor" element={<BecomeMentor />} />
           <Route path="/portfolio/:slug" element={<PublicPortfolio />} />
+          <Route path="/contact" element={<WithNav><Contact /></WithNav>} />
+          <Route path="/privacy-policy" element={<WithNav><PrivacyPolicy /></WithNav>} />
 
           <Route path="/auth/callback" element={<AuthCallback />} />
 


### PR DESCRIPTION
## 🚀 Description

Adds the missing `/contact` and `/privacy-policy` routes to the application's router configuration.

### Root Cause

The footer contained links to Contact and Privacy Policy pages, but the corresponding routes were not registered in the router. As a result, users navigating through these links were redirected to the Not Found (404) page.

### Changes Made

* Added route registration for `/contact`.
* Added route registration for `/privacy-policy`.
* Connected both routes to their respective page components.
* Preserved existing routing behavior.

### Files Changed

* `src/App.tsx`

### Result

* Contact page is accessible through `/contact`.
* Privacy Policy page is accessible through `/privacy-policy`.
* Footer navigation works correctly.
* Existing routes remain unaffected.

### Verification

* Verified navigation to `/contact`.
* Verified navigation to `/privacy-policy`.
* Confirmed both pages render successfully.
* Confirmed existing routes continue to function correctly.

Fixes #523

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

---

## ✅ Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my code
* [x] My changes generate no new warnings
