### PR TITLE
Fix ResetPassword recovery validation and password confirmation

### DIFF
--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -6,18 +6,73 @@ const ResetPassword = () => {
   const navigate = useNavigate();
 
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [message, setMessage] = useState("");
+  const [isCheckingRecovery, setIsCheckingRecovery] = useState(true);
+  const [isRecoverySession, setIsRecoverySession] = useState(false);
 
-  const handleReset = async (e) => {
+  useEffect(() => {
+    let cancelled = false;
+
+    const hash = window.location.hash.startsWith("#")
+      ? window.location.hash.slice(1)
+      : window.location.hash;
+    const hashParams = new URLSearchParams(hash);
+    const isRecoveryLink = hashParams.get("type") === "recovery";
+
+    if (!isRecoveryLink) {
+      setIsRecoverySession(false);
+      setIsCheckingRecovery(false);
+      setMessage("Invalid or expired reset link. Request a new password reset email.");
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      if (cancelled) return;
+      setIsRecoverySession(false);
+      setIsCheckingRecovery(false);
+      setMessage("Invalid or expired reset link. Request a new password reset email.");
+    }, 10000);
+
+    const { data: listener } = supabase.auth.onAuthStateChange((event, session) => {
+      if (cancelled) return;
+
+      if (event === "PASSWORD_RECOVERY" && session) {
+        window.clearTimeout(timeoutId);
+        setIsRecoverySession(true);
+        setIsCheckingRecovery(false);
+        setMessage("");
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+      listener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleReset = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
+    if (isCheckingRecovery) {
+      setMessage("Checking reset link. Please wait a moment.");
+      return;
+    }
+
+    if (!isRecoverySession) {
+      setMessage("Invalid or expired reset link. Request a new password reset email.");
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setMessage("Passwords do not match.");
+      return;
+    }
+
     try {
-      // Supabase embeds the recovery token in the URL hash when the user
-      // clicks the reset link (e.g. /reset-password#access_token=...&type=recovery).
-      // The Supabase JS client detects the hash on page load and creates a
-      // short-lived recovery session automatically. Calling updateUser here
-      // uses that session to set the new password without needing to extract
-      // or forward any token manually.
       const { error } = await supabase.auth.updateUser({ password });
 
       if (error) {
@@ -46,7 +101,15 @@ const ResetPassword = () => {
           style={styles.input}
         />
 
-        <button type="submit" style={styles.button}>
+        <input
+          type="password"
+          placeholder="Confirm new password"
+          required
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          style={styles.input}
+        />
+
+        <button type="submit" style={styles.button} disabled={isCheckingRecovery || !isRecoverySession}>
           Reset Password
         </button>
       </form>
@@ -56,7 +119,7 @@ const ResetPassword = () => {
   );
 };
 
-const styles = {
+const styles: Record<string, React.CSSProperties> = {
   container: {
     height: "100vh",
     display: "flex",


### PR DESCRIPTION
## Summary

Fixed password reset flow validation in ResetPassword.tsx.

### Changes

* Added recovery flow validation using Supabase PASSWORD_RECOVERY event
* Added URL hash validation for type=recovery
* Added password confirmation field
* Added password mismatch validation
* Blocked direct access to reset flow without valid recovery state
* Added cleanup for auth subscription and timeout

This addresses the assigned password reset security issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Confirm new password" field to the password reset form
  * Implemented recovery link validation with timeout protection
  * Form submission now requires an active recovery session

* **Bug Fixes**
  * Enhanced error messaging for invalid or expired recovery links
  * Form submission is blocked during recovery session validation
  * Improved handling of failed password reset scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->