### PR TITLE
fix: add aria-label to icon-only buttons for screen reader accessibility

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -250,7 +250,8 @@ const Navbar = () => {
                 variant="ghost"
                 size="icon"
                 className="h-10 w-10 rounded-xl text-white hover:bg-white/10"
-                title="Theme: Dark (Default)"
+                aria-label="Change theme"
+                title="Change theme"
               >
                 <Moon className="h-5 w-5 text-cyan-400" />
               </Button>
@@ -389,10 +390,10 @@ const Navbar = () => {
         <button
           onClick={() => setMobileOpen(!mobileOpen)}
           className="rounded-lg border border-white/10 bg-white/5 p-3 text-white md:hidden active:scale-95"
+          aria-label={mobileOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileOpen}
         >
-
           {mobileOpen ? <X /> : <Menu />}
-
         </button>
 
       </div>

--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -129,6 +129,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
             size="icon"
             className={cn(isSaved && "text-primary")}
             onClick={handleSave}
+            aria-label={isSaved ? "Unsave resource" : "Save resource"}
             title={isSaved ? "Unsave resource" : "Save resource"}
           >
             <Bookmark className="h-5 w-5" fill={isSaved ? "currentColor" : "none"} />

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -491,6 +491,7 @@ const Portfolio = () => {
                         size="icon"
                         variant="ghost"
                         className="h-8 w-8 text-slate-300 hover:bg-white/10 hover:text-white"
+                        aria-label={`Remove project ${index + 1}`}
                         onClick={() => setForm({ ...form, projects: form.projects.filter((_, itemIndex) => itemIndex !== index) })}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -551,6 +552,7 @@ const Portfolio = () => {
                         size="icon"
                         variant="ghost"
                         className="h-8 w-8 text-slate-300 hover:bg-white/10 hover:text-white"
+                        aria-label={`Remove achievement ${index + 1}`}
                         onClick={() => setForm({ ...form, achievements: form.achievements.filter((_, itemIndex) => itemIndex !== index) })}
                       >
                         <Trash2 className="h-4 w-4" />
@@ -591,7 +593,7 @@ const Portfolio = () => {
                 <p className="text-xs uppercase tracking-wide text-slate-500">Shareable URL</p>
                 <div className="mt-2 flex items-center gap-2">
                   <p className="min-w-0 flex-1 truncate text-sm text-cyan-200">{publicUrl || "Set a slug to create a URL"}</p>
-                  <Button type="button" size="icon" variant="ghost" className="h-8 w-8 text-white hover:bg-white/10" onClick={copyShareLink}>
+                  <Button type="button" size="icon" variant="ghost" className="h-8 w-8 text-white hover:bg-white/10" aria-label="Copy shareable link" onClick={copyShareLink}>
                     <Copy className="h-4 w-4" />
                   </Button>
                 </div>

--- a/src/pages/aipage.tsx
+++ b/src/pages/aipage.tsx
@@ -188,6 +188,7 @@ const AIPage = () => {
 
           <button
             onClick={sendMessage}
+            aria-label="Send message"
             className="bg-cyan-400 hover:bg-cyan-300 transition text-black p-4 rounded-2xl"
           >
             <Send size={20} />


### PR DESCRIPTION
Closes #731

## Summary

Multiple buttons across the app rendered only an icon with no visible text and no `aria-label` attribute. Screen readers announced these as simply "button" with no description, making them completely inaccessible to users relying on assistive technology. WCAG 2.1 Level AA (SC 4.1.2) requires all interactive elements to have an accessible name.

## What was the issue

The following icon-only buttons had no accessible name:
- `src/components/Navbar.tsx` — theme toggle button (Moon icon) had only a `title` attribute; mobile hamburger/close button had no label and no `aria-expanded` state
- `src/pages/Portfolio.tsx` — delete project buttons (Trash2 icon), delete achievement buttons (Trash2 icon), and copy share link button (Copy icon) had no label
- `src/components/resources/ResourceCard.tsx` — save/bookmark button had only a `title` attribute, no `aria-label`
- `src/pages/aipage.tsx` — send message button (Send icon) had no label

## What was the fix

Added `aria-label` to each icon-only button with a descriptive action name:

| File | Button | aria-label added |
|---|---|---|
| `Navbar.tsx` | Theme toggle | `"Change theme"` |
| `Navbar.tsx` | Mobile menu | `"Open menu"` / `"Close menu"` (dynamic) + `aria-expanded` |
| `Portfolio.tsx` | Delete project | `"Remove project N"` (dynamic, N = 1-based index) |
| `Portfolio.tsx` | Delete achievement | `"Remove achievement N"` (dynamic) |
| `Portfolio.tsx` | Copy share link | `"Copy shareable link"` |
| `ResourceCard.tsx` | Save/unsave | `"Save resource"` / `"Unsave resource"` (matches existing `title`) |
| `aipage.tsx` | Send message | `"Send message"` |

The mobile menu button also received `aria-expanded={mobileOpen}` following the WCAG disclosure widget pattern, so screen readers announce the open/closed state of the menu.

## Testing

1. Enable VoiceOver (Mac: `Cmd+F5`) or NVDA
2. Tab through buttons in the Navbar, Portfolio page, Resources page, and AI page
3. Confirm each previously-unlabelled button now announces a meaningful action
4. Run `node_modules/.bin/tsc --noEmit` — zero TypeScript errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility across the application by adding descriptive labels to icon-only buttons in the navigation menu, portfolio management, resource cards, and chat functionality. These improvements provide better screen reader support and keyboard navigation, ensuring the application is more accessible for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->