### PR TITLE
fix: make Piston code execution API URL environment-configurable (#802)

### DIFF
--- a/src/components/studyroom/LiveCodeRunner.tsx
+++ b/src/components/studyroom/LiveCodeRunner.tsx
@@ -2,6 +2,9 @@ import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Play, Code, Share, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { env } from "@/env";
+
+const PISTON_API_URL = env.VITE_PISTON_API_URL ?? "https://emkc.org/api/v2/piston/execute";
 
 interface LiveCodeRunnerProps {
   onShare: (code: string, language: string, output: string) => void;
@@ -31,7 +34,7 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
     setOutput("");
 
     try {
-      const response = await fetch("https://emkc.org/api/v2/piston/execute", {
+      const response = await fetch(PISTON_API_URL, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/src/env.ts
+++ b/src/env.ts
@@ -9,6 +9,7 @@ const envSchema = z.object({
   NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().min(1).optional(),
   VITE_VAPID_PUBLIC_KEY: z.string().min(1).optional(),
   VITE_API_URL: z.string().url().optional(),
+  VITE_PISTON_API_URL: z.string().url().optional(),
 });
 
 const _env = envSchema.safeParse(import.meta.env);


### PR DESCRIPTION
## What does this PR do?

Fixes #802

The Piston execute endpoint (`https://emkc.org/api/v2/piston/execute`) was hardcoded as a string literal inside `LiveCodeRunner.tsx`. It could not be overridden without a code change and redeploy — unlike every other external URL in the codebase which is read from env via `src/config/api.ts`.

## Changes

- Added `VITE_PISTON_API_URL` (optional, validated as URL) to the Zod env schema in `src/env.ts`
- Derived a module-level `PISTON_API_URL` constant in `LiveCodeRunner.tsx` that falls back to the public `emkc.org` endpoint when the variable is unset — **zero behavior change for existing deployments**
- Replaced the inline string literal with the constant in the `fetch` call

## Type of change

- [x] Bug fix / configuration improvement

## Checklist

- [x] Code follows the project's coding standards and patterns already in `src/env.ts`
- [x] TypeScript compiles with no errors
- [x] Default behavior is unchanged when `VITE_PISTON_API_URL` is not set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Code execution server endpoint is now configurable through environment variables, allowing flexible deployment with different execution backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->