### PR TITLE
[GSSoC'26] fix(auth): use timing-safe JWT signature compare (#677)

### DIFF
--- a/backend/middlewares/requireAuth.js
+++ b/backend/middlewares/requireAuth.js
@@ -25,7 +25,13 @@ const verifyLocalJwt = (token, secret) => {
       .replace(/\//g, "_")
       .replace(/=/g, "");
 
-    if (expectedSignature !== signatureB64) {
+    const expectedSignatureBuffer = Buffer.from(expectedSignature);
+    const signatureBuffer = Buffer.from(signatureB64);
+
+    if (
+      expectedSignatureBuffer.length !== signatureBuffer.length ||
+      !crypto.timingSafeEqual(expectedSignatureBuffer, signatureBuffer)
+    ) {
       return null;
     }
 

--- a/backend/tests/requireAuth.test.js
+++ b/backend/tests/requireAuth.test.js
@@ -1,0 +1,72 @@
+import crypto from "crypto";
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { errorHandler } from "../middlewares/errorHandler.js";
+
+vi.mock("../utils/supabase.js", () => ({
+  getSupabaseAdmin: vi.fn(() => ({
+    auth: {
+      getUser: vi.fn(),
+    },
+  })),
+}));
+
+const base64UrlEncode = (value) =>
+  Buffer.from(JSON.stringify(value))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+const createLocalJwt = (payload, secret) => {
+  const header = base64UrlEncode({ alg: "HS256", typ: "JWT" });
+  const body = base64UrlEncode(payload);
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(`${header}.${body}`)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+  return `${header}.${body}.${signature}`;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("requireAuth local JWT verification", () => {
+  it("uses a timing-safe comparison for valid local JWT signatures", async () => {
+    vi.stubEnv("SUPABASE_JWT_SECRET", "test-secret");
+    const timingSafeEqualSpy = vi.spyOn(crypto, "timingSafeEqual");
+    const { requireAuth } = await import("../middlewares/requireAuth.js");
+    const token = createLocalJwt(
+      {
+        sub: "user-123",
+        email: "learner@example.com",
+        exp: Math.floor(Date.now() / 1000) + 60,
+        role: "authenticated",
+      },
+      "test-secret",
+    );
+
+    const app = express();
+    app.get("/me", requireAuth, (req, res) => {
+      res.json({ user: req.user });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app).get("/me").set("Authorization", `Bearer ${token}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.user).toMatchObject({
+      id: "user-123",
+      email: "learner@example.com",
+      role: "authenticated",
+    });
+    expect(timingSafeEqualSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What changed
- Replaced direct HMAC signature string comparison in local JWT verification with `crypto.timingSafeEqual`.
- Added a backend regression test proving valid local JWT verification uses the timing-safe comparison path.

## Why
`verifyLocalJwt()` compared the expected HMAC signature and token signature with `!==`, which can leak comparison timing information. Using length-checked buffers with `crypto.timingSafeEqual` removes the byte-by-byte early-exit behavior.

## Tests
- `npm test -- backend/tests/requireAuth.test.js`
- `npm test`
- `npm run lint` (passes with existing warnings only)

## AI assistance
AI assistance was used to inspect the assigned issue, implement the fix, and add the regression test; the changes were reviewed and verified locally.

Closes #677
