### PR TITLE
fix(portfolio): enforce slug uniqueness validation prior to upsert to…

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -241,6 +241,32 @@ const Portfolio = () => {
 
     setSaving(true);
 
+    const { data: existingSlugUser, error: slugCheckError } = await supabase
+      .from("portfolio_profiles")
+      .select("profile_id")
+      .eq("slug", slug)
+      .maybeSingle();
+
+    if (slugCheckError) {
+      setSaving(false);
+      toast({
+        title: "Error checking URL",
+        description: "Failed to verify if the URL is available.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    if (existingSlugUser && existingSlugUser.profile_id !== user.id) {
+      setSaving(false);
+      toast({
+        title: "URL already taken",
+        description: "This public URL is already in use by someone else. Please choose another one.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     const payload = {
       profile_id: user.id,
       slug,


### PR DESCRIPTION
## Description
This PR resolves a data integrity vulnerability where the Public Portfolio feature could crash for multiple users due to URL collisions.
Closes #584 
Previously, the `savePortfolio` function blindly upserted the requested URL `slug` into the database without checking if it was already taken. If two users successfully claimed the same slug, any visitor to that URL would trigger a fatal PostgREST error, because `PublicPortfolio.tsx` expected exactly 1 row from `.maybeSingle()` but received 2 rows instead.

### Key Changes
- **Pre-flight Uniqueness Check**: Implemented a pre-flight verification layer right before the database transaction. The system now securely queries the `portfolio_profiles` table to check if the requested slug already exists.
- **Graceful Error Handling**: If the slug is taken by a different user, the system immediately aborts the save operation and presents a user-friendly error toast advising them to choose a different URL.

## Type of change
- [x] Bug Fix (Prevents database URL collisions and fatal UI crashes)
