### PR TITLE
fix: connect AnonymousDoubts to Supabase — replace hardcoded state wi…

### DIFF
--- a/src/pages/AnonymousDoubts.tsx
+++ b/src/pages/AnonymousDoubts.tsx
@@ -1,109 +1,142 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/useAuth";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
 
-const initialDoubts = [
-  {
-    id: 1,
-    content: "How does React Context work?",
-    subject: "React",
-    anonymous: true,
-    upvotes: 12,
-    replies: ["Used for global state sharing"],
-  },
-  {
-    id: 2,
-    content: "Difference between SQL and NoSQL?",
-    subject: "Database",
-    anonymous: false,
-    upvotes: 8,
-    replies: ["SQL is relational"],
-  },
-];
+type Doubt = {
+  id: string;
+  content: string;
+  subject: string;
+  anonymous: boolean;
+  upvotes: number;
+  created_at: string;
+};
 
 export default function AnonymousDoubts() {
-  const [doubts, setDoubts] = useState(initialDoubts);
+  const { user } = useAuth();
+  const [doubts, setDoubts] = useState<Doubt[]>([]);
+  const [loading, setLoading] = useState(true);
   const [text, setText] = useState("");
   const [subject, setSubject] = useState("");
   const [anonymous, setAnonymous] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
-  const addDoubt = () => {
-    if (!text || !subject) return;
+  useEffect(() => {
+    fetchDoubts();
+  }, []);
 
-    setDoubts([
-      {
-        id: Date.now(),
-        content: text,
-        subject,
-        anonymous,
-        upvotes: 0,
-        replies: [],
-      },
-      ...doubts,
-    ]);
+  const fetchDoubts = async () => {
+    setLoading(true);
+    const { data, error } = await (supabase as any)
+      .from("doubts")
+      .select("id, content, subject, anonymous, upvotes, created_at")
+      .order("created_at", { ascending: false });
 
-    setText("");
-    setSubject("");
-    setAnonymous(false);
+    if (error) {
+      toast.error("Failed to load doubts.");
+    } else {
+      setDoubts(data ?? []);
+    }
+    setLoading(false);
   };
 
-  const upvote = (id: number) => {
+  const addDoubt = async () => {
+    const trimmedText = text.trim();
+    const trimmedSubject = subject.trim();
+    if (!trimmedText || !trimmedSubject) return;
+    if (!user) { toast.error("Please log in to post a doubt."); return; }
+
+    setSubmitting(true);
+    const { error } = await (supabase as any).from("doubts").insert({
+      user_id: anonymous ? null : user.id,
+      content: trimmedText,
+      subject: trimmedSubject,
+      anonymous,
+    });
+
+    if (error) {
+      toast.error("Failed to post doubt.");
+    } else {
+      toast.success("Doubt posted!");
+      setText("");
+      setSubject("");
+      setAnonymous(false);
+      fetchDoubts();
+    }
+    setSubmitting(false);
+  };
+
+  const upvote = (id: string) => {
     setDoubts(
-      doubts.map((d) => (d.id === id ? { ...d, upvotes: d.upvotes + 1 } : d)),
+      doubts.map((d) => (d.id === id ? { ...d, upvotes: d.upvotes + 1 } : d))
     );
   };
 
   return (
-    <div className="p-6">
-      <h1 className="text-3xl font-bold mb-4">Anonymous Doubt Posting</h1>
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6">Anonymous Doubt Posting</h1>
 
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Ask your doubt..."
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-      />
-
-      <input
-        className="border p-2 w-full mb-2"
-        placeholder="Subject Tag"
-        value={subject}
-        onChange={(e) => setSubject(e.target.value)}
-      />
-
-      <label className="flex gap-2 mb-4">
-        <input
-          type="checkbox"
-          checked={anonymous}
-          onChange={() => setAnonymous(!anonymous)}
+      {/* Post a Doubt */}
+      <div className="border rounded-xl p-4 mb-8 space-y-3">
+        <textarea
+          className="border p-2 w-full rounded resize-none"
+          placeholder="Ask your doubt..."
+          rows={3}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
         />
-        Post Anonymously
-      </label>
-
-      <button
-        onClick={addDoubt}
-        className="bg-blue-500 text-white px-4 py-2 rounded"
-      >
-        Post Doubt
-      </button>
-
-      <div className="mt-6 space-y-4">
-        {doubts.map((d) => (
-          <div key={d.id} className="border p-4 rounded">
-            <h2 className="font-bold">{d.anonymous ? "Anonymous" : "User"}</h2>
-            <p>{d.content}</p>
-            <small>{d.subject}</small>
-
-            <button onClick={() => upvote(d.id)} className="ml-4">
-              👍 {d.upvotes}
-            </button>
-
-            <div className="mt-2">
-              {d.replies.map((r, i) => (
-                <p key={i}>↳ {r}</p>
-              ))}
-            </div>
-          </div>
-        ))}
+        <input
+          className="border p-2 w-full rounded"
+          placeholder="Subject Tag (e.g. React, DSA)"
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+        />
+        <label className="flex gap-2 items-center">
+          <input
+            type="checkbox"
+            checked={anonymous}
+            onChange={() => setAnonymous(!anonymous)}
+          />
+          Post Anonymously
+        </label>
+        <button
+          onClick={addDoubt}
+          disabled={submitting || !text.trim() || !subject.trim()}
+          className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+        >
+          {submitting ? "Posting..." : "Post Doubt"}
+        </button>
       </div>
+
+      {/* Doubts List */}
+      {loading ? (
+        <div className="flex justify-center py-10">
+          <Loader2 className="w-8 h-8 animate-spin text-blue-500" />
+        </div>
+      ) : doubts.length === 0 ? (
+        <p className="text-center text-slate-400">No doubts yet. Be the first to ask!</p>
+      ) : (
+        <div className="space-y-4">
+          {doubts.map((d) => (
+            <div key={d.id} className="border p-4 rounded-xl">
+              <div className="flex justify-between items-start">
+                <div>
+                  <h2 className="font-bold">{d.anonymous ? "Anonymous" : "User"}</h2>
+                  <p className="mt-1">{d.content}</p>
+                  <span className="text-xs text-slate-400">{d.subject}</span>
+                </div>
+                <button
+                  onClick={() => upvote(d.id)}
+                  className="ml-4 px-3 py-1 rounded-full text-sm bg-slate-100 hover:bg-blue-100"
+                >
+                  👍 {d.upvotes}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/supabase/migrations/20260608000001_anonymous_doubts.sql
+++ b/supabase/migrations/20260608000001_anonymous_doubts.sql
@@ -1,0 +1,29 @@
+create table if not exists doubts (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references profiles(id) on delete cascade,
+  content     text not null,
+  subject     text not null,
+  anonymous   boolean not null default false,
+  upvotes     integer not null default 0,
+  created_at  timestamptz not null default now()
+);
+
+alter table doubts enable row level security;
+
+create policy "anyone can read doubts"
+  on doubts for select using (true);
+
+revoke select on table doubts from anon, authenticated;
+grant select (id, content, subject, anonymous, upvotes, created_at)
+  on table doubts to anon, authenticated;
+
+create policy "authenticated users can insert doubts"
+  on doubts for insert
+  with check (
+    auth.uid() is not null
+    and (
+      (anonymous = true and user_id is null)
+      or (anonymous = false and user_id = auth.uid())
+    )
+    and upvotes = 0
+  );


### PR DESCRIPTION
## Description
The `AnonymousDoubts` page was completely disconnected from the database. It used only local React state (`useState`) with two hardcoded mock entries (`initialDoubts`). Any doubt posted by a user was lost immediately on page refresh or navigation, and doubts were never visible to other users.

This PR connects the page to Supabase by creating a `doubts` table with RLS policies, replacing the hardcoded state with a fetch on component mount, and saving new doubts via Supabase insert on form submit.

> Note: This is a clean re-submission of #872 (now closed) which had unrelated commits from another feature branch accidentally included in the diff.

## Changes Made

### New Files
- `supabase/migrations/20260608000001_anonymous_doubts.sql` — creates the `doubts` table with RLS policies including column-level security to prevent `user_id` leakage on anonymous posts, and identity spoofing protection on insert

### Modified Files
- `src/pages/AnonymousDoubts.tsx` — replaced hardcoded `initialDoubts` state with Supabase fetch on mount and insert on submit. Added loading state, error handling via toast, input trimming before validation and insert, and disabled submit button until required fields are filled

## What Was Wrong
- Only `useState` was imported — no Supabase client, no fetch call
- Doubts were initialized from a hardcoded array in the component
- No `doubts` table existed in the database schema
- The feature was fully isolated — no backend route, no Supabase query, nothing

## Security Notes (addressed from CodeRabbit review on #872)
- Public SELECT policy now uses column-level grants to exclude `user_id` from anonymous/public reads — prevents identity leakage on anonymous posts
- INSERT policy enforces that `user_id` matches `auth.uid()` for non-anonymous posts, `user_id` is null for anonymous posts, and `upvotes` defaults to 0 — prevents identity spoofing and vote tampering on insert

## Notes
- Upvote spam fix (Bug #837) and Reply functionality fix are tracked as separate issues and will be addressed in separate PRs
- Used `supabase as any` for the new table queries since `types.ts` will need to be regenerated after the migration runs (`supabase gen types typescript`)

## Related Issue
Fixes #836

## Program
GSSoC26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anonymous Doubts section now persists submissions across sessions
  * Submit doubts anonymously or while logged in
  * Upvote doubts to show support
  * Improved user experience with loading indicators and error notifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->