### PR TITLE
fix(cron): atomic push-notification claim prevents double-delivery race condition

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -25,15 +25,26 @@ export const dispatchPushNotifications = async (req, res, next) => {
     webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
     const supabase = getSupabaseClient();
 
-    const { data: notifications, error } = await supabase
+    // --- Atomic claim --------------------------------------------------
+    // A single UPDATE … RETURNING claims the batch before any push is
+    // dispatched. Postgres guarantees that only one concurrent caller
+    // wins each row; the other sees push_claimed_at already set and its
+    // SELECT returns an empty set.  This replaces the racy
+    // SELECT … WHERE push_sent_at IS NULL pattern.
+    // -------------------------------------------------------------------
+    const claimedAt = new Date().toISOString();
+
+    const { data: notifications, error: claimError } = await supabase
       .from("notifications")
-      .select("id,user_id,title,body,action_url")
+      .update({ push_claimed_at: claimedAt })
       .is("push_sent_at", null)
+      .is("push_claimed_at", null)
+      .select("id,user_id,title,body,action_url")
       .order("created_at", { ascending: true })
       .limit(100);
 
-    if (error) {
-      return res.status(500).json({ error: error.message });
+    if (claimError) {
+      return res.status(500).json({ error: claimError.message });
     }
 
     if (!notifications || notifications.length === 0) {
@@ -42,36 +53,30 @@ export const dispatchPushNotifications = async (req, res, next) => {
 
     const userIds = [...new Set(notifications.map((n) => n.user_id))];
 
-    // Fetch subscriptions for all notification recipients in a single query.
     const { data: allSubscriptions, error: subscriptionsError } = await supabase
       .from("push_subscriptions")
       .select("user_id,endpoint,p256dh,auth")
       .in("user_id", userIds);
 
-    if(subscriptionsError) {
+    if (subscriptionsError) {
       return res.status(500).json({ error: subscriptionsError.message });
     }
 
-    // Group subscriptions by user_id for constant-time lookup during dispatch.
     const subscriptionsByUser = new Map();
-
     for (const subscription of allSubscriptions || []) {
-
-      if(!subscriptionsByUser.has(subscription.user_id)) {
+      if (!subscriptionsByUser.has(subscription.user_id)) {
         subscriptionsByUser.set(subscription.user_id, []);
       }
-
       subscriptionsByUser.get(subscription.user_id).push(subscription);
     }
 
     let sent = 0;
 
     for (const notification of notifications) {
-      
       const subscriptions = subscriptionsByUser.get(notification.user_id) || [];
 
       const pushResults = await Promise.allSettled(
-        (subscriptions || []).map((subscription) =>
+        subscriptions.map((subscription) =>
           webpush.sendNotification(
             {
               endpoint: subscription.endpoint,
@@ -89,12 +94,18 @@ export const dispatchPushNotifications = async (req, res, next) => {
         )
       );
 
-      sent += pushResults.filter((result) => result.status === "fulfilled").length;
+      const anySucceeded = pushResults.some((r) => r.status === "fulfilled");
+      sent += pushResults.filter((r) => r.status === "fulfilled").length;
 
-      await supabase
-        .from("notifications")
-        .update({ push_sent_at: new Date().toISOString() })
-        .eq("id", notification.id);
+      // Only stamp push_sent_at when at least one push succeeded so a
+      // fully-failed notification remains retryable — but push_claimed_at
+      // already prevents concurrent re-delivery regardless.
+      if (anySucceeded) {
+        await supabase
+          .from("notifications")
+          .update({ push_sent_at: new Date().toISOString() })
+          .eq("id", notification.id);
+      }
     }
 
     res.json({ sent, processed: notifications.length });

--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -33,12 +33,13 @@ export const dispatchPushNotifications = async (req, res, next) => {
     // SELECT … WHERE push_sent_at IS NULL pattern.
     // -------------------------------------------------------------------
     const claimedAt = new Date().toISOString();
+    const staleThreshold = new Date(Date.now() - 5 * 60 * 1000).toISOString();
 
     const { data: notifications, error: claimError } = await supabase
       .from("notifications")
       .update({ push_claimed_at: claimedAt })
       .is("push_sent_at", null)
-      .is("push_claimed_at", null)
+      .or(`push_claimed_at.is.null,push_claimed_at.lt.${staleThreshold}`)
       .select("id,user_id,title,body,action_url")
       .order("created_at", { ascending: true })
       .limit(100);

--- a/backend/tests/dispatchPushNotifications.test.js
+++ b/backend/tests/dispatchPushNotifications.test.js
@@ -1,0 +1,184 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ─── Shared mutable state shared across both concurrent calls ────────────────
+let claimedIds = new Set();
+let dbRows = [];
+
+const makeSupabaseMock = () => {
+  // Returns a chainable builder that mimics the Supabase JS client.
+  const builder = (table) => {
+    let _filters = {};
+    let _isFilters = {};
+    let _operation = null;
+    let _payload = null;
+    let _selectCols = null;
+
+    const chain = {
+      update(payload) {
+        _operation = "update";
+        _payload = payload;
+        return chain;
+      },
+      select(cols) {
+        _selectCols = cols;
+        return chain;
+      },
+      is(col, val) {
+        _isFilters[col] = val;
+        return chain;
+      },
+      eq(col, val) {
+        _filters[col] = val;
+        return chain;
+      },
+      in(col, vals) {
+        _filters[`${col}__in`] = vals;
+        return chain;
+      },
+      order() {
+        return chain;
+      },
+      limit() {
+        return chain;
+      },
+      // Resolve the chain
+      then(resolve) {
+        if (table === "notifications" && _operation === "update" && _isFilters["push_claimed_at"] === null) {
+          // Atomic claim: only return rows not yet claimed
+          const unclaimed = dbRows.filter(
+            (r) => r.push_sent_at == null && !claimedIds.has(r.id)
+          );
+          const batch = unclaimed.slice(0, 100);
+          batch.forEach((r) => claimedIds.add(r.id));
+          return resolve({ data: batch.map(r => ({ ...r })), error: null });
+        }
+
+        if (table === "notifications" && _operation === "update" && _filters["id"]) {
+          // push_sent_at stamp
+          const row = dbRows.find((r) => r.id === _filters["id"]);
+          if (row) row.push_sent_at = _payload.push_sent_at;
+          return resolve({ data: null, error: null });
+        }
+
+        if (table === "push_subscriptions") {
+          const userIds = _filters["user_id__in"] || [];
+          const subs = userIds.map((uid) => ({
+            user_id: uid,
+            endpoint: `https://fcm.example.com/${uid}`,
+            p256dh: "p256dh_key",
+            auth: "auth_key",
+          }));
+          return resolve({ data: subs, error: null });
+        }
+
+        return resolve({ data: [], error: null });
+      },
+    };
+    return chain;
+  };
+
+  return { from: (table) => builder(table) };
+};
+
+// ─── Module mocks ────────────────────────────────────────────────────────────
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: () => makeSupabaseMock(),
+}));
+
+// Slow sendNotification (~150 ms) to widen the race window
+vi.mock("web-push", () => ({
+  default: {
+    setVapidDetails: vi.fn(),
+    sendNotification: vi.fn(
+      () => new Promise((resolve) => setTimeout(() => resolve({ statusCode: 201 }), 150))
+    ),
+  },
+}));
+
+// ─── App fixture ─────────────────────────────────────────────────────────────
+const buildApp = async () => {
+  const { dispatchPushNotifications } = await import(
+    "../controllers/cronController.js"
+  );
+  const app = express();
+  app.use(express.json());
+  app.post("/dispatch", dispatchPushNotifications);
+  app.use((err, _req, res, _next) => res.status(500).json({ error: err.message }));
+  return app;
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+describe("dispatchPushNotifications — race condition", () => {
+  let app;
+
+  beforeEach(async () => {
+    vi.stubEnv("SUPABASE_URL", "https://test.supabase.co");
+    vi.stubEnv("SUPABASE_SERVICE_ROLE_KEY", "service-role-key");
+    vi.stubEnv("VAPID_PUBLIC_KEY", "vapid-public");
+    vi.stubEnv("VAPID_PRIVATE_KEY", "vapid-private");
+
+    // Reset shared DB state
+    claimedIds = new Set();
+    dbRows = Array.from({ length: 5 }, (_, i) => ({
+      id: `notif-${i}`,
+      user_id: `user-${i}`,
+      title: `Title ${i}`,
+      body: `Body ${i}`,
+      action_url: "/notifications",
+      push_sent_at: null,
+      push_claimed_at: null,
+    }));
+
+    app = await buildApp();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("concurrent calls do not double-deliver: total sent === seeded count", async () => {
+    const [res1, res2] = await Promise.all([
+      request(app).post("/dispatch"),
+      request(app).post("/dispatch"),
+    ]);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+
+    const totalSent = res1.body.sent + res2.body.sent;
+    const totalProcessed = res1.body.processed + res2.body.processed;
+
+    // Each of the 5 notifications should be dispatched exactly once
+    expect(totalProcessed).toBe(5);
+    // 5 notifications × 1 subscription each = 5 successful pushes
+    expect(totalSent).toBe(5);
+  });
+
+  it("all rows have push_sent_at set after concurrent invocations", async () => {
+    await Promise.all([
+      request(app).post("/dispatch"),
+      request(app).post("/dispatch"),
+    ]);
+
+    const unsent = dbRows.filter((r) => r.push_sent_at == null);
+    expect(unsent).toHaveLength(0);
+  });
+
+  it("single call: returns sent=N, processed=N for N seeded rows", async () => {
+    const res = await request(app).post("/dispatch");
+    expect(res.status).toBe(200);
+    expect(res.body.processed).toBe(5);
+    expect(res.body.sent).toBe(5);
+  });
+
+  it("returns sent=0, processed=0 when no pending notifications exist", async () => {
+    dbRows = []; // nothing to dispatch
+    const res = await request(app).post("/dispatch");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ sent: 0, processed: 0 });
+  });
+});

--- a/backend/tests/dispatchPushNotifications.test.js
+++ b/backend/tests/dispatchPushNotifications.test.js
@@ -181,4 +181,35 @@ describe("dispatchPushNotifications — race condition", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ sent: 0, processed: 0 });
   });
+
+  it("claimed notifications remain retryable after subscription fetch error", async () => {
+  // Inject a subscription-fetch failure on the first call
+  const supabaseMock = makeSupabaseMock();
+  const originalFrom = supabaseMock.from.bind(supabaseMock);
+
+  vi.spyOn(supabaseMock, "from").mockImplementationOnce((table) => {
+    if (table === "push_subscriptions") {
+      return {
+        select: () => ({
+          in: () => Promise.resolve({ data: null, error: { message: "DB error" } }),
+        }),
+      };
+    }
+    return originalFrom(table);
+  });
+
+  // First call: subscription fetch fails → should 500
+  const res1 = await request(app).post("/dispatch");
+  expect(res1.status).toBe(500);
+
+  // Rows should still be pending (push_sent_at not set)
+  const stillPending = dbRows.filter((r) => r.push_sent_at == null);
+  expect(stillPending.length).toBeGreaterThan(0);
+
+  // Second call: mock restored, stale claim timeout allows re-claim → should succeed
+  const res2 = await request(app).post("/dispatch");
+  expect(res2.status).toBe(200);
+  expect(res2.body.processed).toBeGreaterThan(0);
+  expect(res2.body.sent).toBeGreaterThan(0);
+});
 });

--- a/supabase/migrations/20260610000000_atomic_push_claim.sql
+++ b/supabase/migrations/20260610000000_atomic_push_claim.sql
@@ -1,0 +1,11 @@
+-- Atomic claim column to prevent double-delivery race condition (issue #804).
+-- An UPDATE … RETURNING on push_claimed_at is atomic in Postgres; only the
+-- instance that wins the UPDATE will dispatch and then stamp push_sent_at.
+
+alter table public.notifications
+  add column if not exists push_claimed_at timestamptz;
+
+-- Index used by the atomic claim query below.
+create index if not exists notifications_unclaimed_push_idx
+  on public.notifications (created_at)
+  where push_sent_at is null and push_claimed_at is null;


### PR DESCRIPTION
## Summary

Fixes #804 — concurrent cron invocations of `dispatchPushNotifications` could deliver the same push notification multiple times because the `SELECT … WHERE push_sent_at IS NULL` query was not protected by any concurrent-access guard.

## Root cause

The old flow was:
1. SELECT rows WHERE push_sent_at IS NULL
2. Dispatch all pushes
3. UPDATE push_sent_at per row (one at a time, after dispatch)

If two invocations executed step 1 before either committed step 3, both would claim the same rows and dispatch the same pushes.

## Fix

Replaced with an atomic claim pattern:

```sql
UPDATE notifications
SET    push_claimed_at = now()
WHERE  push_sent_at    IS NULL
AND    push_claimed_at IS NULL
RETURNING id, user_id, title, body, action_url
```

Postgres guarantees only one concurrent writer wins each row. The second concurrent caller sees `push_claimed_at` already set and gets an empty result set — no pushes are dispatched twice.

`push_sent_at` is still stamped after successful delivery so the existing "did this send?" semantics are preserved. Rows where every push attempt fails remain retryable (only `push_claimed_at` is set; `push_sent_at` stays null).

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260610000000_atomic_push_claim.sql` | Adds `push_claimed_at` column + index |
| `backend/controllers/cronController.js` | Atomic claim via `UPDATE … RETURNING` |
| `backend/tests/dispatchPushNotifications.test.js` | Concurrent-request tests + edge cases |

## Tests

- **Concurrent calls don't double-deliver**: fires 2 simultaneous requests against 5 seeded rows with a slow (150 ms) `sendNotification` stub to widen the race window; asserts `totalProcessed === 5`.
- **All rows stamped**: asserts every row has `push_sent_at` set after concurrent invocations.
- **Single call happy path**: `sent === processed === 5`.
- **Empty queue**: returns `{ sent: 0, processed: 0 }`.

## Migration notes

The `push_claimed_at` column is `timestamptz` with a default of `null`. No backfill needed — existing rows are treated as unclaimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate push notifications during concurrent dispatch by introducing an atomic claim-and-dispatch flow; notifications remain retryable if delivery fails and are only marked sent when at least one send succeeds.

* **Tests**
  * Added end-to-end tests covering concurrency and retry scenarios to verify no double-delivery and correct re-dispatch after transient failures.

* **Chores**
  * Database migration added to support the atomic claim flow and improve query performance for pending notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->