### PR TITLE
sec(backend): restrict AI models and clamp token limits to prevent bi…

### DIFF
--- a/backend/controllers/chatController.js
+++ b/backend/controllers/chatController.js
@@ -38,11 +38,22 @@ export const createChatCompletion = async (req, res, next) => {
       return;
     }
 
+    const ALLOWED_MODELS = [
+      "google/gemini-2.5-flash",
+      "meta-llama/llama-3-8b-instruct",
+      "mistralai/mistral-7b-instruct:free",
+      "google/gemma-7b-it:free"
+    ];
+
+    const safeModel = ALLOWED_MODELS.includes(model) ? model : "google/gemini-2.5-flash";
+    const safeMaxTokens = Math.min(parseInt(max_tokens, 10) || 512, 1024);
+    const safeTemperature = Math.min(Math.max(parseFloat(temperature) || 0.7, 0), 2);
+
     const response = await openrouter.chat.completions.create({
-      model,
+      model: safeModel,
       messages: [{ role: "system", content: SYSTEM_PROMPT }, ...messages],
-      max_tokens: max_tokens ?? 512,
-      temperature,
+      max_tokens: safeMaxTokens,
+      temperature: safeTemperature,
     });
 
     res.json({ reply: response.choices[0].message.content });


### PR DESCRIPTION
## Description
This PR resolves a high-severity "Billing Exhaustion" vulnerability inside the backend AI controller.
Closes #557 
Previously, `backend/controllers/chatController.js` extracted the `model`, `max_tokens`, and `temperature` directly from the incoming HTTP request body and passed them blindly to the OpenRouter API. A malicious user could intercept the network request and alter the JSON payload to utilize incredibly expensive, non-standard AI models (like `gpt-4-32k` or `claude-3-opus`) while setting `max_tokens` to an astronomical number, easily draining the platform's API credits.

### Key Changes
- **Model Whitelisting**: Implemented a strict `ALLOWED_MODELS` array. If an unauthorized model is requested, it silently overrides it to a safe default (`google/gemini-2.5-flash`).
- **Token Clamping**: Added mathematical bounds using `Math.min()` and `Math.max()` to enforce a hard maximum of `1024` generated tokens and a maximum temperature of `2.0`.

## Type of change
- [x] Security Fix (Prevents DoS and Billing Exhaustion attacks)
