### PR TITLE
fix: sanitize discover search parameter to prevent PostgREST filter injection

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -172,9 +172,10 @@ export const getSupabaseDiscover = async (req, res) => {
       .limit(100);
 
     if (search.trim()) {
-      const safeSearch = search.trim().replace(/[",()]/g, '');
+      const safeSearch = search.trim().replace(/[^\w\s-]/g, "");
       if (safeSearch) {
-        query = query.or(`name.ilike."%${safeSearch}%",skills.ilike."%${safeSearch}%"`);
+        const pattern = `%${safeSearch.replace(/['"]/g, "")}%`;
+        query = query.or(`name.ilike."${pattern}",skills.ilike."${pattern}"`);
       }
     }
 


### PR DESCRIPTION
## Summary

This PR fixes a potential PostgREST filter injection vulnerability in the `/api/match/discover` endpoint.

### Changes Made

* Sanitized the `search` query parameter using a whitelist approach.
* Removed characters that could be interpreted as PostgREST filter operators before constructing the `.or()` query.
* Preserved normal alphanumeric, whitespace, underscore (`_`), and hyphen (`-`) based searches.

### Security Impact

Previously, the search parameter was directly concatenated into a Supabase `.or()` filter string while only escaping a limited set of characters. This could allow crafted input containing PostgREST syntax characters to manipulate the generated query.

The updated implementation restricts the input to safe characters, preventing injection of arbitrary PostgREST operators while maintaining the intended search functionality.

### Testing

Tested with normal search inputs:

* `javascript`
* `react developer`
* `node-js`

Closes #705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query sanitization and pattern matching in the match discovery feature to enhance search reliability and consistency when filtering potential matches by name or skills. The update ensures more robust and secure handling of search inputs and special characters, leading to more accurate and predictable search results for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->