### PR TITLE
fixed positioning of streak and problem solved card

### DIFF
--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -95,7 +95,7 @@ export function Hero({ streak }: HeroProps) {
         <motion.div
           animate={{ y: [0, -10, 0] }}
           transition={{ duration: 4, repeat: Infinity }}
-          className="absolute -left-8 top-10 rounded-3xl border border-white/10 bg-white/10 p-5 backdrop-blur-2xl"
+          className="absolute -left-16 top-32 z-0 rounded-3xl border border-white/10 bg-white/10 p-5 backdrop-blur-2xl md:top-36"
         >
           <div className="flex items-center gap-3">
             <Flame className="text-cyan-400" />
@@ -111,7 +111,7 @@ export function Hero({ streak }: HeroProps) {
         <motion.div
           animate={{ y: [0, 12, 0] }}
           transition={{ duration: 5, repeat: Infinity }}
-          className="absolute bottom-10 right-0 rounded-3xl border border-white/10 bg-white/10 p-5 backdrop-blur-2xl"
+          className="absolute -bottom-10 right-0 z-20 rounded-3xl border border-white/10 bg-white/10 p-5 backdrop-blur-2xl md:-bottom-8"
         >
           <div className="flex items-center gap-3">
             <Brain className="text-cyan-400" />


### PR DESCRIPTION
## Description 

The large group illustration overlaps and partially hides important interface elements, including the "Your Streak – 1 Days" card and the "Solved" card. This reduces visibility and makes the dashboard information difficult to read.

Closes #684 

## Type of fix 

- [x] UI
- [x] Enhancement

## Changes Made 

- The streak card now sits a bit higher, is placed behind the illustration (z-0), and shifted farther left so the text should remain visible instead of being covered.
- Lower than before z-20, so they render above the hero illustration instead of being covered by it

<img width="1072" height="765" alt="Screenshot 2026-06-03 203400" src="https://github.com/user-attachments/assets/db0bd084-d16f-4d8d-adb8-7fb84172e623" />


## Test 

- [x] Check the changes on a local browser 
- [x]  ran "npm run build"
