### PR TITLE
fix: move session tokens from localStorage to httpOnly cookies (#692)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,19 +1,21 @@
 import { createContext, useEffect, useState, ReactNode, useCallback, useRef } from "react";
 import { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
+import { API_BASE_URL } from "@/config/api";
 
 const syncSessionCookie = async (session: Session | null) => {
   try {
-    const API_BASE_URL = import.meta.env.VITE_API_URL || "http://localhost:8080";
     if (session?.access_token) {
       await fetch(`${API_BASE_URL}/api/auth/set-cookie`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ access_token: session.access_token }),
       });
     } else {
       await fetch(`${API_BASE_URL}/api/auth/clear-cookie`, {
         method: "POST",
+        credentials: "include",
       });
     }
   } catch (err) {

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -259,6 +259,7 @@ export function useSessions(user: any) {
           "Content-Type": "application/json",
           ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
         },
+        credentials:"include",
         body: JSON.stringify({ messages }),
       });
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -109,7 +109,8 @@ const Dashboard = () => {
       const res = await fetch(`${API_BASE_URL}/api/match/supabase-discover?limit=3`, {
         headers: {
           Authorization: `Bearer ${session.access_token}`
-        }
+        },
+        credentials:"include"
       });
       
       const data = await res.json();

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -183,7 +183,8 @@ const Discover = () => {
           const res = await fetch(`${API_BASE_URL}/api/match/supabase-discover?${searchParams.toString()}`, {
             headers: {
               Authorization: `Bearer ${session.access_token}`
-            }
+            },
+            credentials:"include"
           });
           const apiData = await res.json();
           if (apiData.success) {

--- a/src/pages/MockInterview.tsx
+++ b/src/pages/MockInterview.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { useAuth } from "@/contexts/useAuth";
+import { supabase } from "@/integrations/supabase/client";
 import { API_BASE_URL } from "@/config/api";
 import { toast } from "sonner";
 import { Loader2, Send, Bot, User, CheckCircle2, AlertTriangle, ArrowRight } from "lucide-react";
@@ -56,13 +57,14 @@ const MockInterview = () => {
   const sendMessage = async (currentMessages: Message[]) => {
     setLoading(true);
     try {
-      const token = localStorage.getItem("token");
+      const { data: { session } } = await supabase.auth.getSession();
       const response = await fetch(`${API_BASE_URL}/api/ai/mock-interview/chat`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
         },
+        credentials: "include",
         body: JSON.stringify({ messages: currentMessages, role }),
       });
 
@@ -96,13 +98,14 @@ const MockInterview = () => {
     setIsFinished(true);
     setGeneratingReport(true);
     try {
-      const token = localStorage.getItem("token");
+      const { data: { session } } = await supabase.auth.getSession();
       const response = await fetch(`${API_BASE_URL}/api/ai/mock-interview/report`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
         },
+        credentials: "include",
         body: JSON.stringify({ messages }),
       });
 

--- a/src/pages/aipage.tsx
+++ b/src/pages/aipage.tsx
@@ -44,6 +44,7 @@ const AIPage = () => {
           "Content-Type": "application/json",
           Authorization: `Bearer ${session?.access_token}`,
         },
+        credentials:"include",
         body: JSON.stringify({
           question: prompt,
         }),


### PR DESCRIPTION
Closes #692

## Changes Made
- AuthContext.tsx: Added credentials: "include" + unified API_BASE_URL import
- MockInterview.tsx: Replaced localStorage.getItem("token") with Supabase session
- Discover.tsx: Added credentials: "include"
- Dashboard.tsx: Added credentials: "include"  
- aipage.tsx: Added credentials: "include"
- useSessions.ts: Added credentials: "include"

## Testing
- Login → DevTools → Application → Cookies → confirm access_token cookie present with HttpOnly flag
- Confirm no token key in localStorage used for API auth
- Confirm all API calls still work correctly