### PR TITLE
fix(#459): add DELETE policy to peer_connections so users can withdraw or remove connections

### DIFF
--- a/supabase/migrations/20260602000001_fix_peer_connections_delete_policy.sql
+++ b/supabase/migrations/20260602000001_fix_peer_connections_delete_policy.sql
@@ -1,0 +1,29 @@
+-- Add DELETE policy to peer_connections so users can withdraw or remove connections.
+--
+-- Before this migration, the peer_connections table had no DELETE policy.
+-- Row Level Security blocked all DELETE operations for authenticated users,
+-- leaving two broken UX paths:
+--   1. A sender could not cancel a pending request after sending it.
+--   2. Neither party could remove an accepted connection.
+--
+-- Rules applied by this policy:
+--   - A sender may delete a connection they created while it is still 'pending'
+--     (i.e. cancel an unanswered request).
+--   - Either the sender or the receiver may delete an 'accepted' connection
+--     (i.e. remove an established peer connection).
+--   - Rejected connections can only be deleted by the sender so the sender can
+--     clean up after a refusal.
+
+DROP POLICY IF EXISTS "Users can delete own connections" ON public.peer_connections;
+
+CREATE POLICY "Users can delete own connections"
+ON public.peer_connections
+FOR DELETE
+TO authenticated
+USING (
+  -- Sender may delete: pending (cancel) or rejected (clean up)
+  (auth.uid() = sender_id AND status IN ('pending', 'rejected'))
+  OR
+  -- Either party may delete an accepted connection
+  (status = 'accepted' AND (auth.uid() = sender_id OR auth.uid() = receiver_id))
+);


### PR DESCRIPTION
## Summary

Adds a DELETE RLS policy to \`peer_connections\` so senders can cancel pending requests and either party can remove an accepted connection.

## Related Issue

Closes #459

## Type of Change

- [x] Bug fix

## Root Cause

The \`peer_connections\` table had no DELETE policy. RLS blocks all DELETE operations by default when no matching policy exists, making it impossible for users to cancel their own pending requests or remove accepted connections.

## What Changed

- \`supabase/migrations/20260602000001_fix_peer_connections_delete_policy.sql\`: adds policy allowing:
  - Sender to delete connections they created while status is \`pending\` or \`rejected\`
  - Either party to delete a connection with status \`accepted\`

## Testing

- [ ] Sender can delete a pending connection they sent
- [ ] Sender can delete a rejected connection
- [ ] Either party can delete an accepted connection
- [ ] Receiver cannot delete a pending connection they did not send

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change