### PR TITLE
perf(messages): add strict 100 limit to payload fetch to prevent brow…

### DIFF
--- a/src/pages/Messages.tsx
+++ b/src/pages/Messages.tsx
@@ -456,10 +456,11 @@ const Messages = ({ user }: MessagesProps) => {
         .from("messages")
         .select("id,sender_id,receiver_id,content,text,message,created_at,read_at")
         .or(`sender_id.eq.${currentUserId},receiver_id.eq.${currentUserId}`)
-        .order("created_at", { ascending: true });
+        .order("created_at", { ascending: false })
+        .limit(100);
 
       if (!error && data) {
-        setMessages(data as MessageRow[]);
+        setMessages((data as MessageRow[]).reverse());
       } else if (error) {
         console.error("Failed to load messages:", error.message);
       }


### PR DESCRIPTION
## Description
This PR resolves a high-severity performance vulnerability where the Direct Messaging Dashboard requested unbounded data payloads.
Closes #576 
Previously, the `loadMessages` query requested *every single message* the user had ever sent or received by using an unbounded `.select()` without any `.limit()` constraints. For power users with thousands of messages, this would crash their browser tab by forcing them to download megabytes of JSON instantly and attempt to render it all into memory at once.

### Key Changes
- **Payload Clamping**: Implemented a strict `.limit(100)` constraint on the initial fetch.
- **Reverse Chronological Rendering**: Modified the query to fetch the newest messages first (`.order("created_at", { ascending: false })`) and invoked `.reverse()` on the client side. This guarantees that the 100 most recent messages are always fetched efficiently, while maintaining the correct chronological UI rendering (oldest at the top, newest at the bottom).

## Type of change
- [x] Performance Improvement (Fixes unbounded payload memory exhaustion)
