### PR TITLE
fix(ai): resolve payload mismatch and implement conversational memory…

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -108,32 +108,32 @@ const callOpenRouter = async ({ messages, maxTokens, temperature = 0.7, response
 
 export const askAI = async (req, res, next) => {
   try {
-    const { question } = req.body;
+    const { messages } = req.body;
 
-    if (!question || typeof question !== "string") {
-      return res.status(400).json({ error: "Invalid question provided" });
+    if (!Array.isArray(messages) || messages.length === 0) {
+      return res.status(400).json({ error: "Invalid messages provided" });
     }
 
-    if (question.length > 2000) {
-      return res.status(400).json({ error: "Question exceeds maximum length of 2000 characters" });
+    const latestMessage = messages[messages.length - 1].content;
+    if (typeof latestMessage !== "string" || latestMessage.length > 2000) {
+      return res.status(400).json({ error: "Message exceeds maximum length of 2000 characters" });
     }
 
-    const maxTokens = budgetResponseTokens(question, ASK_AI_MAX_TOKENS);
+    const maxTokens = budgetResponseTokens(latestMessage, ASK_AI_MAX_TOKENS);
+    
+    const openRouterMessages = [
+      {
+        role: "system",
+        content:
+          "You are an AI peer mentor for students. Answer questions about coding, AI, DSA, and roadmaps in a supportive, clear, and approachable way.",
+      },
+      ...messages.slice(-10).map(m => ({ role: m.role || "user", content: m.content || "" }))
+    ];
 
     const data = await callOpenRouter({
       maxTokens,
       temperature: 0.7,
-      messages: [
-        {
-          role: "system",
-          content:
-            "You are an AI peer mentor for students. Answer questions about coding, AI, DSA, and roadmaps in a supportive, clear, and approachable way.",
-        },
-        {
-          role: "user",
-          content: question,
-        },
-      ],
+      messages: openRouterMessages,
     });
 
     const content = extractMessageContent(data);


### PR DESCRIPTION
## Description
This PR resolves a structural bug where the AI Chatbot was functionally broken in production due to an API payload mismatch.
Closes #583 
Previously, `src/components/Chatbot.tsx` sent a full conversation payload (an array of `{ role, content }` objects) to `/api/ai/ask`, but the backend controller strictly expected a single string payload called `{ question: string }`. This caused the backend to reject every message with a 400 Bad Request error.

### Key Changes
- **Payload Parsing Fix**: Refactored the `askAI` controller to correctly destructure and validate the incoming `{ messages }` array payload sent by the frontend.
- **Conversational Memory**: Implemented an intelligent truncation layer that seamlessly slices the user's conversation history down to the 10 most recent messages, granting the AI full conversational context memory while preventing API token exhaustion.

## Type of change
- [x] Bug Fix (Restores Chatbot functionality and adds LLM conversational memory)
