### PR TITLE
fix: prevent XP farming by deduplicating handleJoinVideo awards (#799)

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -27,6 +27,7 @@ export function useSessions(user: any) {
   const channelRef = useRef<any>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout>>();
   const lastMoveRef = useRef(0);
+  const awardedSessionsRef = useRef<Set<string | number>>(new Set());
 
   useEffect(() => {
     const fetchSessions = async () => {
@@ -287,10 +288,11 @@ export function useSessions(user: any) {
 
   const handleJoinVideo = useCallback(() => {
     setIsVideoActive(true);
-    // Simple mock logic for preventing double XP without using localStorage here directly unless needed
-    // Assuming backend or component handles it or we could use the old local storage logic if needed
-    awardXP({ activity: 'session_join' });
-  }, [awardXP]);
+    if (selectedSession && !awardedSessionsRef.current.has(selectedSession.id)) {
+      awardedSessionsRef.current.add(selectedSession.id);
+      awardXP({ activity: 'session_join' });
+    }
+  }, [awardXP, selectedSession]);
 
   return {
     sessions,

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -199,6 +199,7 @@ export function useSessions(user: any) {
         toast({ title: "Success! 🎉", description: "You have joined the session." });
 
         if (!existingParticipant) {
+          awardedSessionsRef.current.add(sessionId);
           awardXP({ activity: "session_join" });
         }
       }


### PR DESCRIPTION
## What does this PR do?

Fixes #799

`handleJoinVideo` called `awardXP({ activity: 'session_join' })` unconditionally on every click. A user could farm unlimited XP by repeatedly clicking the Join Video button. The comment in the original code acknowledged this was unhandled.

## Changes

- Added `awardedSessionsRef` — a `useRef<Set>` that tracks session IDs that have already received XP within the current hook lifecycle
- `handleJoinVideo` now only calls `awardXP` if the current session ID is not in the set, then adds it
- Added `selectedSession` to the `useCallback` dependency array accordingly

This mirrors the deduplication pattern already used in `handleJoinSession`, which checks `existingParticipant` before awarding XP.

## Type of change

- [x] Bug fix (security / gamification integrity)

## Checklist

- [x] Code follows the project's coding standards
- [x] TypeScript compiles with no errors
- [x] Deduplication is consistent with `handleJoinSession` pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where users could receive duplicate XP for the same session. XP for joining a session is now awarded only once per unique session, preventing repeated rewards if a user re-enters or rejoins the same session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->