### PR TITLE
perf(frontend): enforce query limit on upcoming sessions to prevent O…

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -139,10 +139,13 @@ const Dashboard = () => {
   // Sessions
   useEffect(() => {
     const fetchSessions = async () => {
+      // SECURITY/PERF: Limit fetch to top 4 to prevent downloading 10,000 global sessions
+      // which would cause massive browser OOM crashes and render thrashing.
       const { data, error } = await supabase
         .from("sessions")
         .select("*")
-        .eq("status", "upcoming");
+        .eq("status", "upcoming")
+        .limit(4);
 
       if (error || !data) {
         setUpcomingSessions([]);


### PR DESCRIPTION
## Description
This PR resolves a massive frontend memory vulnerability and over-fetching bug on the main Dashboard.
Closes #542 
Previously, `src/pages/Dashboard.tsx` executed an unbounded database query (`.from("sessions").select("*").eq("status", "upcoming")`) to populate the "Upcoming Sessions" widget. Because it lacked a pagination limit, this query downloaded *every single upcoming session across the entire platform* directly into the user's browser. If the platform scales to 10,000 sessions, the frontend would attempt to render 10,000 `<SessionCard>` components simultaneously, instantly causing a browser Out-Of-Memory (OOM) crash and generating a massive network payload.

### Key Changes
- **Guaranteed `O(1)` Scaling**: Appended a `.limit(4)` constraint to the Supabase query. The Dashboard now strictly fetches only the maximum amount of sessions it needs to populate the UI. Network payloads and React rendering time will now remain perfectly constant regardless of how many millions of sessions exist in the database.

## Type of change
- [x] Bug fix (Resolves severe Out-Of-Memory browser crash vector)
- [x] Performance Improvement (Saves massive network bandwidth)
