### PR TITLE
fix: Implement RFC 5321/5322 compliant email validation (#713)

### DIFF
--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -1,9 +1,49 @@
 import nodemailer from "nodemailer";
 import { env } from "../config.js";
 
-// Basic email format check — catches the most common malformed inputs
-// before a network call is made.
-const isValidEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(value));
+// Stricter email validation following RFC 5321/5322 simplified rules
+// Prevents accepting invalid formats like 'a@b' (no TLD) or single-character components
+const isValidEmail = (value) => {
+  const email = String(value).trim().toLowerCase();
+
+  // RFC 5321/5322 simplified pattern with stricter requirements:
+  // - Local part: alphanumeric, dots, hyphens, underscores, plus signs
+  // - Domain: alphanumeric and hyphens, multiple levels
+  // - TLD: at least 2 characters (required for valid domain)
+  const emailRegex = /^[a-z0-9._%-+]+@[a-z0-9.-]+\.[a-z]{2,}$/i;
+
+  if (!emailRegex.test(email)) {
+    return false;
+  }
+
+  // Additional validation rules
+  // Prevent addresses that exceed RFC 5321 limits (254 chars total, 64 chars local)
+  if (email.length > 254) {
+    return false;
+  }
+
+  const [localPart, domain] = email.split('@');
+  if (localPart.length > 64) {
+    return false;
+  }
+
+  // Prevent consecutive dots (invalid in both local and domain parts)
+  if (email.includes('..')) {
+    return false;
+  }
+
+  // Prevent leading or trailing dots in local part
+  if (localPart.startsWith('.') || localPart.endsWith('.')) {
+    return false;
+  }
+
+  // Prevent leading or trailing hyphens in domain (RFC 952)
+  if (domain.startsWith('-') || domain.endsWith('-')) {
+    return false;
+  }
+
+  return true;
+};
 
 // Ensure the reset URL uses a safe scheme before embedding it in an email.
 // A javascript: or data: URL would execute in some email clients.

--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -10,7 +10,9 @@ const isValidEmail = (value) => {
   // - Local part: alphanumeric, dots, hyphens, underscores, plus signs
   // - Domain: alphanumeric and hyphens, multiple levels
   // - TLD: at least 2 characters (required for valid domain)
-  const emailRegex = /^[a-z0-9._%-+]+@[a-z0-9.-]+\.[a-z]{2,}$/i;
+  // The email is already normalised to lowercase above so the /i flag
+  // is redundant and is intentionally omitted here.
+  const emailRegex = /^[a-z0-9._%-+]+@[a-z0-9.-]+\.[a-z]{2,}$/;
 
   if (!emailRegex.test(email)) {
     return false;
@@ -37,9 +39,18 @@ const isValidEmail = (value) => {
     return false;
   }
 
-  // Prevent leading or trailing hyphens in domain (RFC 952)
-  if (domain.startsWith('-') || domain.endsWith('-')) {
-    return false;
+  // Validate each domain label individually per RFC 1035:
+  // - No empty labels (consecutive dots already caught above, but defensive)
+  // - No label longer than 63 characters
+  // - No leading or trailing hyphen (RFC 952)
+  const domainLabels = domain.split('.');
+  for (const label of domainLabels) {
+    if (label.length === 0 || label.length > 63) {
+      return false;
+    }
+    if (label.startsWith('-') || label.endsWith('-')) {
+      return false;
+    }
   }
 
   return true;


### PR DESCRIPTION
## Summary

Implements RFC 5321/5322 compliant email validation to replace the overly permissive regex that accepted invalid email formats like 'a@b' without TLD.

## Problem

The original regex `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` was too permissive and accepted invalid email formats:
- `a@b` - No TLD, just domain name
- `x@y.c` - Single character components
- No length limit checking
- Allowed consecutive dots

## Solution

Implemented stricter validation following RFC 5321/5322 standards:

**Regex Pattern:**
- Local part: alphanumeric, dots, hyphens, underscores, plus signs
- Domain: alphanumeric and hyphens, multiple levels
- TLD: minimum 2 characters (required)

**Additional Checks:**
- Total length max 254 characters (RFC 5321)
- Local part max 64 characters
- No consecutive dots
- No leading/trailing dots in local part
- No leading/trailing hyphens in domain

## Testing

Rejected formats:
- ❌ `a@b` - No TLD
- ❌ `test@localhost` - localhost invalid
- ❌ `user@.com` - Invalid format
- ❌ `user..name@example.com` - Consecutive dots
- ❌ `.user@example.com` - Leading dot
- ❌ `user@-example.com` - Leading hyphen in domain

Accepted formats:
- ✅ `user@example.com`
- ✅ `user.name+tag@example.co.uk`
- ✅ `first.last@sub.domain.example.com`

## Related Issue

Fixes #713

## GSSoC 2026

This PR addresses validation security improvements within the GSSoC 2026 program.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened email validation: input is normalized (trim/lowercase) and stricter rules now reject invalid addresses (consecutive dots, leading/trailing dots in local part, leading/trailing hyphens in domain).
  * Enforces sensible length limits for local-part and whole address and requires a 2+ character TLD to reduce delivery errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->