### PR TITLE
fix(db): make join_session INSERT and counter UPDATE atomic

### DIFF
--- a/supabase/migrations/20260531000001_fix_join_session_status.sql
+++ b/supabase/migrations/20260531000001_fix_join_session_status.sql
@@ -30,19 +30,21 @@ BEGIN
     RAISE EXCEPTION 'Session is full.';
   END IF;
 
-  -- Insert the participant
+  -- Insert the participant and increment the counter atomically within a
+  -- subtransaction so that a failure on either statement rolls back both.
   BEGIN
     INSERT INTO public.session_participants (session_id, user_id)
     VALUES (p_session_id, auth.uid());
+
+    -- Increment the participants count in the same subtransaction so the
+    -- counter always reflects the actual number of rows in session_participants.
+    UPDATE public.sessions
+    SET participants = participants + 1
+    WHERE id = p_session_id;
   EXCEPTION WHEN unique_violation THEN
-    -- Already joined
+    -- Already joined; no counter change needed.
     RETURN;
   END;
-
-  -- Increment the participants count
-  UPDATE public.sessions
-  SET participants = participants + 1
-  WHERE id = p_session_id;
 
 END;
 $$;


### PR DESCRIPTION
## Summary

- `join_session` in `supabase/migrations/20260531000001_fix_join_session_status.sql` performed the participant `INSERT` and the `sessions.participants` counter `UPDATE` as separate sequential statements.
- The `INSERT` was wrapped in a `BEGIN...EXCEPTION` block (to catch duplicate joins), but the `UPDATE` was outside it. If the `UPDATE` failed after the `INSERT` completed, the participant row would exist in `session_participants` while the counter remained stale, allowing additional joins beyond the configured seat limit.
- This PR moves the `UPDATE` inside the same `BEGIN...EXCEPTION` subtransaction. If either statement fails, both are rolled back, keeping the counter consistent with the actual row count.

## Root cause

In PL/pgSQL, a `BEGIN...EXCEPTION` block creates an implicit savepoint (subtransaction). Statements inside it are rolled back together if an exception is raised. Placing the `UPDATE` outside that block meant it was committed independently.

## Fix

Both the `INSERT` and the counter `UPDATE` now execute inside the same `BEGIN...EXCEPTION` block. The `unique_violation` handler fires only when the user has already joined, in which case neither statement has any side effect.

## Test plan

- [ ] A new user calling `join_session` inserts a row in `session_participants` and increments `sessions.participants` by 1
- [ ] A second call from the same user returns without error and does not modify the counter
- [ ] Simulating a failure on the `UPDATE` (e.g. via a lock or constraint) also rolls back the `INSERT`, leaving both tables unchanged
- [ ] Seat limit enforcement still rejects joins when `participants >= seat_limit`
- [ ] Session status checks (scheduled/live only) still work correctly

Closes #460