### PR TITLE
feat: add rls policies for system_config table

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,3 +1,5 @@
+process.env.OPENROUTER_API_KEY = "dummy-test-key";
+
 vi.mock("openai", () => {
   return {
     default: class {

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,4 +1,4 @@
-process.env.OPENROUTER_API_KEY = "dummy-test-key";
+process.env.OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY || "dummy-test-key";
 
 vi.mock("openai", () => {
   return {

--- a/supabase/migrations/20260609000000_secure_system_config_rls.sql
+++ b/supabase/migrations/20260609000000_secure_system_config_rls.sql
@@ -1,0 +1,24 @@
+-- Enable Row-Level Security on system_config
+ALTER TABLE public.system_config ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing restrictive policies if they exist to prevent conflicts
+DROP POLICY IF EXISTS "Deny all access to system_config" ON public.system_config;
+DROP POLICY IF EXISTS "Allow admin access to system_config" ON public.system_config;
+
+-- Create policy for admin access
+CREATE POLICY "Allow admin access to system_config"
+ON public.system_config
+FOR ALL
+TO authenticated
+USING (
+    EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid() AND role = 'admin'
+    )
+)
+WITH CHECK (
+    EXISTS (
+        SELECT 1 FROM public.profiles
+        WHERE id = auth.uid() AND role = 'admin'
+    )
+);


### PR DESCRIPTION
Fixes #859

This PR introduces granular Row-Level Security (RLS) policies for the \system_config\ table. It ensures that only authenticated users with the \dmin\ role can read or modify system configurations, while completely denying access to standard users and anonymous clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Row-level security enabled for system configuration; access and write operations are limited to authenticated admin profiles.
* **Tests**
  * Test setup injects a dummy API key into the environment when none is present to ensure tests run reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->