### PR TITLE
fix(mock-interview): replace undefined session reference with access token

### DIFF
--- a/src/pages/MockInterview.tsx
+++ b/src/pages/MockInterview.tsx
@@ -79,7 +79,7 @@ const MockInterview = () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         credentials: "include",
         body: JSON.stringify({ messages: currentMessages, role }),
@@ -127,7 +127,7 @@ const MockInterview = () => {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {}),
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         credentials: "include",
         body: JSON.stringify({ messages }),


### PR DESCRIPTION
## Description

Fixes a runtime ReferenceError in `MockInterview.tsx` caused by references to an undefined `session` variable when constructing Authorization headers.

## Related Issue

Fixes #877

## Changes Made

- Replaced `session?.access_token` with the token returned by `getAccessToken()`
- Updated both affected request handlers:
  - `sendMessage`
  - `endInterview`

## Testing

- Verified TypeScript compilation succeeds
- Confirmed no undefined `session` references remain in `MockInterview.tsx`
- Verified authentication headers now use the retrieved access token

## Checklist

- [x] Code follows project conventions
- [x] Linked related issue
- [x] Tested changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved authentication handling in mock interview sessions to ensure consistent access token usage for chat and evaluation requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->