### PR TITLE
perf(messages): replace O(n2) realtime database refetch with zero-lat…

### DIFF
--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -420,29 +420,23 @@ const Messages = ({ user }: MessagesProps) => {
           schema: "public",
           table: "profiles",
         },
-        () => {
-          void supabase
-            .from("profiles")
-            .select("*")
-            .neq("id", currentUserId)
-            .order("name", { ascending: true })
-            .limit(100)
-            .then(({ data: profileData }) => {
-              void supabase
-                .from("users")
-                .select("*")
-                .neq("id", currentUserId)
-                .order("name", { ascending: true })
-                .limit(100)
-                .then(({ data: userData }) => {
-                  setProfiles(
-                    mergeProfiles(
-                      (profileData ?? []).map((row) => row as ProfileSummary),
-                      (userData ?? []) as UserRow[]
-                    )
-                  );
-                });
+        (payload) => {
+          if (payload.new && payload.new.id && payload.new.id !== currentUserId) {
+            setProfiles((prev) => {
+              const updated = normalizeProfile(payload.new as ProfileRow);
+              const index = prev.findIndex((p) => p.id === updated.id);
+              
+              if (index === -1) {
+                const newProfiles = [...prev, updated];
+                newProfiles.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+                return newProfiles;
+              }
+              
+              const newProfiles = [...prev];
+              newProfiles[index] = { ...newProfiles[index], ...updated };
+              return newProfiles;
             });
+          }
         }
       )
       .subscribe();


### PR DESCRIPTION
## Description
This PR resolves a catastrophic $O(N^2)$ network cascade ("Thundering Herd" DDoS) vulnerability in the Messaging Dashboard's Realtime architecture.
Closes #575 
Previously, the `messages-profiles-realtime` WebSocket listener triggered a complete, unbounded re-fetch of up to 200 user profiles every single time *any* profile updated in the database. If 100 users were online and one user updated their status, 100 clients would instantly fire 200 database queries at the exact same millisecond, severely throttling the Supabase instance.

### Key Changes
- **Optimistic State Updates**: Completely removed the expensive nested Supabase `.select()` queries from the realtime WebSocket callback. The listener now strictly inspects the raw `payload.new` object broadcasted by the WebSocket and seamlessly patches the specific user's state directly in the React memory space.
- **Zero-Latency UI**: The frontend now updates instantly without waiting for a secondary network round-trip.

## Type of change
- [x] Performance Improvement (Fixes severe Thundering Herd DDoS vulnerability)
