### PR TITLE
[Critical] fix: replace .single() with .maybeSingle() in RoleContext to prevent silent 404 for new users

### DIFF
--- a/src/contexts/RoleContext.tsx
+++ b/src/contexts/RoleContext.tsx
@@ -46,7 +46,7 @@ export const RoleProvider = ({ children }: { children: ReactNode }) => {
         .from("profiles")
         .select("is_mentor, is_learner")
         .eq("id", user.id)
-        .single();
+        .maybeSingle();
 
       const mentor = profile?.is_mentor === true;
       const learner = profile?.is_learner === true;


### PR DESCRIPTION
**Issue**
The profile fetch in `RoleContext.tsx` uses Supabase's `.single()` method which throws a `PGRST116` error when zero rows match the query. For new users whose profile hasn't been created yet, this silently aborts the role initialization, leaving `isMentor` and `isLearner` at their initial `false` values and preventing the user from seeing role-appropriate UI.

**Cause**
```
const { data: profile } = await supabase
  .from("profiles")
  .select("is_mentor, is_learner")
  .eq("id", user.id)
  .single();   // throws when no row exists
```

**Fix**
Replaced `.single()` with `.maybeSingle()` which returns `null` instead of throwing:
```
const { data: profile } = await supabase
  .from("profiles")
  .select("is_mentor, is_learner")
  .eq("id", user.id)
  .maybeSingle();
```

**Additional context**
`AuthContext.tsx` already uses `.maybeSingle()` correctly in three places (lines 100, 147, 198). This was an inconsistency where `RoleContext.tsx` was written with `.single()`. The optional chaining on `profile?.is_mentor` and `profile?.is_learner` already handles the null case gracefully, so no additional null guard is needed.

**Closes #793**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user profile lookup handling to gracefully manage cases where profile data may be unavailable, reducing potential errors during role initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->