### PR TITLE
fix: resolve overloaded webhook auth vulnerability

### DIFF
--- a/backend/routers/notificationRoutes.js
+++ b/backend/routers/notificationRoutes.js
@@ -1,7 +1,6 @@
 import express from "express";
 import crypto from "crypto";
 import { sendPushNotification } from "../controllers/notificationController.js";
-import { requireAuth } from "../middlewares/requireAuth.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
 import { HttpError } from "../utils/httpError.js";
 import {
@@ -12,12 +11,16 @@ import {
 
 const router = express.Router();
 
-// Custom middleware to support both CRON/WEBHOOK secret and user auth
+// Custom middleware to strictly verify WEBHOOK secret
 const verifyNotificationAuth = (req, res, next) => {
   const authHeader = req.headers.authorization;
   const webhookSecret = process.env.WEBHOOK_SECRET;
 
-  if (webhookSecret && authHeader && authHeader.startsWith("Bearer ")) {
+  if (!webhookSecret) {
+    return next(new HttpError(500, "Webhook secret is not configured on the server"));
+  }
+
+  if (authHeader && authHeader.startsWith("Bearer ")) {
     const providedSecret = authHeader.slice(7);
 
     // Both buffers must be the same length for timingSafeEqual.
@@ -42,8 +45,7 @@ const verifyNotificationAuth = (req, res, next) => {
     }
   }
 
-  // Fallback to standard user auth
-  return requireAuth(req, res, next);
+  return next(new HttpError(401, "Unauthorized webhook access"));
 };
 
 router.post("/send-push", verifyNotificationAuth, asyncHandler(sendPushNotification));

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,3 +1,5 @@
+process.env.OPENROUTER_API_KEY = "dummy-test-key";
+
 vi.mock("openai", () => {
   return {
     default: class {

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,4 +1,4 @@
-process.env.OPENROUTER_API_KEY = "dummy-test-key";
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "dummy-test-key";
 
 vi.mock("openai", () => {
   return {


### PR DESCRIPTION
Fixes #857

This PR removes the silent fallback to user authentication in the webhook middleware (\erifyNotificationAuth\). The middleware now strictly requires \process.env.WEBHOOK_SECRET\ and validates it against the \Authorization\ header. If the secret is missing or the header doesn't match, it returns a \401 Unauthorized\ or \500\ response immediately, preventing unauthorized access.