### PR TITLE
fix: remove console.log/error leaking XP amounts and activity types in production (#801)

### DIFF
--- a/src/hooks/useAwardXP.ts
+++ b/src/hooks/useAwardXP.ts
@@ -28,14 +28,12 @@ export const useAwardXP = () => {
       // but the UI queries will be invalidated and refetched automatically.
       return { awarded: xpToAward };
     },
-    onSuccess: (data) => {
-      // Invalidate both profile and leaderboard queries to instantly sync UI
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["profile"] });
       queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
-      console.log(`Awarded ${data.awarded} XP!`);
     },
-    onError: (error) => {
-      console.error("Failed to award XP:", error);
+    onError: () => {
+      // Errors are handled by the calling component via the mutation's error state
     }
   });
 };

--- a/src/hooks/useAwardXP.ts
+++ b/src/hooks/useAwardXP.ts
@@ -32,8 +32,10 @@ export const useAwardXP = () => {
       queryClient.invalidateQueries({ queryKey: ["profile"] });
       queryClient.invalidateQueries({ queryKey: ["leaderboard"] });
     },
-    onError: () => {
-      // Errors are handled by the calling component via the mutation's error state
+    onError: (error) => {
+      if (import.meta.env.DEV) {
+        console.error("Failed to award XP:", error);
+      }
     }
   });
 };


### PR DESCRIPTION
## What does this PR do?

Fixes #801

`useAwardXP.ts` printed the exact XP amount awarded (`console.log`) and full error details (`console.error`) on every gamification event. These ran in production, exposing internal scoring logic and error internals to any user who opened browser DevTools.

## Changes

- Removed `console.log(\`Awarded ${data.awarded} XP!\`)` from `onSuccess`
- Removed `console.error("Failed to award XP:", error)` from `onError`
- Simplified `onSuccess` signature (unused `data` parameter dropped)
- Errors remain accessible via the mutation's `error` state for components that need to handle them

## Type of change

- [x] Bug fix (information disclosure)

## Checklist

- [x] Code follows the project's coding standards
- [x] TypeScript compiles with no errors
- [x] No sensitive internal data exposed in browser console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved XP award handling so profile and leaderboard refresh immediately after awarding.
  * Reduced noisy logging in production; error reporting now relies on the app's UI/error states while developers retain verbose logs in development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->