### PR TITLE
fix: (clean) add md and txt to ResourceHub code filter — inconsistent…

### DIFF
--- a/src/pages/ResourceHub.tsx
+++ b/src/pages/ResourceHub.tsx
@@ -46,7 +46,7 @@ const ResourceHub = () => {
       return resources;
     }
 
-    return resources.filter((resource) => ["py", "js", "ts"].includes(resource.file_type));
+    return resources.filter((resource) => ["py", "js", "ts", "md", "txt"].includes(resource.file_type));
   }, [resources, selectedType]);
 
   const gridRows = useMemo(() => {


### PR DESCRIPTION
## Description
The "Code" filter in the Resource Hub only matched three file extensions — `py`, `js`, `ts` — but the upload dialog accepts more file types including `md` and `txt`. This means resources uploaded as `.txt` or `.md` files were never shown when a user clicked the "Code" filter, even though they were legitimately uploaded as code files.

## Root Cause
In `src/pages/ResourceHub.tsx`, the Code filter hardcoded only 3 extensions:

```ts
return resources.filter((resource) => ["py", "js", "ts"].includes(resource.file_type));
```

But in `src/lib/uploadResource.ts`, the allowed upload types include `md` and `txt`:

```ts
const ALLOWED_FILE_TYPES = new Set(["pdf", "docx", "zip", "py", "js", "ts", "md", "txt"]);
```

So `.txt` and `.md` files were accepted on upload but silently excluded from Code filter results. The filter and the uploader were out of sync.

> Note: This is a clean re-submission of #873 (now closed) which had unrelated commits from another feature branch accidentally included in the diff.

## Changes Made
- `src/pages/ResourceHub.tsx` — added `md` and `txt` to the Code filter extensions array

## Related Issue
Fixes #838

## Program
GSSoC26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resource Hub now displays Markdown and text files in addition to previously supported resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->