### PR TITLE
fix: check response.ok and surface API errors in chatbot UI (#800)

### DIFF
--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -118,10 +118,9 @@ export default function Chatbot() {
 
       await supabase.from("chat_messages").insert([botMsg]);
     } catch (err) {
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", text: "Something went wrong. Please try again." },
-      ]);
+      const errorMsg = { role: "assistant", text: "Something went wrong. Please try again.", user_id: userId };
+      setMessages((prev) => [...prev, errorMsg]);
+      await supabase.from("chat_messages").insert([errorMsg]);
     }
 
     setLoading(false);

--- a/src/components/Chatbot.tsx
+++ b/src/components/Chatbot.tsx
@@ -83,6 +83,10 @@ export default function Chatbot() {
         }),
       });
 
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+
       const data = await res.json();
 
       const botReply = data?.reply || "No response 😅";
@@ -114,7 +118,10 @@ export default function Chatbot() {
 
       await supabase.from("chat_messages").insert([botMsg]);
     } catch (err) {
-      console.error("AI error:", err);
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", text: "Something went wrong. Please try again." },
+      ]);
     }
 
     setLoading(false);


### PR DESCRIPTION
## What does this PR do?

Fixes #800

The Chatbot's `sendMessage` function called `res.json()` without first checking `res.ok`. When the AI backend returned a 4xx or 5xx response, the error was silently swallowed — the `catch` block only logged to the console, and users saw nothing.

## Changes

- Added `if (!res.ok) throw new Error(...)` immediately after `fetch` resolves, before attempting to parse the body
- Updated the `catch` block to append a user-visible error message (`"Something went wrong. Please try again."`) as an assistant message in the chat, so users know to retry instead of assuming silence is a normal reply
- Removed the `console.error` that leaked internal error details

## Type of change

- [x] Bug fix

## Checklist

- [x] Code follows the project's coding standards
- [x] TypeScript compiles with no errors
- [x] No internal error details are exposed to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat error handling: failed AI responses are now detected, a friendly assistant error message is shown in the conversation ("Something went wrong. Please try again."), and that error message is persisted so it remains visible to users instead of disappearing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->