### PR TITLE
Fix missing INSERT policy on conversation_participants (#448)

### DIFF
--- a/supabase/migrations/20260602000001_fix_chat_participation_policies.sql
+++ b/supabase/migrations/20260602000001_fix_chat_participation_policies.sql
@@ -1,0 +1,20 @@
+-- Fix Broken Chat Participation (Missing INSERT Policy on conversation_participants)
+-- Issue #448
+
+CREATE POLICY "Users can create conversations"
+ON public.conversations
+FOR INSERT
+TO authenticated
+WITH CHECK (true);
+
+CREATE POLICY "Users can insert conversation participants"
+ON public.conversation_participants
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  auth.uid() = user_id 
+  OR EXISTS (
+    SELECT 1 FROM public.conversation_participants cp 
+    WHERE cp.conversation_id = conversation_id AND cp.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
Fixes #448

## Description
Fixed the broken chat participation by adding missing INSERT policies:
- Added an INSERT policy for the `conversations` table.
- Added an INSERT policy for the `conversation_participants` table, ensuring users can only add themselves or participants if they are already a member of the conversation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the GSSoC 2026 guidelines
- [x] I have tested the changes locally
