### PR TITLE
Fix: SQL Injection in Supabase Peer Discovery (#688)

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -168,8 +168,10 @@ export const getSupabaseDiscover = async (req, res) => {
     let query = supabaseAdmin.from("profiles").select("*").neq("id", userId).limit(100);
 
     if (search.trim()) {
-      const safeSearch = search.trim().replace(/"/g, '""');
-      query = query.or(`name.ilike."%${safeSearch}%",skills.ilike."%${safeSearch}%"`);
+      const safeSearch = search.trim().replace(/[",()]/g, '');
+      if (safeSearch) {
+        query = query.or(`name.ilike."%${safeSearch}%",skills.ilike."%${safeSearch}%"`);
+      }
     }
 
     if (filter !== "All") {


### PR DESCRIPTION
This PR resolves issue #688 by stripping out special PostgREST characters (such as commas and parentheses) from the search input before it is interpolated into the `.or()` filter string. This completely prevents attackers from bypassing the double-quote escaping to inject arbitrary SQL logic.