### PR TITLE
Add Cookie Consent Banner and Cookies Policy Page (#842)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { AuthProvider } from "@/contexts/AuthContext";
+import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
 import { RoleProvider } from "@/contexts/RoleContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import AdminRoute from "@/components/AdminRoute";
@@ -17,6 +18,7 @@ import ProtectedMentorRoute from "@/components/ProtectedMentorRoute";
 import Navbar from "./components/Navbar";
 import Chatbot from "./components/Chatbot";
 import StreakBadge from "./components/StreakBadge";
+import CookieConsentBanner from "./components/CookieConsentBanner";
 import FloatingAI from "./components/FloatingAI";
 import MouseSparkles from "./components/MouseSparkles";
 
@@ -55,6 +57,7 @@ const StudyRooms = React.lazy(() => import("./components/StudyRooms"));
 const Room = React.lazy(() => import("./components/Room"));
 const Contact = React.lazy(() => import("./pages/Contact"));
 const PrivacyPolicy = React.lazy(() => import("./pages/privacy"));
+const CookiesPolicy = React.lazy(() => import("./pages/cookies-policy"));
 const PeerReviewDashboard = React.lazy(() => import("./pages/PeerReviewDashboard"));
 const SubmitForReview = React.lazy(() => import("./pages/SubmitForReview"));
 const ReviewSubmission = React.lazy(() => import("./pages/ReviewSubmission"));
@@ -79,7 +82,7 @@ function AppContent() {
   return (
     <>
       <MouseSparkles />
-
+      <CookieConsentBanner />
 
       <Suspense fallback={<div className="flex min-h-screen items-center justify-center bg-[#020617]"><div className="h-10 w-10 animate-spin rounded-full border-4 border-cyan-400 border-t-transparent" /></div>}>
         <Routes>
@@ -107,6 +110,7 @@ function AppContent() {
           <Route path="/portfolio/:slug" element={<PublicPortfolio />} />
           <Route path="/contact" element={<WithNav><Contact /></WithNav>} />
           <Route path="/privacy-policy" element={<WithNav><PrivacyPolicy /></WithNav>} />
+          <Route path="/cookies-policy" element={<WithNav><CookiesPolicy /></WithNav>} />
 
           <Route path="/auth/callback" element={<AuthCallback />} />
 
@@ -369,11 +373,13 @@ function App() {
           <Sonner />
 
           <BrowserRouter>
-            <AuthProvider>
-              <RoleProvider>
-                <AppContent />
-              </RoleProvider>
-            </AuthProvider>
+            <CookieConsentProvider>
+              <AuthProvider>
+                <RoleProvider>
+                  <AppContent />
+                </RoleProvider>
+              </AuthProvider>
+            </CookieConsentProvider>
           </BrowserRouter>
         </TooltipProvider>
       </ThemeProvider>

--- a/src/components/CookieConsentBanner.tsx
+++ b/src/components/CookieConsentBanner.tsx
@@ -1,0 +1,260 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  defaultCategoryPreferences,
+  useCookieConsent,
+} from "@/contexts/CookieConsentContext";
+import type { CookieCategoryPreferences } from "@/lib/cookieConsent";
+import { cn } from "@/lib/utils";
+
+const categoryLabels: Record<
+  keyof CookieCategoryPreferences | "essential",
+  { title: string; description: string }
+> = {
+  essential: {
+    title: "Essential Cookies",
+    description: "Required for authentication, security, and core site functionality.",
+  },
+  analytics: {
+    title: "Analytics Cookies",
+    description: "Help us understand how visitors use PeerLearn to improve the platform.",
+  },
+  functional: {
+    title: "Functional Cookies",
+    description: "Remember your theme, role mode, and other preferences.",
+  },
+  marketing: {
+    title: "Marketing Cookies",
+    description: "Used to deliver relevant promotions if we introduce them in the future.",
+  },
+};
+
+export default function CookieConsentBanner() {
+  const {
+    showBanner,
+    preferences,
+    acceptAll,
+    rejectNonEssential,
+    saveCustomPreferences,
+    closeBanner,
+  } = useCookieConsent();
+
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+  const [draftPreferences, setDraftPreferences] = useState<CookieCategoryPreferences>(
+    defaultCategoryPreferences(),
+  );
+
+  useEffect(() => {
+    if (customizeOpen) {
+      setDraftPreferences({
+        analytics: preferences?.analytics ?? false,
+        functional: preferences?.functional ?? false,
+        marketing: preferences?.marketing ?? false,
+      });
+    }
+  }, [customizeOpen, preferences]);
+
+  if (!showBanner) {
+    return null;
+  }
+
+  const handleSaveCustom = () => {
+    saveCustomPreferences(draftPreferences);
+    setCustomizeOpen(false);
+  };
+
+  const handleCustomizeCancel = () => {
+    setCustomizeOpen(false);
+    if (preferences?.consentGiven) {
+      closeBanner();
+    }
+  };
+
+  return (
+    <>
+      <div
+        role="region"
+        aria-label="Cookie consent"
+        className="fixed inset-x-0 bottom-0 z-[100] border-t border-white/10 bg-[#020617]/95 p-4 shadow-2xl backdrop-blur-xl sm:p-6"
+      >
+        <div className="mx-auto flex max-w-6xl flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex-1 space-y-2">
+            <p className="text-sm font-semibold text-white sm:text-base">
+              We use cookies to improve your experience
+            </p>
+            <p className="text-sm leading-relaxed text-slate-300">
+              PeerLearn uses cookies and similar technologies to keep you signed in,
+              remember your preferences, and understand how our platform is used. You
+              can accept all cookies, reject non-essential cookies, or customize your
+              choices. Read our{" "}
+              <Link
+                to="/cookies-policy"
+                className="font-medium text-cyan-400 underline-offset-4 hover:text-cyan-300 hover:underline"
+              >
+                Cookies Policy
+              </Link>{" "}
+              for more details.
+            </p>
+          </div>
+
+          <div className="flex w-full flex-col gap-2 sm:flex-row sm:flex-wrap lg:w-auto lg:justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+              onClick={rejectNonEssential}
+            >
+              Reject Non-Essential
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="border-cyan-400/40 bg-transparent text-cyan-300 hover:bg-cyan-400/10 hover:text-cyan-200"
+              onClick={() => setCustomizeOpen(true)}
+            >
+              Customize Preferences
+            </Button>
+            <Button
+              type="button"
+              className="bg-gradient-to-r from-cyan-400 to-blue-500 font-semibold text-black hover:from-cyan-300 hover:to-blue-400"
+              onClick={acceptAll}
+            >
+              Accept All
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <Dialog
+        open={customizeOpen}
+        onOpenChange={(open) => {
+          setCustomizeOpen(open);
+          if (!open && preferences?.consentGiven) {
+            closeBanner();
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg border-white/10 bg-[#071127] text-white sm:rounded-2xl">
+          <DialogHeader>
+            <DialogTitle className="text-xl text-cyan-300">
+              Cookie Preferences
+            </DialogTitle>
+            <DialogDescription className="text-slate-300">
+              Choose which optional cookie categories you allow. Essential cookies
+              cannot be disabled because they are required for the site to work.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-2">
+            <PreferenceRow
+              id="essential-cookies"
+              title={categoryLabels.essential.title}
+              description={categoryLabels.essential.description}
+              checked
+              disabled
+            />
+
+            <PreferenceRow
+              id="analytics-cookies"
+              title={categoryLabels.analytics.title}
+              description={categoryLabels.analytics.description}
+              checked={draftPreferences.analytics}
+              onCheckedChange={(checked) =>
+                setDraftPreferences((prev) => ({ ...prev, analytics: checked }))
+              }
+            />
+
+            <PreferenceRow
+              id="functional-cookies"
+              title={categoryLabels.functional.title}
+              description={categoryLabels.functional.description}
+              checked={draftPreferences.functional}
+              onCheckedChange={(checked) =>
+                setDraftPreferences((prev) => ({ ...prev, functional: checked }))
+              }
+            />
+
+            <PreferenceRow
+              id="marketing-cookies"
+              title={categoryLabels.marketing.title}
+              description={categoryLabels.marketing.description}
+              checked={draftPreferences.marketing}
+              onCheckedChange={(checked) =>
+                setDraftPreferences((prev) => ({ ...prev, marketing: checked }))
+              }
+            />
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="border-white/20 bg-transparent text-white hover:bg-white/10 hover:text-white"
+              onClick={handleCustomizeCancel}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="bg-gradient-to-r from-cyan-400 to-blue-500 font-semibold text-black hover:from-cyan-300 hover:to-blue-400"
+              onClick={handleSaveCustom}
+            >
+              Save Preferences
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function PreferenceRow({
+  id,
+  title,
+  description,
+  checked,
+  disabled = false,
+  onCheckedChange,
+}: {
+  id: string;
+  title: string;
+  description: string;
+  checked: boolean;
+  disabled?: boolean;
+  onCheckedChange?: (checked: boolean) => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-start justify-between gap-4 rounded-xl border border-white/10 bg-white/5 p-4",
+        disabled && "opacity-80",
+      )}
+    >
+      <div className="space-y-1">
+        <Label htmlFor={id} className="text-sm font-semibold text-white">
+          {title}
+        </Label>
+        <p className="text-sm leading-relaxed text-slate-300">{description}</p>
+      </div>
+      <Switch
+        id={id}
+        checked={checked}
+        disabled={disabled}
+        onCheckedChange={onCheckedChange}
+        aria-readonly={disabled}
+      />
+    </div>
+  );
+}

--- a/src/contexts/CookieConsentContext.tsx
+++ b/src/contexts/CookieConsentContext.tsx
@@ -1,0 +1,111 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  acceptAllPreferences,
+  defaultCategoryPreferences,
+  getStoredConsent,
+  rejectNonEssentialPreferences,
+  saveConsent,
+  saveCustomPreferences,
+  type CookieCategoryPreferences,
+  type CookiePreferences,
+} from "@/lib/cookieConsent";
+
+interface CookieConsentContextType {
+  preferences: CookiePreferences | null;
+  hasConsent: boolean;
+  showBanner: boolean;
+  acceptAll: () => void;
+  rejectNonEssential: () => void;
+  saveCustomPreferences: (categories: CookieCategoryPreferences) => void;
+  openPreferences: () => void;
+  closeBanner: () => void;
+}
+
+const CookieConsentContext = createContext<CookieConsentContextType | undefined>(
+  undefined,
+);
+
+export const CookieConsentProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [preferences, setPreferences] = useState<CookiePreferences | null>(() =>
+    getStoredConsent(),
+  );
+  const [showBanner, setShowBanner] = useState(() => !getStoredConsent());
+
+  const persistPreferences = useCallback((prefs: CookiePreferences) => {
+    saveConsent(prefs);
+    setPreferences(prefs);
+    setShowBanner(false);
+  }, []);
+
+  const acceptAll = useCallback(() => {
+    persistPreferences(acceptAllPreferences());
+  }, [persistPreferences]);
+
+  const rejectNonEssential = useCallback(() => {
+    persistPreferences(rejectNonEssentialPreferences());
+  }, [persistPreferences]);
+
+  const saveCustom = useCallback(
+    (categories: CookieCategoryPreferences) => {
+      persistPreferences(saveCustomPreferences(categories));
+    },
+    [persistPreferences],
+  );
+
+  const openPreferences = useCallback(() => {
+    setShowBanner(true);
+  }, []);
+
+  const closeBanner = useCallback(() => {
+    if (preferences?.consentGiven) {
+      setShowBanner(false);
+    }
+  }, [preferences]);
+
+  const value = useMemo(
+    () => ({
+      preferences,
+      hasConsent: Boolean(preferences?.consentGiven),
+      showBanner,
+      acceptAll,
+      rejectNonEssential,
+      saveCustomPreferences: saveCustom,
+      openPreferences,
+      closeBanner,
+    }),
+    [
+      preferences,
+      showBanner,
+      acceptAll,
+      rejectNonEssential,
+      saveCustom,
+      openPreferences,
+      closeBanner,
+    ],
+  );
+
+  return (
+    <CookieConsentContext.Provider value={value}>
+      {children}
+    </CookieConsentContext.Provider>
+  );
+};
+
+export const useCookieConsent = () => {
+  const context = useContext(CookieConsentContext);
+  if (!context) {
+    throw new Error("useCookieConsent must be used within a CookieConsentProvider");
+  }
+  return context;
+};
+
+export { defaultCategoryPreferences };

--- a/src/contexts/CookieConsentContext.tsx
+++ b/src/contexts/CookieConsentContext.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import {
   acceptAllPreferences,
+  clearFunctionalStorage,
   defaultCategoryPreferences,
   getStoredConsent,
   rejectNonEssentialPreferences,
@@ -42,6 +43,9 @@ export const CookieConsentProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const persistPreferences = useCallback((prefs: CookiePreferences) => {
     saveConsent(prefs);
+    if (!prefs.functional) {
+      clearFunctionalStorage();
+    }
     setPreferences(prefs);
     setShowBanner(false);
   }, []);

--- a/src/contexts/RoleContext.tsx
+++ b/src/contexts/RoleContext.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import { useAuth } from "@/contexts/useAuth";
+import { hasFunctionalConsent } from "@/lib/cookieConsent";
 import { supabase } from "@/integrations/supabase/client";
 
 export type UserMode = "learner" | "mentor";
@@ -59,7 +60,16 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
       } else if (mentor && !learner) {
         setCurrentMode("mentor");
       } else if (mentor && learner) {
-        const storedMode = localStorage.getItem("peerlearn_mode");
+        let storedMode: string | null = null;
+
+        if (hasFunctionalConsent()) {
+          try {
+            storedMode = localStorage.getItem("peerlearn_mode");
+          } catch {
+            storedMode = null;
+          }
+        }
+
         setCurrentMode(
           storedMode === "mentor" || storedMode === "learner"
             ? storedMode
@@ -76,8 +86,12 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
   const setMode = (mode: UserMode) => {
     setCurrentMode(mode);
 
-    if (isDualRole) {
-      localStorage.setItem("peerlearn_mode", mode);
+    if (isDualRole && hasFunctionalConsent()) {
+      try {
+        localStorage.setItem("peerlearn_mode", mode);
+      } catch {
+        // ignore storage access failures
+      }
     }
   };
 

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,5 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 
+import { hasFunctionalConsent } from "@/lib/cookieConsent";
+
 export type Theme = "default" | "purple" | "blue" | "green" | "orange" | "black-white";
 
 interface ThemeContextType {
@@ -11,12 +13,27 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setThemeState] = useState<Theme>(() => {
-    return (localStorage.getItem("app-theme") as Theme) || "default";
+    if (!hasFunctionalConsent()) {
+      return "default";
+    }
+
+    try {
+      return (localStorage.getItem("app-theme") as Theme) || "default";
+    } catch {
+      return "default";
+    }
   });
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem("app-theme", newTheme);
+
+    if (hasFunctionalConsent()) {
+      try {
+        localStorage.setItem("app-theme", newTheme);
+      } catch {
+        // ignore storage access failures
+      }
+    }
   };
 
   useEffect(() => {

--- a/src/lib/cookieConsent.ts
+++ b/src/lib/cookieConsent.ts
@@ -1,0 +1,79 @@
+export type CookieCategory = "essential" | "analytics" | "functional" | "marketing";
+
+export interface CookiePreferences {
+  version: number;
+  consentGiven: boolean;
+  essential: true;
+  analytics: boolean;
+  functional: boolean;
+  marketing: boolean;
+  timestamp: string;
+}
+
+export type CookieCategoryPreferences = Pick<
+  CookiePreferences,
+  "analytics" | "functional" | "marketing"
+>;
+
+const STORAGE_KEY = "peerlearn_cookie_consent";
+const CURRENT_VERSION = 1;
+
+const createPreferences = (
+  categories: CookieCategoryPreferences,
+  consentGiven = true,
+): CookiePreferences => ({
+  version: CURRENT_VERSION,
+  consentGiven,
+  essential: true,
+  analytics: categories.analytics,
+  functional: categories.functional,
+  marketing: categories.marketing,
+  timestamp: new Date().toISOString(),
+});
+
+export const getStoredConsent = (): CookiePreferences | null => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as CookiePreferences;
+    if (parsed.version !== CURRENT_VERSION || !parsed.consentGiven) {
+      return null;
+    }
+
+    return {
+      ...parsed,
+      essential: true,
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const saveConsent = (prefs: CookiePreferences): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+};
+
+export const acceptAllPreferences = (): CookiePreferences =>
+  createPreferences({
+    analytics: true,
+    functional: true,
+    marketing: true,
+  });
+
+export const rejectNonEssentialPreferences = (): CookiePreferences =>
+  createPreferences({
+    analytics: false,
+    functional: false,
+    marketing: false,
+  });
+
+export const saveCustomPreferences = (
+  categories: CookieCategoryPreferences,
+): CookiePreferences => createPreferences(categories);
+
+export const defaultCategoryPreferences = (): CookieCategoryPreferences => ({
+  analytics: false,
+  functional: false,
+  marketing: false,
+});

--- a/src/lib/cookieConsent.ts
+++ b/src/lib/cookieConsent.ts
@@ -68,10 +68,10 @@ const readConsentFromStorage = (storage: Storage): CookiePreferences | null => {
   }
 };
 
-/** Read stored consent from localStorage, falling back to sessionStorage. */
+/** Read stored consent from sessionStorage, falling back to localStorage. */
 export const getStoredConsent = (): CookiePreferences | null => {
   return (
-    readConsentFromStorage(localStorage) ?? readConsentFromStorage(sessionStorage)
+    readConsentFromStorage(sessionStorage) ?? readConsentFromStorage(localStorage)
   );
 };
 
@@ -81,6 +81,11 @@ export const saveConsent = (prefs: CookiePreferences): void => {
 
   try {
     localStorage.setItem(STORAGE_KEY, serialized);
+    try {
+      sessionStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore storage access failures
+    }
     return;
   } catch {
     // fall through to sessionStorage
@@ -88,6 +93,11 @@ export const saveConsent = (prefs: CookiePreferences): void => {
 
   try {
     sessionStorage.setItem(STORAGE_KEY, serialized);
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore storage access failures
+    }
   } catch {
     console.warn("[cookieConsent] Unable to persist consent preferences.");
   }

--- a/src/lib/cookieConsent.ts
+++ b/src/lib/cookieConsent.ts
@@ -1,5 +1,7 @@
+/** Cookie category identifiers used for consent preferences. */
 export type CookieCategory = "essential" | "analytics" | "functional" | "marketing";
 
+/** Persisted cookie consent preferences for the current user. */
 export interface CookiePreferences {
   version: number;
   consentGiven: boolean;
@@ -10,6 +12,7 @@ export interface CookiePreferences {
   timestamp: string;
 }
 
+/** Toggleable non-essential cookie category preferences. */
 export type CookieCategoryPreferences = Pick<
   CookiePreferences,
   "analytics" | "functional" | "marketing"
@@ -17,6 +20,14 @@ export type CookieCategoryPreferences = Pick<
 
 const STORAGE_KEY = "peerlearn_cookie_consent";
 const CURRENT_VERSION = 1;
+
+const FUNCTIONAL_STORAGE_KEYS = [
+  "app-theme",
+  "peerlearn_mode",
+  "pl_streak",
+  "pl_last_active",
+  "pl_streak_cache",
+] as const;
 
 const createPreferences = (
   categories: CookieCategoryPreferences,
@@ -31,11 +42,10 @@ const createPreferences = (
   timestamp: new Date().toISOString(),
 });
 
-export const getStoredConsent = (): CookiePreferences | null => {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) return null;
+const parseStoredConsent = (raw: string | null): CookiePreferences | null => {
+  if (!raw) return null;
 
+  try {
     const parsed = JSON.parse(raw) as CookiePreferences;
     if (parsed.version !== CURRENT_VERSION || !parsed.consentGiven) {
       return null;
@@ -50,10 +60,55 @@ export const getStoredConsent = (): CookiePreferences | null => {
   }
 };
 
-export const saveConsent = (prefs: CookiePreferences): void => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+const readConsentFromStorage = (storage: Storage): CookiePreferences | null => {
+  try {
+    return parseStoredConsent(storage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
 };
 
+/** Read stored consent from localStorage, falling back to sessionStorage. */
+export const getStoredConsent = (): CookiePreferences | null => {
+  return (
+    readConsentFromStorage(localStorage) ?? readConsentFromStorage(sessionStorage)
+  );
+};
+
+/** Persist consent preferences without throwing if storage is unavailable. */
+export const saveConsent = (prefs: CookiePreferences): void => {
+  const serialized = JSON.stringify(prefs);
+
+  try {
+    localStorage.setItem(STORAGE_KEY, serialized);
+    return;
+  } catch {
+    // fall through to sessionStorage
+  }
+
+  try {
+    sessionStorage.setItem(STORAGE_KEY, serialized);
+  } catch {
+    console.warn("[cookieConsent] Unable to persist consent preferences.");
+  }
+};
+
+/** Returns true when the user has granted functional cookie consent. */
+export const hasFunctionalConsent = (): boolean =>
+  getStoredConsent()?.functional === true;
+
+/** Remove functional localStorage entries when consent is revoked. */
+export const clearFunctionalStorage = (): void => {
+  for (const key of FUNCTIONAL_STORAGE_KEYS) {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // ignore storage access failures
+    }
+  }
+};
+
+/** Build preferences that accept all non-essential cookie categories. */
 export const acceptAllPreferences = (): CookiePreferences =>
   createPreferences({
     analytics: true,
@@ -61,6 +116,7 @@ export const acceptAllPreferences = (): CookiePreferences =>
     marketing: true,
   });
 
+/** Build preferences that reject all non-essential cookie categories. */
 export const rejectNonEssentialPreferences = (): CookiePreferences =>
   createPreferences({
     analytics: false,
@@ -68,10 +124,12 @@ export const rejectNonEssentialPreferences = (): CookiePreferences =>
     marketing: false,
   });
 
+/** Build preferences from custom non-essential category choices. */
 export const saveCustomPreferences = (
   categories: CookieCategoryPreferences,
 ): CookiePreferences => createPreferences(categories);
 
+/** Default non-essential category preferences (all disabled). */
 export const defaultCategoryPreferences = (): CookieCategoryPreferences => ({
   analytics: false,
   functional: false,

--- a/src/lib/streakSystem.ts
+++ b/src/lib/streakSystem.ts
@@ -11,6 +11,7 @@
  * It is always reconciled against the server on load.
  */
 
+import { hasFunctionalConsent } from "@/lib/cookieConsent";
 import { supabase } from "@/integrations/supabase/client";
 
 // ── Local cache keys (read-only cache, never source of truth) ──
@@ -38,12 +39,20 @@ export const calculateStreakXP = (streak: number): number => {
 
 // ── Cache helpers ──────────────────────────────────────────────
 function writeCache(data: StreakData): void {
+  if (!hasFunctionalConsent()) {
+    return;
+  }
+
   try {
     localStorage.setItem(CACHE_KEY, JSON.stringify(data));
   } catch { /* ignore */ }
 }
 
 function readCache(): StreakData | null {
+  if (!hasFunctionalConsent()) {
+    return null;
+  }
+
   try {
     const raw = localStorage.getItem(CACHE_KEY);
     return raw ? (JSON.parse(raw) as StreakData) : null;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
 import { useTheme } from "@/contexts/ThemeContext";
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
 import { useState, useEffect } from "react";
 
 import { Hero } from "@/components/landing/Hero";
@@ -40,6 +41,7 @@ const faqs = [
 export default function Landing() {
   const { scrollYProgress } = useScroll();
   const { setTheme } = useTheme();
+  const { openPreferences } = useCookieConsent();
 
   const [open, setOpen] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -354,6 +356,21 @@ export default function Landing() {
             >
               Privacy Policy
             </Link>
+
+            <Link
+              to="/cookies-policy"
+              className="transition hover:text-cyan-400"
+            >
+              Cookies Policy
+            </Link>
+
+            <button
+              type="button"
+              onClick={openPreferences}
+              className="transition hover:text-cyan-400"
+            >
+              Cookie Settings
+            </button>
           </div>
 
           <div className="text-slate-500">© 2026 PeerLearn</div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -41,7 +41,7 @@ const faqs = [
 export default function Landing() {
   const { scrollYProgress } = useScroll();
   const { setTheme } = useTheme();
-  const { openPreferences } = useCookieConsent();
+  const { openPreferences, preferences } = useCookieConsent();
 
   const [open, setOpen] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
@@ -74,6 +74,17 @@ export default function Landing() {
     // Device-local daily streak using localStorage
     const KEY_STREAK = "pl_streak";
     const KEY_LAST = "pl_last_active";
+
+    if (!preferences?.functional) {
+      try {
+        localStorage.removeItem(KEY_STREAK);
+        localStorage.removeItem(KEY_LAST);
+      } catch {
+        // ignore storage access failures
+      }
+      setStreak(null);
+      return;
+    }
 
     const today = new Date();
     const todayKey = today.toISOString().slice(0, 10); // YYYY-MM-DD
@@ -112,7 +123,7 @@ export default function Landing() {
     } catch (e) {
       setStreak(0);
     }
-  }, []);
+  }, [preferences?.functional]);
 
   if (loading) {
     return (

--- a/src/pages/cookies-policy.tsx
+++ b/src/pages/cookies-policy.tsx
@@ -1,0 +1,157 @@
+import { type ReactNode } from "react";
+import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
+
+import { useCookieConsent } from "@/contexts/CookieConsentContext";
+
+export default function CookiesPolicy() {
+  const { openPreferences } = useCookieConsent();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#020617] via-[#071127] to-[#020B1F] px-6 py-20 text-white">
+      <motion.div
+        initial={{ opacity: 0, y: 30 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.6 }}
+        className="mx-auto max-w-4xl rounded-3xl border border-white/10 bg-white/5 p-10 backdrop-blur-2xl"
+      >
+        <h1 className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-4xl font-black text-transparent">
+          Cookies Policy
+        </h1>
+
+        <p className="mt-6 leading-7 text-slate-300">
+          This Cookies Policy explains what cookies and similar technologies PeerLearn
+          uses, why we use them, and how you can manage your preferences. For broader
+          privacy practices, see our{" "}
+          <Link
+            to="/privacy-policy"
+            className="font-medium text-cyan-400 underline-offset-4 hover:text-cyan-300 hover:underline"
+          >
+            Privacy Policy
+          </Link>
+          .
+        </p>
+
+        <Section title="1. Introduction to Cookies">
+          Cookies are small text files stored on your device when you visit a website.
+          Similar technologies such as local storage may also be used to remember
+          settings and improve your experience. PeerLearn uses these technologies to
+          keep the platform secure, remember your preferences, and understand how our
+          services are used.
+        </Section>
+
+        <Section title="2. Essential Cookies">
+          Essential cookies are required for PeerLearn to function and cannot be
+          disabled through our consent banner. These include authentication session
+          cookies (such as the secure <code className="text-cyan-200">access_token</code>{" "}
+          cookie used for backend API access) and UI state cookies (such as{" "}
+          <code className="text-cyan-200">sidebar:state</code>, which remembers sidebar
+          visibility for up to 7 days). Without these cookies, core features such as
+          signing in and navigating the platform may not work correctly.
+        </Section>
+
+        <Section title="3. Analytics Cookies">
+          Analytics cookies help us measure traffic, understand feature usage, and
+          improve PeerLearn. We do not currently deploy third-party analytics cookies.
+          If we introduce analytics tools in the future, they will only be activated
+          when you grant analytics consent through our cookie banner.
+        </Section>
+
+        <Section title="4. Functional Cookies">
+          Functional cookies and local storage entries remember choices that enhance
+          your experience. On PeerLearn, these may include your selected theme (
+          <code className="text-cyan-200">app-theme</code>), learner/mentor mode (
+          <code className="text-cyan-200">peerlearn_mode</code>), and cached streak
+          data used to display progress quickly. These preferences are stored locally
+          and can be declined through the cookie banner if you prefer a minimal setup.
+        </Section>
+
+        <Section title="5. Marketing Cookies">
+          Marketing cookies are used to deliver personalized advertising or measure ad
+          campaign performance. PeerLearn does not currently use marketing cookies. If
+          this changes, we will update this policy and request your consent before
+          enabling them.
+        </Section>
+
+        <Section title="6. Cookie Retention Duration">
+          <ul className="mt-2 list-disc space-y-2 pl-5 leading-7 text-slate-300">
+            <li>
+              <strong className="text-white">Essential:</strong> session cookies expire
+              when you close your browser; sidebar state may persist for up to 7 days.
+            </li>
+            <li>
+              <strong className="text-white">Analytics:</strong> not currently active;
+              future analytics cookies would typically persist from 24 hours to 13 months
+              depending on the provider.
+            </li>
+            <li>
+              <strong className="text-white">Functional:</strong> stored until you clear
+              browser data or change your consent preferences.
+            </li>
+            <li>
+              <strong className="text-white">Marketing:</strong> not currently used.
+            </li>
+          </ul>
+        </Section>
+
+        <Section title="7. Managing or Deleting Cookies">
+          You can manage cookie preferences at any time using our cookie banner. To
+          reopen it, use{" "}
+          <button
+            type="button"
+            onClick={openPreferences}
+            className="font-medium text-cyan-400 underline-offset-4 hover:text-cyan-300 hover:underline"
+          >
+            Cookie Settings
+          </button>{" "}
+          from the site footer or click the button below. You can also delete cookies
+          through your browser settings. Note that removing essential cookies may affect
+          login and core functionality.
+        </Section>
+
+        <Section title="8. Contact Us">
+          If you have questions about this Cookies Policy or how we handle your data,
+          contact us at{" "}
+          <a
+            href="mailto:support@peerlearn.com"
+            className="font-medium text-cyan-400 underline-offset-4 hover:text-cyan-300 hover:underline"
+          >
+            support@peerlearn.com
+          </a>
+          .
+        </Section>
+
+        <div className="mt-10 flex flex-wrap gap-4">
+          <Link
+            to="/"
+            className="inline-block rounded-xl bg-gradient-to-r from-cyan-400 to-blue-500 px-6 py-3 font-semibold text-black transition hover:scale-105"
+          >
+            Back to Home
+          </Link>
+          <button
+            type="button"
+            onClick={openPreferences}
+            className="inline-block rounded-xl border border-cyan-400/40 px-6 py-3 font-semibold text-cyan-300 transition hover:bg-cyan-400/10"
+          >
+            Cookie Settings
+          </button>
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-8">
+      <h2 className="text-xl font-bold text-cyan-300">{title}</h2>
+      <div className="mt-2 leading-7 text-slate-300">{children}</div>
+    </div>
+  );
+}

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -55,7 +55,15 @@ export default function PrivacyPolicy() {
         <Section title="6. Cookies & Tracking Technologies">
           We use cookies and similar technologies to remember user preferences,
           analyze traffic, and improve user experience. You may disable cookies
-          in your browser settings.
+          in your browser settings or manage your choices through our cookie
+          banner. For detailed information, see our{" "}
+          <Link
+            to="/cookies-policy"
+            className="font-medium text-cyan-400 underline-offset-4 hover:text-cyan-300 hover:underline"
+          >
+            Cookies Policy
+          </Link>
+          .
         </Section>
 
         <Section title="7. Data Retention">


### PR DESCRIPTION
## Summary
- Adds a first-visit cookie consent banner (Accept All / Reject Non-Essential / Customize)
- Saves preferences in `localStorage` and hides the banner on return visits
- Adds `/cookies-policy` page and links from banner, footer, and Privacy Policy

Closes #842

## Test plan
- [ ] Clear `peerlearn_cookie_consent` → banner shows
- [ ] Accept/Reject/Customize → choice persists after reload
- [ ] `/cookies-policy` loads with all sections
- [ ] Footer + Privacy Policy links work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global cookie-consent experience: banner, preferences dialog, provider and dedicated Cookies Policy page.
  * Quick access to cookie settings from the landing and policy pages.
  * App respects functional-cookie choices: streaks, theme, and other persisted settings are enabled, cleared, or avoided based on consent.

* **Documentation**
  * Privacy Policy updated to reference and link to the new Cookies Policy page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->