### PR TITLE
[Critical] fix: use functional updater for setActivities in presence sync handler to prevent stale data corruption

### DIFF
--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -58,9 +58,9 @@ export default function Room() {
 
           setParticipants(onlineUsers);
 
-          setActivities([
+          setActivities((prev) => [
             `${onlineUsers.length} participant(s) online`,
-            ...activities,
+            ...prev,
           ]);
         })
         .on('postgres_changes', {


### PR DESCRIPTION
**Issue**
The presence sync callback in `Room.tsx` captures `activities` from its closure at the time the effect registered the handler. When a presence sync event fires (another user joins/leaves), the handler overwrites the activity log with stale data, silently discarding recent entries added by other handlers.

**Cause**
The `.on('presence', { event: 'sync' }, ...)` callback references `activities` directly instead of using the functional updater pattern:
```
setActivities([
  `${onlineUsers.length} participant(s) online`,
  ...activities,   // stale closure — captured at effect registration time
]);
```

**Fix**
Replaced the stale variable reference with the functional updater:
```
setActivities((prev) => [
  `${onlineUsers.length} participant(s) online`,
  ...prev,
]);
```

**Additional context**
The other two handlers in the same file (join message on line 81, leave message on line 92) already use the correct `setActivities((prev) => [...prev, ...])` pattern. This was an inconsistency bug where the presence sync handler was missed. The bug manifests as seemingly random disappearance of activity log entries when presence sync events fire.

**Closes #792**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved presence synchronization handling to ensure correct ordering of online participant status messages and prevent data inconsistencies during real-time updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->