### PR TITLE
fix(#458): add WITH CHECK to peer_connections UPDATE policy to block status rollback

### DIFF
--- a/supabase/migrations/20260602000002_fix_peer_connections_update_with_check.sql
+++ b/supabase/migrations/20260602000002_fix_peer_connections_update_with_check.sql
@@ -1,0 +1,24 @@
+-- Harden the peer_connections UPDATE policy with a WITH CHECK constraint.
+--
+-- The previous migration (20260531000000_fix_peer_connections_idor.sql) added
+-- a USING clause restricting updates to the receiver, but omitted a WITH CHECK
+-- clause. Without WITH CHECK, PostgreSQL permits any new row value that passes
+-- the existing table-level CHECK constraint, including resetting an already-
+-- accepted connection back to 'pending'.
+--
+-- This migration replaces the policy with one that enforces valid status
+-- transitions in the WITH CHECK clause:
+--   - Only 'accepted' or 'rejected' are valid target values.
+--   - The USING clause is unchanged: only the receiver may update.
+
+DROP POLICY IF EXISTS "Users can update own connections" ON public.peer_connections;
+
+CREATE POLICY "Users can update own connections"
+ON public.peer_connections
+FOR UPDATE
+TO authenticated
+USING (auth.uid() = receiver_id)
+WITH CHECK (
+  auth.uid() = receiver_id
+  AND status IN ('accepted', 'rejected')
+);


### PR DESCRIPTION
## Summary

Adds a \`WITH CHECK\` constraint to the \`peer_connections\` UPDATE policy to prevent receivers from resetting an accepted connection back to pending.

## Related Issue

Closes #458

## Type of Change

- [x] Security fix

## Root Cause

Migration \`20260531000000_fix_peer_connections_idor.sql\` added \`USING (auth.uid() = receiver_id)\` to restrict who can update, but omitted a \`WITH CHECK\` clause. PostgreSQL's \`FOR UPDATE\` policies apply \`USING\` to determine which rows can be modified and \`WITH CHECK\` to validate the resulting row. Without \`WITH CHECK\`, any new \`status\` value that passes the table-level \`CHECK\` constraint is accepted, including setting an accepted connection back to pending.

## What Changed

- \`supabase/migrations/20260602000002_fix_peer_connections_update_with_check.sql\`: replaces the policy with one that adds \`WITH CHECK (status IN ('accepted', 'rejected'))\`

## Testing

- [ ] Receiver accepting a pending connection succeeds
- [ ] Receiver rejecting a pending connection succeeds
- [ ] Receiver attempting to set status back to pending after accepting returns a policy violation

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change