### PR TITLE
feat(frontend): transform MentorDashboard into a fully data-driven co…

### DIFF
--- a/src/pages/MentorDashboard.tsx
+++ b/src/pages/MentorDashboard.tsx
@@ -1,56 +1,115 @@
+import { useEffect, useState } from "react";
 import { useRole } from "@/contexts/RoleContext";
 import { useAuth } from "@/contexts/useAuth";
 import { Link } from "react-router-dom";
+import { supabase } from "@/integrations/supabase/client";
+import SessionCard from "@/components/SessionCard";
 
 const MentorDashboard = () => {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const { currentMode } = useRole();
+  
+  const [profile, setProfile] = useState<any>(null);
+  const [upcomingSessions, setUpcomingSessions] = useState<any[]>([]);
 
   const displayName =
+    profile?.name ||
     user?.user_metadata?.name ||
     user?.user_metadata?.full_name ||
     user?.email ||
     "Mentor";
+
+  useEffect(() => {
+    if (!user) return;
+
+    const fetchDashboardData = async () => {
+      try {
+        // Fetch real Mentor Profile Stats
+        const { data: profileData } = await supabase
+          .from("profiles")
+          .select("*")
+          .eq("id", user.id)
+          .single();
+        
+        if (profileData) {
+          setProfile(profileData);
+        }
+
+        // Fetch Upcoming Mentor Sessions
+        const { data: sessionData } = await supabase
+          .from("sessions")
+          .select("*")
+          .eq("status", "upcoming")
+          .limit(4);
+
+        if (sessionData) {
+          setUpcomingSessions(sessionData);
+        }
+      } catch (err) {
+        console.error("Failed to fetch mentor dashboard data", err);
+      }
+    };
+
+    fetchDashboardData();
+  }, [user]);
+
+  if (loading) return null;
 
   return (
     <div className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100">
       <div className="mx-auto max-w-6xl space-y-8">
         <div className="space-y-2">
           <Link
-  to="/"
-  className="inline-block rounded-md bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-500"
->
-  ← Back 
-</Link>
+            to="/"
+            className="inline-block rounded-md bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-500"
+          >
+            ← Back 
+          </Link>
 
           <p className="text-sm text-emerald-300">
             Current mode: {currentMode}
           </p>
           <h1 className="text-3xl font-bold">Mentor Dashboard</h1>
-          <p className="text-slate-400">{displayName}</p>
+          <p className="text-slate-400">Welcome back, {displayName}!</p>
         </div>
 
         <div className="grid gap-4 md:grid-cols-3">
           <div className="rounded-xl border border-slate-800 bg-slate-900 p-5">
             <p className="text-sm text-slate-400">Sessions Hosted</p>
-            <p className="mt-2 text-3xl font-semibold">0</p>
+            <p className="mt-2 text-3xl font-semibold text-emerald-400">
+              {profile?.sessions_completed || 0}
+            </p>
           </div>
           <div className="rounded-xl border border-slate-800 bg-slate-900 p-5">
-            <p className="text-sm text-slate-400">Active Learners</p>
-            <p className="mt-2 text-3xl font-semibold">0</p>
+            <p className="text-sm text-slate-400">Total XP</p>
+            <p className="mt-2 text-3xl font-semibold text-cyan-400">
+              {profile?.points || 0}
+            </p>
           </div>
           <div className="rounded-xl border border-slate-800 bg-slate-900 p-5">
             <p className="text-sm text-slate-400">Average Rating</p>
-            <p className="mt-2 text-3xl font-semibold">&nbsp;</p>
+            <p className="mt-2 text-3xl font-semibold text-yellow-400">
+              {profile?.rating ? `${profile.rating}/5` : "New 🚀"}
+            </p>
           </div>
         </div>
 
         <section className="rounded-xl border border-slate-800 bg-slate-900 p-6">
-          <h2 className="text-xl font-semibold">Upcoming Sessions</h2>
-          <p className="mt-3 text-slate-400">
-            No upcoming sessions. Once learners book with you, they will appear
-            here.
-          </p>
+          <h2 className="mb-5 text-xl font-semibold">Upcoming Mentorship Sessions</h2>
+          
+          {upcomingSessions.length > 0 ? (
+            <div className="grid gap-4 md:grid-cols-2">
+              {upcomingSessions.map((session) => (
+                <div key={session.id} className="bg-slate-950 rounded-xl p-2 border border-slate-800">
+                  <SessionCard session={session} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="mt-3 text-slate-400">
+              No upcoming sessions. Once learners book with you, they will appear here.
+            </p>
+          )}
         </section>
       </div>
     </div>


### PR DESCRIPTION
## Description
This PR resolves an incomplete feature implementation where the Mentor Dashboard was left as a static, hardcoded skeleton.
Closes #550 
Previously, `src/pages/MentorDashboard.tsx` hardcoded the numbers "0" for Sessions Hosted and Active Learners, and displayed a static string saying "No upcoming sessions". It did absolutely zero data fetching, rendering the entire page useless for actual mentors using the platform.

### Key Changes
- **Live Profile Data**: Integrated `useAuth` and `useEffect` hooks to securely fetch the authenticated mentor's profile from the Supabase `profiles` table.
- **Dynamic Statistics**: Bound the real profile statistics (`sessions_completed`, `points`, `rating`) to the UI statistic cards, complete with dynamic layout updates.
- **Session Integration**: Implemented a secure query to fetch `upcoming` sessions and mapped them into interactive, styled `SessionCard` components instead of a static placeholder paragraph.

## Type of change
- [x] New feature (Completes the Mentor Dashboard functionality)
- [x] UI / UX Enhancement
