### PR TITLE
[Critical] fix: add Zod validation schemas for mock interview endpoints

### DIFF
--- a/backend/routers/aiRoutes.js
+++ b/backend/routers/aiRoutes.js
@@ -21,7 +21,7 @@ const aiBodyLimit = express.json({ limit: "50kb" });
 
 router.post("/ask", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.askAI), asyncHandler(askAI));
 router.post("/generate-summary", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.generateSessionSummary), asyncHandler(generateSessionSummary));
-router.post("/mock-interview/chat", aiBodyLimit, requireAuth, rateLimiter, asyncHandler(conductMockInterview));
-router.post("/mock-interview/report", aiBodyLimit, requireAuth, rateLimiter, asyncHandler(generateMockInterviewReport));
+router.post("/mock-interview/chat", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.mockInterviewChat), asyncHandler(conductMockInterview));
+router.post("/mock-interview/report", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.mockInterviewReport), asyncHandler(generateMockInterviewReport));
 
 export default router;

--- a/backend/validation/schemas.js
+++ b/backend/validation/schemas.js
@@ -76,6 +76,41 @@ export const aiSchemas = {
       model: z.string().optional()
     }),
   },
+  mockInterviewChat: {
+    body: z.object({
+      messages: z.array(
+        z.object({
+          role: z.enum(["user", "assistant"]),
+          content: z.string().trim().min(1).max(2000),
+        })
+      ).min(1).max(50),
+      role: z.string().trim().min(1).max(200),
+    }),
+  },
+  mockInterviewReport: {
+    body: z
+      .object({
+        messages: z.array(
+          z.object({
+            role: z.enum(["user", "assistant"]),
+            content: z.string().trim().min(1).max(4000),
+          })
+        ).min(1).max(100),
+      })
+      .superRefine((data, ctx) => {
+        const totalLength = data.messages.reduce(
+          (sum, m) => sum + m.content.length,
+          0
+        );
+        if (totalLength > 20000) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["messages"],
+            message: "Total content exceeds maximum allowed length",
+          });
+        }
+      }),
+  },
   generateSessionSummary: {
     body: z
       .object({


### PR DESCRIPTION
**Issue**
The `mock-interview/chat` and `mock-interview/report` endpoints are missing Zod validation middleware, unlike the sibling `/ask` and `/generate-summary` endpoints which are protected by `validate(aiSchemas.askAI)` and `validate(aiSchemas.generateSessionSummary)`. Malformed messages (wrong types, missing fields, excessively long content) pass through to the OpenRouter AI API, wasting tokens and incurring cost.

**Cause**
Route registration showed the gap:
```
router.post("/ask", ..., validate(aiSchemas.askAI), asyncHandler(askAI));
router.post("/generate-summary", ..., validate(aiSchemas.generateSessionSummary), asyncHandler(generateSessionSummary));
router.post("/mock-interview/chat", ..., asyncHandler(conductMockInterview));           // no validate()
router.post("/mock-interview/report", ..., asyncHandler(generateMockInterviewReport));  // no validate()
```

**Fix**
Added Zod schemas for both endpoints in `schemas.js`:
```
mockInterviewChat: {
  body: z.object({
    messages: z.array(
      z.object({ role: z.enum(["user", "assistant"]), content: z.string().trim().min(1).max(2000) })
    ).min(1).max(50),
    role: z.string().trim().min(1).max(200),
  }),
},
mockInterviewReport: {
  body: z.object({
    messages: z.array(
      z.object({ role: z.enum(["user", "assistant"]), content: z.string().trim().min(1).max(4000) })
    ).min(1).max(100),
  }).superRefine((data, ctx) => {
    const totalLength = data.messages.reduce((sum, m) => sum + m.content.length, 0);
    if (totalLength > 20000) {
      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["messages"], message: "Total content exceeds max length" });
    }
  }),
},
```
And applied validation on the routes:
```
router.post("/mock-interview/chat", ..., validate(aiSchemas.mockInterviewChat), asyncHandler(conductMockInterview));
router.post("/mock-interview/report", ..., validate(aiSchemas.mockInterviewReport), asyncHandler(generateMockInterviewReport));
```

**Additional context**
The inline body limit (50KB via `aiBodyLimit`) provides some protection against oversized payloads, but without schema validation, individual malformed messages could still pass through. The sibling endpoints already had this protection — the mock interview endpoints were added later and not integrated with the existing validation pipeline.

**Closes #794**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added request validation to AI mock-interview chat and report endpoints to enforce message format requirements and content length constraints for improved data integrity.

* **Chores**
  * Enhanced API validation infrastructure with improved schema definitions for mock-interview endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->