### PR TITLE
fix: enforce SUPABASE_JWT_SECRET at startup, remove network fallback

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,20 @@
+# Server
+PORT=5000
+NODE_ENV=development
+
+# Supabase — get these from your Supabase project dashboard
+# Settings → API
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# Settings → API → JWT Settings
+SUPABASE_JWT_SECRET=your_jwt_secret
+
+# Frontend
+FRONTEND_URL=http://localhost:5173
+
+# Optional
+OPENROUTER_API_KEY=
+SITE_URL=
+TRUSTED_PROXIES=
+TRUST_PROXY=

--- a/backend/middlewares/requireAuth.js
+++ b/backend/middlewares/requireAuth.js
@@ -66,37 +66,9 @@ const verifyLocalJwt = (token, secret) => {
 const jwtSecret = process.env.SUPABASE_JWT_SECRET;
 
 if (!jwtSecret) {
-  if (process.env.NODE_ENV === "production") {
-    console.error("[security] FATAL: SUPABASE_JWT_SECRET is not set. Local JWT verification is required in production.");
-    process.exit(1);
-  }
-  console.warn("[security] WARNING: SUPABASE_JWT_SECRET is not set. Using slow network-based auth (dev only).");
+  console.error("[security] FATAL: SUPABASE_JWT_SECRET is not set. Set it from your Supabase project settings.");
+  process.exit(1);
 }
-
-/**
- * Simple rate limiter specifically for the network fallback path.
- * Prevents attackers from spamming invalid tokens to exhaust Supabase API quotas.
- */
-const FALLBACK_WINDOW_MS = 60_000;
-const FALLBACK_MAX_REQUESTS = 10;
-const fallbackRateCounts = new Map();
-
-const isFallbackRateLimited = (ip) => {
-  const now = Date.now();
-  const entry = fallbackRateCounts.get(ip);
-
-  if (!entry || now - entry.windowStart >= FALLBACK_WINDOW_MS) {
-    fallbackRateCounts.set(ip, { count: 1, windowStart: now });
-    return false;
-  }
-
-  if (entry.count >= FALLBACK_MAX_REQUESTS) {
-    return true;
-  }
-
-  entry.count += 1;
-  return false;
-};
 
 /**
  * Express middleware that validates a Supabase JWT.
@@ -106,19 +78,10 @@ const isFallbackRateLimited = (ip) => {
  *   2. Authorization header (`Bearer <token>`)
  *
  * Verification strategy:
- *   - Production: Local HMAC-SHA256 verification only (fast, zero network latency).
- *     Server refuses to start if SUPABASE_JWT_SECRET is missing.
- *   - Development: Falls back to Supabase getUser() if the secret is absent,
- *     with a strict per-IP rate limiter to prevent API exhaustion.
+ *   - Always uses local HMAC-SHA256 verification (fast, zero network latency).
+ *   - Server refuses to start if SUPABASE_JWT_SECRET is missing.
  */
 export const requireAuth = async (req, res, next) => {
-  const supabaseAdmin = getSupabaseAdmin();
-
-  if (!supabaseAdmin) {
-    next(new HttpError(500, "Supabase configuration is missing"));
-    return;
-  }
-
   let token = null;
 
   if (req.cookies && req.cookies.access_token) {
@@ -132,41 +95,21 @@ export const requireAuth = async (req, res, next) => {
     return;
   }
 
-  // PRIMARY PATH: Fast, local HMAC verification (0ms network latency)
-  if (jwtSecret) {
-    const payload = verifyLocalJwt(token, jwtSecret);
-    if (!payload) {
-      next(new HttpError(401, "Invalid or expired session"));
-      return;
-    }
-
-    req.user = { 
-      id: payload.sub,
-      email: payload.email,
-      user_metadata: payload.user_metadata,
-      app_metadata: payload.app_metadata,
-      role: payload.role
-    };
-    return next();
-  }
-
-  // FALLBACK PATH (development only — production exits at startup above)
-  // Rate-limit this path to prevent Supabase API quota exhaustion from token spam.
-  const clientIp = req.socket?.remoteAddress || req.ip || "unknown";
-  if (isFallbackRateLimited(clientIp)) {
-    next(new HttpError(429, "Too many authentication attempts. Please try again later."));
-    return;
-  }
-
-  const { data, error } = await supabaseAdmin.auth.getUser(token);
-
-  if (error || !data?.user) {
+  // LOCAL HMAC verification — no network call
+  const payload = verifyLocalJwt(token, jwtSecret);
+  if (!payload) {
     next(new HttpError(401, "Invalid or expired session"));
     return;
   }
 
-  req.user = data.user;
-  next();
+  req.user = {
+    id: payload.sub,
+    email: payload.email,
+    user_metadata: payload.user_metadata,
+    app_metadata: payload.app_metadata,
+    role: payload.role
+  };
+  return next();
 };
 
 const deriveActiveRoles = (profile) => {

--- a/backend/utils/env.js
+++ b/backend/utils/env.js
@@ -4,6 +4,7 @@ const envSchema = z.object({
   PORT: z.string().default("5000"),
   SUPABASE_URL: z.string().url(),
   SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  SUPABASE_JWT_SECRET: z.string().min(1),
   OPENROUTER_API_KEY: z.string().optional(),
   FRONTEND_URL: z.string().url().default("http://localhost:5173"),
   SITE_URL: z.string().url().optional()


### PR DESCRIPTION
Fixes #711

## What was wrong
In requireAuth.js (lines 65-95), if SUPABASE_JWT_SECRET wasn't set, the
server just logged a warning and fell back to calling
supabaseAdmin.auth.getUser() on every request. This meant:

- every auth check made a network call (100ms+ instead of ~1ms)
- if Supabase was down, auth broke completely
- the missing secret was easy to miss since the app kept running
- no local validation if Supabase was ever compromised

## What I changed

**requireAuth.js** — removed the fallback entirely. The startup check no
longer has a dev/prod condition; a missing secret always exits with a
clear error. Also removed the fallback rate limiter and the supabaseAdmin
block inside requireAuth since they were only there to support the
fallback. Updated the JSDoc comment to match.

**env.js** — added SUPABASE_JWT_SECRET to the zod schema so it's caught
at startup alongside the other required vars.

**backend/.env.example** — this file didn't exist. Added it with all
required variables and a note on where to find the JWT secret in the
Supabase dashboard.

## Testing
- [x] App fails to start without SUPABASE_JWT_SECRET
- [x] Clear error message on startup
- [x] No network calls during auth (~1ms local HMAC)
- [x] Invalid tokens rejected locally without a Supabase call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend environment configuration requirements. Added example configuration file with server and authentication settings.
  * Modified backend authentication middleware to use local JWT verification. `SUPABASE_JWT_SECRET` is now a required environment variable for server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->