### PR TITLE
fix(ai-chat): replace raw error.message in 500 responses with generic message

### DIFF
--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -81,8 +81,9 @@ serve(async (req) => {
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 200 }
     )
   } catch (error) {
+    console.error('ai-chat error:', error)
     return new Response(
-      JSON.stringify({ error: error.message }),
+      JSON.stringify({ error: 'An unexpected error occurred. Please try again.' }),
       { headers: { ...corsHeaders, 'Content-Type': 'application/json' }, status: 500 }
     )
   }


### PR DESCRIPTION
## Summary

- The `catch` block in `supabase/functions/ai-chat/index.ts` returned `error.message` directly in the HTTP 500 response body.
- Deno runtime errors and upstream `fetch` failures regularly include the full OpenRouter API URL, TLS handshake details, DNS errors, rate-limit payloads, and model identifiers — all of which are infrastructure details that should not be visible to clients.
- This PR logs the full error server-side and returns a generic user-facing message instead, consistent with the pattern already used for the missing `OPENROUTER_API_KEY` check earlier in the same function.

## Changes

`supabase/functions/ai-chat/index.ts` — catch block:

```diff
- } catch (error) {
-   return new Response(
-     JSON.stringify({ error: error.message }),
+ } catch (error) {
+   console.error('ai-chat error:', error)
+   return new Response(
+     JSON.stringify({ error: 'An unexpected error occurred. Please try again.' }),
```

## Test plan

- [ ] Configuring an invalid `OPENROUTER_API_KEY` and sending a request returns `{"error":"An unexpected error occurred. Please try again."}` with status 500, not raw upstream error text
- [ ] The full error (including upstream URL and details) appears in Supabase function logs via `console.error`
- [ ] Normal successful requests are unaffected
- [ ] The existing 401 and 400 error responses are unaffected

Closes #461