### PR TITLE
fix(ai): align AI matchmaker payload with backend schema

### DIFF
--- a/src/pages/aipage.tsx
+++ b/src/pages/aipage.tsx
@@ -38,6 +38,11 @@ const AIPage = () => {
     try {
       const { data: { session } } = await supabase.auth.getSession();
       
+      const formattedMessages = [...messages, userMessage].map((msg: any) => ({
+        role: msg.role,
+        content: msg.content,
+      }));
+
       const res = await fetch(`${API_BASE_URL}/api/ai/ask`, {
         method: "POST",
         headers: {
@@ -46,7 +51,7 @@ const AIPage = () => {
         },
         credentials:"include",
         body: JSON.stringify({
-          question: prompt,
+          messages: formattedMessages,
         }),
       });
 


### PR DESCRIPTION
## Description

This PR fixes the AI Matchmaker request payload to match the backend API contract expected by `/api/ai/ask`.

Previously, the AI Matchmaker page sent a payload containing `question`, while the backend validation schema (`aiSchemas.askAI`) requires a `messages` array. This mismatch caused requests from the `/ai` page to fail validation.

The implementation has been updated to send a properly formatted `messages` array, aligning the AI Matchmaker with the backend schema and the existing implementation used in `src/components/Chatbot.tsx`.

## Related Issue

Fixes #796

## Changes Made

- Updated AI Matchmaker request payload to use a `messages` array instead of `question`
- Aligned `/ai` page payload with `aiSchemas.askAI`
- Matched the payload format already used by `src/components/Chatbot.tsx`
- Preserved existing AI Matchmaker functionality and response handling

## Checklist

- [x] I have read CONTRIBUTING.md
- [ ] I have tested my changes locally
- [x] No new console errors
- [x] Linked the issue with `Fixes #796 `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated AI message handling to support conversation history format when communicating with the AI backend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->