### PR TITLE
[Critical] fix: add retry logic and cookieSynced state to syncSessionCookie — closes #751

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,31 +3,40 @@ import { Session, User } from "@supabase/supabase-js";
 import { supabase } from "@/integrations/supabase/client";
 import { API_BASE_URL } from "@/config/api";
 
-const syncSessionCookie = async (session: Session | null) => {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 3000);
+const syncSessionCookie = async (session: Session | null, setSynced?: (v: boolean) => void) => {
+  const MAX_RETRIES = 3;
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 3000);
 
-    if (session?.access_token) {
-      await fetch(`${API_BASE_URL}/api/auth/set-cookie`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
-        signal: controller.signal,
-        body: JSON.stringify({ access_token: session.access_token }),
-      });
-    } else {
-      await fetch(`${API_BASE_URL}/api/auth/clear-cookie`, {
-        method: "POST",
-        credentials: "include",
-        signal: controller.signal,
-      });
+      if (session?.access_token) {
+        await fetch(`${API_BASE_URL}/api/auth/set-cookie`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          signal: controller.signal,
+          body: JSON.stringify({ access_token: session.access_token }),
+        });
+      } else {
+        await fetch(`${API_BASE_URL}/api/auth/clear-cookie`, {
+          method: "POST",
+          credentials: "include",
+          signal: controller.signal,
+        });
+      }
+
+      clearTimeout(timeoutId);
+      setSynced?.(true);
+      return;
+    } catch (err) {
+      console.warn(`Cookie sync attempt ${attempt + 1}/${MAX_RETRIES} failed:`, err);
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+      }
     }
-
-    clearTimeout(timeoutId);
-  } catch (err) {
-    console.error("Failed to sync session cookie:", err);
   }
+  setSynced?.(false);
 };
 export interface AuthContextType {
   session: Session | null;
@@ -35,6 +44,8 @@ export interface AuthContextType {
   loading: boolean;
   needsOnboarding: boolean;
   setNeedsOnboarding: (needs: boolean) => void;
+  cookieSynced: boolean;
+  retrySyncSessionCookie: () => Promise<void>;
   signUp: (email: string, password: string, name: string) => Promise<{ error: Error | null }>;
   signIn: (email: string, password: string) => Promise<{ error: Error | null }>;
   signOut: () => Promise<void>;
@@ -47,6 +58,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [needsOnboarding, setNeedsOnboarding] = useState(false);
+  const [cookieSynced, setCookieSynced] = useState(true);
   const isCreatingProfile = useRef(false);
 
   /**
@@ -125,7 +137,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
         setSession(session);
         setUser(session?.user ?? null);
         
-        await syncSessionCookie(session);
+        await syncSessionCookie(session, setCookieSynced);
 
         if (session?.user) {
           // PERF: Read first to avoid firing a database write on every single page load
@@ -175,7 +187,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
           // gotrue-js awaits every onAuthStateChange subscriber before resolving
           // the signUp/signIn promise, so awaiting a backend call that may hang
           // would delay the caller by the full timeout duration.
-          syncSessionCookie(session);
+          syncSessionCookie(session, setCookieSynced);
 
           if (session?.user) {
             try {
@@ -255,6 +267,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
   };
 
+  const retrySyncSessionCookie = useCallback(async () => {
+    await syncSessionCookie(session, setCookieSynced);
+  }, [session]);
+
   const signOut = async () => {
     try {
       const { error } = await supabase.auth.signOut();
@@ -265,7 +281,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   };
 
   return (
-    <AuthContext.Provider value={{ session, user, loading, needsOnboarding, setNeedsOnboarding, signUp, signIn, signOut }}>
+    <AuthContext.Provider value={{ session, user, loading, needsOnboarding, setNeedsOnboarding, cookieSynced, retrySyncSessionCookie, signUp, signIn, signOut }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Description
Fixes silent cookie sync failures in `AuthContext.tsx` where `syncSessionCookie` used an empty catch block that only logged to console, causing silent authentication failures on backend API calls that depend on the HttpOnly cookie.

## Related Issue
Closes #751

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- **`src/contexts/AuthContext.tsx`**: 
  - Added retry logic with exponential backoff (3 attempts, 1s/2s delays) to `syncSessionCookie`
  - Added `cookieSynced` state variable tracking whether sync succeeded
  - Added `retrySyncSessionCookie` callback exposed via context for manual retry
  - Updated both call sites (initial session load and auth state change) to pass the state setter

## Testing
1. Start the app with the backend down — verify `cookieSynced` becomes `false` after retries
2. Start the backend — use `retrySyncSessionCookie()` to re-sync
3. Normal login/logout flow — verify cookie syncs on first attempt as before

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of session cookie synchronization with automatic retry logic and enhanced error handling for failed synchronization attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->