### PR TITLE
fix: eliminate N+1 query pattern in push notification dispatch

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -40,13 +40,35 @@ export const dispatchPushNotifications = async (req, res, next) => {
       return res.json({ sent: 0, processed: 0 });
     }
 
+    const userIds = [...new Set(notifications.map((n) => n.user_id))];
+
+    // Fetch subscriptions for all notification recipients in a single query.
+    const { data: allSubscriptions, error: subscriptionsError } = await supabase
+      .from("push_subscriptions")
+      .select("user_id,endpoint,p256dh,auth")
+      .in("user_id", userIds);
+
+    if(subscriptionsError) {
+      return res.status(500).json({ error: subscriptionsError.message });
+    }
+
+    // Group subscriptions by user_id for constant-time lookup during dispatch.
+    const subscriptionsByUser = new Map();
+
+    for (const subscription of allSubscriptions || []) {
+
+      if(!subscriptionsByUser.has(subscription.user_id)) {
+        subscriptionsByUser.set(subscription.user_id, []);
+      }
+
+      subscriptionsByUser.get(subscription.user_id).push(subscription);
+    }
+
     let sent = 0;
 
     for (const notification of notifications) {
-      const { data: subscriptions } = await supabase
-        .from("push_subscriptions")
-        .select("endpoint,p256dh,auth")
-        .eq("user_id", notification.user_id);
+      
+      const subscriptions = subscriptionsByUser.get(notification.user_id) || [];
 
       const pushResults = await Promise.allSettled(
         (subscriptions || []).map((subscription) =>


### PR DESCRIPTION
## Related issue
- Fixes #841 

## Description
- This PR optimizes push notification dispatch by eliminating the N+1 query pattern in `backend/controllers/cronController.js`.

- Previously, the dispatcher fetched pending notifications and then executed an additional database query for each notification to fetch the recipient's push subscriptions. As the number of notifications increased, the number of database queries scaled linearly.

## Changes made

- [x] Extracted unique `user_id` values from notifications.
- [x] Added a single bulk query to fetch all required push subscriptions.
- [x] Grouped subscriptions by user_id using an in-memory map.
- [x] Replace per notification subscription queries with constant time map lookups during dispatch.

## Benifit

### Before:
- 1 query -> fetch notifications
- N queries -> fetch subscriptions for each notification
- Total: N+1 queries

### After:
- 1 query -> fetch notifications
- 1 query -> fetch all required subscriptions
- Total: 2 queries
- Less Database roundtrips, lower latency, improved scalability, preserved existing functionality.

## Additional details
- No linting or testing failures observed due to changes introduced in this PR during `npm run lint` and `npm run test`. 
- Closes #841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved push notification delivery system by consolidating subscription data retrieval into a single batch operation rather than individual queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->