### PR TITLE
Fix chronology spoofing in study room messages (#450)

### DIFF
--- a/supabase/migrations/20260602000002_fix_study_room_messages_created_at.sql
+++ b/supabase/migrations/20260602000002_fix_study_room_messages_created_at.sql
@@ -1,0 +1,17 @@
+-- Fix Chronology Spoofing in Study Rooms (study_room_messages.created_at)
+-- Issue #450
+
+CREATE OR REPLACE FUNCTION public.set_study_room_message_created_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Always enforce the server timestamp for created_at on insert
+  NEW.created_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS enforce_study_room_message_created_at ON public.study_room_messages;
+CREATE TRIGGER enforce_study_room_message_created_at
+  BEFORE INSERT ON public.study_room_messages
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_study_room_message_created_at();


### PR DESCRIPTION
Fixes #450

## Description
Fixed the chronology spoofing vulnerability in study room messages.
- Added a `BEFORE INSERT` trigger on the `study_room_messages` table.
- The trigger automatically forces `created_at` to `now()`, preventing malicious users from spoofing message timestamps to manipulate the order of messages in study rooms.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the GSSoC 2026 guidelines
- [x] I have tested the changes locally
