### PR TITLE
fix: resolve `ReferenceError: getSupabase is not defined` in matchController

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -157,7 +157,7 @@ export const getSupabaseDiscover = async (req, res) => {
     const filter = req.query.filter || "All";
     const limit = Math.min(parseInt(req.query.limit, 10) || 100, 100);
 
-    const supabase = getSupabase();
+    const supabase = getSupabaseAdmin();
 
     const { data: currentUser, error: meError } = await supabase
       .from("profiles")


### PR DESCRIPTION
Resolves #588

### What changed
- Replaced the undefined `getSupabase()` call with the correctly imported `getSupabaseAdmin()` inside `backend/controllers/matchController.js`.

### Why it matters
The `/supabase-discover` API endpoint was completely broken and crashing with a 500 `ReferenceError` every time it was hit because `getSupabase` is not exported by `utils/supabase.js`. This fixes the discovery route.