### PR TITLE
fix(backend): intercept ZodErrors to return 400 Bad Request and preve…

### DIFF
--- a/backend/middlewares/errorHandler.js
+++ b/backend/middlewares/errorHandler.js
@@ -1,4 +1,16 @@
+import { ZodError } from "zod";
+
 export const errorHandler = (err, req, res, next) => {
+  // Gracefully handle Zod validation errors
+  if (err instanceof ZodError || err.name === "ZodError") {
+    // Downgrade to console.warn to prevent log pollution with massive stack traces
+    console.warn("Validation Error:", err.errors || err.message);
+    return res.status(400).json({ 
+      error: "Validation failed", 
+      details: err.errors 
+    });
+  }
+
   console.error("Unhandled error:", err);
 
   if (res.headersSent) {


### PR DESCRIPTION
## Description
This PR resolves a backend stability bug where routine validation errors falsely triggered critical server crashes.
Closes #558 
Previously, the `validateRequest.js` middleware threw a `ZodError` when request payloads were invalid. Because the global `errorHandler.js` did not know how to parse a `ZodError` (which lacks a `.status` property), it defaulted to a `500 Internal Server Error`. This caused simple frontend mistakes to trigger critical crash alerts, pollute the server logs with massive stack traces, and provide a poor developer experience for API consumers expecting a structured 400 response.

### Key Changes
- **Zod Interception**: The `errorHandler` now explicitly catches any error that is an instance of `ZodError`.
- **Log Downgrade**: Validation errors are downgraded from `console.error` to `console.warn` to prevent log pollution.
- **Proper Status Codes**: Safely extracts the structured validation details from Zod and returns them to the frontend with the correct `400 Bad Request` status code.

## Type of change
- [x] Bug fix (Resolves false-positive 500 errors)
- [x] Developer Experience (DX) Improvement
