### PR TITLE
fix(match): repair /supabase-discover endpoint broken by undefined getSupabase (#646) [GSSoC'26]

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -153,9 +153,9 @@ export const getSupabaseDiscover = async (req, res) => {
     const filter = req.query.filter || "All";
     const limit = Math.min(parseInt(req.query.limit, 10) || 100, 100);
 
-    const supabase = getSupabase();
+    const supabaseAdmin = getSupabaseAdmin();
 
-    const { data: currentUser, error: meError } = await supabase
+    const { data: currentUser, error: meError } = await supabaseAdmin
       .from("profiles")
       .select("*")
       .eq("id", userId)
@@ -165,7 +165,7 @@ export const getSupabaseDiscover = async (req, res) => {
       return res.status(404).json({ success: false, message: "User profile not found" });
     }
 
-    let query = supabase.from("profiles").select("*").neq("id", userId).limit(100);
+    let query = supabaseAdmin.from("profiles").select("*").neq("id", userId).limit(100);
 
     if (search.trim()) {
       const safeSearch = search.trim().replace(/"/g, '""');


### PR DESCRIPTION
## Summary

Fixes the broken `/api/match/supabase-discover` endpoint by replacing a call to a non-existent `getSupabase()` helper with the already-imported `getSupabaseAdmin()`.

Closes #646

## Root cause

In `backend/controllers/matchController.js`, only `getSupabaseAdmin` is imported:

```js
import { getSupabaseAdmin } from "../utils/supabase.js";
```

But on line 156, the controller called the undefined helper:

```js
const supabase = getSupabase();   // ← undefined, throws ReferenceError
```

`getSupabase` is not exported from `backend/utils/supabase.js` (only `getSupabaseAdmin` is). Every request to `GET /api/match/supabase-discover` threw `ReferenceError: getSupabase is not defined`, returning 500.

The variable name on line 156 was already `supabase` while every other Supabase call in the same file uses `supabaseAdmin` (lines 67, 75), strongly suggesting this was a refactor regression where the `Admin` suffix was accidentally dropped.

## Fix

```diff
- const supabase = getSupabase();
+ const supabaseAdmin = getSupabaseAdmin();
```

Both `getSupabaseDiscover` call sites updated (lines 156, 168).

**Total diff:** 1 file, 3 insertions(+), 3 deletions(-).

## RLS consideration

Using `getSupabaseAdmin()` bypasses Row Level Security. This is safe in this specific function because every query is already user-scoped:

- `.from("profiles").select("*").eq("id", userId)` — only fetches the current user
- `.from("profiles").select("*").neq("id", userId).limit(100)` — only fetches peers, excluding self

If finer-grained RLS is needed later (e.g., to mask private profile fields), the right architectural move would be adding a `getSupabase(jwt)` helper in `backend/utils/supabase.js` that returns a per-request user-context client and passing `req.headers.authorization` through. Happy to follow up with that in a separate PR if desired.

## Test plan

- [x] `node --check backend/controllers/matchController.js` — clean
- [x] No `\bsupabase\b` references remain in the file (only `supabaseAdmin`)
- [ ] Vitest suite: `npm test` (could not run locally in this environment due to dependency-install timeouts — CI will exercise it)
- [ ] Manual: `curl -H "Authorization: Bearer <jwt>" http://localhost:8080/api/match/supabase-discover` should now return 200 with results instead of 500

## Relationship to other issues

Same class of refactor regression as #621 ("Missing exports in rateLimiter.js - matchRoutes crashes"), which was already fixed.