### PR TITLE
[Bug] Typing indicator creates unsubscribed Supabase channels on every keystroke

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -141,6 +141,7 @@ const Chat = () => {
   const stopTypingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const conversationsParentRef = useRef<HTMLDivElement | null>(null);
   const messagesParentRef = useRef<HTMLDivElement | null>(null);
+  const typingChannelRef = useRef<ReturnType<typeof supabase.channel> | null>(null);
 
   const filteredUsers = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -372,10 +373,12 @@ const Chat = () => {
         }
       })
       .subscribe();
+    typingChannelRef.current = typingChannel;
 
     return () => {
       supabase.removeChannel(messageChannel);
       supabase.removeChannel(typingChannel);
+      typingChannelRef.current = null;
 
       if (typingTimeoutRef.current) {
         clearTimeout(typingTimeoutRef.current);
@@ -384,22 +387,18 @@ const Chat = () => {
   }, [currentUser?.id, selectedUser?.id]);
 
   const sendTypingStatus = useCallback(async (isTyping: boolean) => {
-    if (!currentUser?.id || !selectedUser?.id) return;
+    if (!typingChannelRef.current) return;
 
-    await supabase
-      .channel(`chat-typing-${[currentUser.id, selectedUser.id].sort().join("-")}`, {
-        config: { private: true },
-      })
-      .send({
-        type: "broadcast",
-        event: "typing",
-        payload: {
-          senderId: currentUser.id,
-          receiverId: selectedUser.id,
-          isTyping,
-        },
-      });
-  }, [currentUser?.id, selectedUser?.id]);
+    await typingChannelRef.current.send({
+      type: "broadcast",
+      event: "typing",
+      payload: {
+        senderId: currentUser?.id,
+        receiverId: selectedUser?.id,
+        isTyping,
+      },
+    });
+  }, []);
 
   const handleMessageChange = useCallback((value: string) => {
     setMessageText(value);


### PR DESCRIPTION
## Description
Fixes #901 — sendTypingStatus created a new Supabase Realtime channel on every keystroke without calling .subscribe(), leaking memory and breaking the typing indicator feature entirely.

## Root Cause
Lines 386-402 created a new supabase.channel(...) on every onChange but never .subscribe()d it, so .send() silently dropped broadcasts. Multiple channels accumulated without cleanup.

## Fix
Added a 	ypingChannelRef that stores the already-subscribed 	ypingChannel created in the effect (lines 351-374). sendTypingStatus now reuses this ref instead of creating orphaned channels.

## Changes
1. Added 	ypingChannelRef next to existing timeout refs
2. Store 	ypingChannel in ref after .subscribe() 
3. Clear ref in cleanup (unsubscribe)
4. Rewrote sendTypingStatus to use 	ypingChannelRef.current.send(...)

Closes #901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized chat typing status broadcast handling for improved efficiency in managing and transmitting real-time typing indicators during conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->