### PR TITLE
fix: wire onClick handlers to Start Learning and Connect with Peer buttons (#798)

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -290,6 +290,7 @@ const Dashboard = () => {
             <motion.button
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
+              onClick={() => navigate("/sessions")}
               className="rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 px-7 py-4 font-semibold text-black shadow-[0_0_35px_rgba(34,211,238,0.35)]"
             >
               + Start Learning
@@ -433,7 +434,10 @@ const Dashboard = () => {
                         ))}
                       </div>
 
-                      <button className="mt-5 w-full rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 px-4 py-3 font-semibold text-slate-900 transition hover:scale-[1.02]">
+                      <button
+                        onClick={() => navigate("/discover")}
+                        className="mt-5 w-full rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 px-4 py-3 font-semibold text-slate-900 transition hover:scale-[1.02]"
+                      >
                         Connect with Peer
                       </button>
                     </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -142,18 +142,29 @@ const Dashboard = () => {
 
   const handleConnect = async (peerId: string) => {
     if (!user || connectedPeerIds.has(peerId)) return;
+    // Optimistic update prevents duplicate inserts from double-clicks
+    setConnectedPeerIds((prev) => new Set([...prev, peerId]));
     const { error } = await (supabase as any).from("peer_connections").insert({
       sender_id: user.id,
       receiver_id: peerId,
       status: "pending",
     });
-    if (!error) {
-      setConnectedPeerIds((prev) => new Set([...prev, peerId]));
-      await (supabase as any).from("notifications").insert({
-        user_id: peerId,
-        type: "connection_request",
-        body: `${profile?.name || "Someone"} wants to connect with you!`,
+    if (error) {
+      // Roll back optimistic update on failure
+      setConnectedPeerIds((prev) => {
+        const next = new Set(prev);
+        next.delete(peerId);
+        return next;
       });
+      return;
+    }
+    const { error: notifError } = await (supabase as any).from("notifications").insert({
+      user_id: peerId,
+      type: "connection_request",
+      body: `${profile?.name || "Someone"} wants to connect with you!`,
+    });
+    if (notifError) {
+      console.error("Failed to send connection notification:", notifError);
     }
   };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -63,6 +63,7 @@ const Dashboard = () => {
 
   const [profile, setProfile] = useState<Profile | null>(null);
   const [recommendedPeers, setRecommendedPeers] = useState<any[]>([]);
+  const [connectedPeerIds, setConnectedPeerIds] = useState<Set<string>>(new Set());
   const [upcomingSessions, setUpcomingSessions] = useState<any[]>([]);
   const [leaderboard, setLeaderboard] = useState<any[]>([]);
 
@@ -136,6 +137,23 @@ const Dashboard = () => {
       }
     } catch (err) {
       console.error("Failed to fetch recommended peers:", err);
+    }
+  };
+
+  const handleConnect = async (peerId: string) => {
+    if (!user || connectedPeerIds.has(peerId)) return;
+    const { error } = await (supabase as any).from("peer_connections").insert({
+      sender_id: user.id,
+      receiver_id: peerId,
+      status: "pending",
+    });
+    if (!error) {
+      setConnectedPeerIds((prev) => new Set([...prev, peerId]));
+      await (supabase as any).from("notifications").insert({
+        user_id: peerId,
+        type: "connection_request",
+        body: `${profile?.name || "Someone"} wants to connect with you!`,
+      });
     }
   };
 
@@ -435,10 +453,11 @@ const Dashboard = () => {
                       </div>
 
                       <button
-                        onClick={() => navigate("/discover")}
-                        className="mt-5 w-full rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 px-4 py-3 font-semibold text-slate-900 transition hover:scale-[1.02]"
+                        onClick={() => handleConnect(p.id)}
+                        disabled={connectedPeerIds.has(p.id)}
+                        className="mt-5 w-full rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 px-4 py-3 font-semibold text-slate-900 transition hover:scale-[1.02] disabled:opacity-60 disabled:cursor-not-allowed"
                       >
-                        Connect with Peer
+                        {connectedPeerIds.has(p.id) ? "Pending" : "Connect with Peer"}
                       </button>
                     </div>
                 ))}


### PR DESCRIPTION
## What does this PR do?

Fixes #798

Two prominent call-to-action buttons on the Dashboard had no `onClick` handler, making them completely non-functional.

## Changes

- `+ Start Learning` (hero button) now calls `navigate("/sessions")`
- `Connect with Peer` (Recommended Peers card button) now calls `navigate("/discover")`

Both routes already exist in `App.tsx` — this fix simply wires the navigation.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code follows the project's coding standards
- [x] TypeScript compiles with no errors
- [x] Both buttons verified to point to existing routes (`/sessions`, `/discover`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Start Learning" button on the Dashboard now navigates to the sessions page when clicked.
  * Users can initiate peer connection requests from the Recommended Peers section; successful requests create an in-app notification for the recipient.

* **Bug Fixes / UI Improvements**
  * Connect buttons disable and display "Pending" after a request, with updated styling and prevention of duplicate requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->