### PR TITLE
fix(frontend): add cleanup function to Portfolio component to prevent…

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -108,22 +108,27 @@ const Portfolio = () => {
   }, [form.slug]);
 
   useEffect(() => {
+    let isMounted = true;
+    let timeout: NodeJS.Timeout;
+
     const loadPortfolio = async () => {
       if (!user) {
-        setLoading(false);
+        if (isMounted) setLoading(false);
         return;
       }
 
-      setLoading(true);
+      if (isMounted) setLoading(true);
 
       // Safety timeout: if queries hang, stop loading after 10 seconds
-      const timeout = setTimeout(() => {
-        setLoading(false);
-        toast({
-          title: "Loading timed out",
-          description: "Some data may not have loaded. Please refresh to try again.",
-          variant: "destructive",
-        });
+      timeout = setTimeout(() => {
+        if (isMounted) {
+          setLoading(false);
+          toast({
+            title: "Loading timed out",
+            description: "Some data may not have loaded. Please refresh to try again.",
+            variant: "destructive",
+          });
+        }
       }, 10_000);
 
       try {
@@ -145,6 +150,7 @@ const Portfolio = () => {
         ]);
 
         clearTimeout(timeout);
+        if (!isMounted) return;
 
         const { data: profile, error: profileError } = profileResult;
         const { data: portfolio, error: portfolioError } = portfolioResult;
@@ -194,17 +200,24 @@ const Portfolio = () => {
         }
       } catch (error) {
         clearTimeout(timeout);
+        if (!isMounted) return;
+
         toast({
           title: "Portfolio could not load",
           description: error instanceof Error ? error.message : "Please try again.",
           variant: "destructive",
         });
       } finally {
-        setLoading(false);
+        if (isMounted) setLoading(false);
       }
     };
 
     void loadPortfolio();
+
+    return () => {
+      isMounted = false;
+      clearTimeout(timeout);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.id]);
 


### PR DESCRIPTION
## Description
This PR resolves a frontend memory leak and a bug where rogue UI toasts would unpredictably fire on incorrect pages.
Closes #559 
Previously, the `Portfolio.tsx` component instantiated a 10-second safety timeout during data fetching, but failed to return a `useEffect` cleanup function. If a user quickly navigated away from the portfolio before the timeout finished, the component unmounted but the timeout remained active. Ten seconds later, it would blindly attempt to run `setLoading(false)` (causing a React memory leak warning) and trigger a confusing "Loading timed out" red toast alert while the user was interacting with an entirely different page (like the Dashboard).

### Key Changes
- **Lifecycle Awareness**: Implemented a robust `isMounted` flag pattern inside the `useEffect`.
- **Aggressive Cleanup**: Added a proper cleanup function that synchronously calls `clearTimeout()` and sets `isMounted = false` the exact moment the component is destroyed.
- **Side-Effect Guarding**: Guarded all state updates and UI toasts behind the `isMounted` flag, guaranteeing they can physically never execute on an unmounted component.

## Type of change
- [x] Bug fix (Resolves memory leak and rogue UI toasts)
