### PR TITLE
fix(#457): make CRON_SECRET auth fail-closed in edge functions

### DIFF
--- a/supabase/functions/dispatch-push-notifications/index.ts
+++ b/supabase/functions/dispatch-push-notifications/index.ts
@@ -20,7 +20,9 @@ serve(async (req) => {
   const authHeader = req.headers.get("Authorization");
   const cronSecret = Deno.env.get("CRON_SECRET");
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  // Fail-closed: reject all requests when CRON_SECRET is not configured
+  // rather than accepting them when the env var is absent.
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
       status: 401,
       headers: { "Content-Type": "application/json" },

--- a/supabase/functions/send-session-reminders/index.ts
+++ b/supabase/functions/send-session-reminders/index.ts
@@ -5,7 +5,9 @@ serve(async (req) => {
   const authHeader = req.headers.get("Authorization");
   const cronSecret = Deno.env.get("CRON_SECRET");
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  // Fail-closed: reject all requests when CRON_SECRET is not configured
+  // rather than accepting them when the env var is absent.
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
       status: 401,
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary

Fixes the fail-open authentication vulnerability in two Supabase edge functions.

## Related Issue

Closes #457

## Type of Change

- [x] Security fix

## Root Cause

Both `send-session-reminders` and `dispatch-push-notifications` used:
\`\`\`typescript
if (cronSecret && authHeader !== \`Bearer \${cronSecret}\`) { return 401 }
\`\`\`
When \`CRON_SECRET\` is not configured, \`Deno.env.get("CRON_SECRET")\` returns \`undefined\` (falsy). JavaScript short-circuits the condition and skips the entire auth block, accepting requests from any unauthenticated caller.

## What Changed

- \`supabase/functions/send-session-reminders/index.ts\`: changed auth guard to \`!cronSecret || authHeader !== ...\`
- \`supabase/functions/dispatch-push-notifications/index.ts\`: same change

Both functions now reject all requests with 401 when \`CRON_SECRET\` is not configured in the deployment environment.

## Testing

- [ ] With \`CRON_SECRET\` unset: any request returns \`401 Unauthorized\`
- [ ] With \`CRON_SECRET\` set and correct header: request proceeds normally
- [ ] With \`CRON_SECRET\` set and wrong header: request returns \`401 Unauthorized\`

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change