### PR TITLE
fix(backend): replace setInterval with passive eviction to resolve se…

### DIFF
--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -4,9 +4,9 @@ const MAX_ENTRIES = 10000;
 const CLEANUP_INTERVAL_MS = 60 * 1000;
 
 const requestCounts = new Map();
+let lastCleanup = Date.now();
 
-const evictStaleEntries = () => {
-  const now = Date.now();
+const evictStaleEntries = (now) => {
   for (const [key, entry] of requestCounts.entries()) {
     if (now - entry.windowStart >= WINDOW_MS) {
       requestCounts.delete(key);
@@ -14,14 +14,18 @@ const evictStaleEntries = () => {
   }
 };
 
-setInterval(evictStaleEntries, CLEANUP_INTERVAL_MS);
-
 export const rateLimiter = (req, res, next) => {
   // If the user is unauthenticated, fallback to req.ip.
   // Because 'trust proxy' in app.js is conditionally secured, req.ip cannot be spoofed 
   // via X-Forwarded-For headers unless explicitly allowed by infrastructure.
   const userId = req.user?.id || req.ip;
   const now = Date.now();
+
+  // Passive eviction: clean up stale entries lazily to avoid holding the event loop open
+  if (now - lastCleanup >= CLEANUP_INTERVAL_MS) {
+    evictStaleEntries(now);
+    lastCleanup = now;
+  }
 
   let entry = requestCounts.get(userId);
 


### PR DESCRIPTION
## Description
This PR resolves a critical memory leak and event-loop hanging issue in the backend rate limiter middleware.
Closes #555 
Previously, `backend/middlewares/rateLimiter.js` utilized a global `setInterval` to periodically evict stale IP entries. Because this interval ran at the module root level and was never cleared, it prevented the Node.js event loop from emptying. In serverless environments (like Vercel, AWS Lambda, or Supabase Edge Functions), active intervals block the container from tearing down, leading to massive compute exhaustion, infinite hangs, and broken automated test suites.

### Key Changes
- **Passive Eviction Strategy**: Completely removed the rogue `setInterval`. Implemented a lazy, request-driven eviction check that triggers synchronously only when `CLEANUP_INTERVAL_MS` has elapsed between incoming requests.
- **Serverless Compatibility**: Because cleanup is now entirely request-driven, the Node.js event loop can immediately empty when traffic stops, allowing serverless containers to spin down securely.

## Type of change
- [x] Bug fix (Resolves serverless memory leak)
- [x] Performance Improvement (Event loop optimization)
