### PR TITLE
Fix race condition (TOCTOU) in join_session RPC (#452)

### DIFF
--- a/supabase/migrations/20260602000003_fix_join_session_race_condition.sql
+++ b/supabase/migrations/20260602000003_fix_join_session_race_condition.sql
@@ -1,0 +1,52 @@
+-- Fix Race Condition (TOCTOU) in Session Joining (join_session RPC)
+-- Issue #452
+
+CREATE OR REPLACE FUNCTION public.join_session(p_session_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_seat_limit integer;
+  v_participants integer;
+  v_status text;
+BEGIN
+  -- Validate the session exists and fetch its limits and status, locking the row to prevent race conditions
+  SELECT seat_limit, participants, status INTO v_seat_limit, v_participants, v_status
+  FROM public.sessions
+  WHERE id = p_session_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Session not found.';
+  END IF;
+
+  -- Verify the session's status
+  IF v_status NOT IN ('scheduled', 'live') THEN
+    RAISE EXCEPTION 'Cannot join a session that is %.', v_status;
+  END IF;
+
+  -- Check if already joined (early exit to prevent incrementing participants wrongly)
+  IF EXISTS (
+    SELECT 1 FROM public.session_participants 
+    WHERE session_id = p_session_id AND user_id = auth.uid()
+  ) THEN
+    RETURN;
+  END IF;
+
+  -- Check if seat limit is reached
+  IF v_seat_limit IS NOT NULL AND v_participants >= v_seat_limit THEN
+    RAISE EXCEPTION 'Session is full.';
+  END IF;
+
+  -- Increment the participants count FIRST to secure the seat
+  UPDATE public.sessions
+  SET participants = participants + 1
+  WHERE id = p_session_id;
+
+  -- Insert the participant
+  INSERT INTO public.session_participants (session_id, user_id)
+  VALUES (p_session_id, auth.uid());
+
+END;
+$$;


### PR DESCRIPTION
Fixes #452

## Description
Fixed the race condition (TOCTOU) in the `join_session` RPC:
- Reordered the execution so the `UPDATE` to increment the participants counter happens *before* the `INSERT` into the `session_participants` table.
- Replaced the `BEGIN...EXCEPTION WHEN unique_violation` block with an upfront `EXISTS` check. This prevents the `INSERT` from throwing or yielding before the seat count is updated, eliminating the narrow race window where a concurrent check on `session_participants` could exceed `max_participants`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the GSSoC 2026 guidelines
- [x] I have tested the changes locally
