### PR TITLE
Added recovery session validation and improved security for ResetPassword page

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -6,32 +6,86 @@ const ResetPassword = () => {
   const navigate = useNavigate();
 
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
+  const [isValidSession, setIsValidSession] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const checkRecoverySession = async () => {
+      try {
+        const {
+          data: { session },
+        } = await supabase.auth.getSession();
+
+        const hasRecoveryHash =
+          window.location.hash.includes("type=recovery");
+
+        // Valid only if Supabase session exists AND came from recovery flow
+        if (session && hasRecoveryHash) {
+          setIsValidSession(true);
+        } else {
+          setMessage(
+            "Invalid or expired reset link. Please request a new password reset email."
+          );
+        }
+      } catch (err) {
+        setMessage("Failed to validate reset session.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    checkRecoverySession();
+  }, []);
 
   const handleReset = async (e) => {
     e.preventDefault();
 
+    if (!isValidSession) {
+      setMessage("Unauthorized password reset attempt.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setMessage("Passwords do not match.");
+      return;
+    }
+
+    if (password.length < 8) {
+      setMessage("Password must be at least 8 characters long.");
+      return;
+    }
+
     try {
-      // Supabase embeds the recovery token in the URL hash when the user
-      // clicks the reset link (e.g. /reset-password#access_token=...&type=recovery).
-      // The Supabase JS client detects the hash on page load and creates a
-      // short-lived recovery session automatically. Calling updateUser here
-      // uses that session to set the new password without needing to extract
-      // or forward any token manually.
-      const { error } = await supabase.auth.updateUser({ password });
+      const { error } = await supabase.auth.updateUser({
+        password,
+      });
 
       if (error) {
         setMessage(error.message);
-      } else {
-        setMessage("Password updated successfully! Redirecting to login...");
-        setTimeout(() => {
-          navigate("/login");
-        }, 2000);
+        return;
       }
-    } catch (error) {
-      setMessage("Something went wrong. Please request a new reset link.");
+
+      setMessage("Password updated successfully. Redirecting...");
+
+      await supabase.auth.signOut();
+
+      setTimeout(() => {
+        navigate("/login");
+      }, 1500);
+    } catch (err) {
+      setMessage("Something went wrong. Please try again.");
     }
   };
+
+  if (loading) {
+    return (
+      <div style={styles.container}>
+        <p>Validating reset session...</p>
+      </div>
+    );
+  }
 
   return (
     <div style={styles.container}>
@@ -40,14 +94,24 @@ const ResetPassword = () => {
       <form onSubmit={handleReset} style={styles.form}>
         <input
           type="password"
-          placeholder="Enter new password"
-          required
+          placeholder="New password"
+          value={password}
           onChange={(e) => setPassword(e.target.value)}
+          required
           style={styles.input}
         />
 
-        <button type="submit" style={styles.button}>
-          Reset Password
+        <input
+          type="password"
+          placeholder="Confirm password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          style={styles.input}
+        />
+
+        <button type="submit" style={styles.button} disabled={!isValidSession}>
+          Update Password
         </button>
       </form>
 


### PR DESCRIPTION
## Description
This PR improves the security and UX of the ResetPassword page by ensuring that password updates only happen through a valid Supabase recovery flow.

Previously, the page allowed any authenticated user to directly access /reset-password and change their password without verifying whether they arrived via a password recovery link. This could lead to unintended or insecure password changes.

## Changes Made
🔒 Security Improvements

- [ ] Added validation to ensure password reset is only allowed via a valid recovery session
- [ ] Checks for type=recovery in the URL hash and Supabase session state before allowing updates

🧩 UX Improvements

- [ ] Added password confirmation field to prevent accidental mismatches
- [ ] Added basic validation for password match and minimum length

🚫 Access Control

- [ ] Prevents direct access to password reset functionality without a valid recovery flow
- [ ] Displays error message for invalid or expired reset attempts

🔄 Auth Handling

- [ ] Signs out user after successful password reset for security
- [ ] Redirects user to login page after completion

🧪 Testing Done

- [ ] Verified recovery flow using Supabase password reset email link
- [ ] Verified that direct navigation to /reset-password is blocked
- [ ] Tested password mismatch validation
- [ ] Tested successful password update and redirect flow

##  Related Issue
Closes #885 (ResetPassword page security issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password reset security with session validation to prevent unauthorized changes
  * Added password confirmation requirement for accuracy
  * Enforced minimum 8-character password length
  * Users are automatically signed out after successful password reset with redirect to login

<!-- end of auto-generated comment: release notes by coderabbit.ai -->