### PR TITLE
[Bug] getRecommendedPartners returns fabricated pagination metadata

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -130,14 +130,24 @@ export const getRecommendedPartners = async (req, res) => {
       };
     });
 
-    // In a real paginated RPC, getting exact total Count requires a separate count query. 
-    // We'll estimate or just provide length for now since counting 1M rows can also be slow.
+    // Get a proper total count for pagination metadata
+    const { count: totalCount, error: countError } = await supabaseAdmin
+      .from("profiles")
+      .select("id", { count: "exact", head: true })
+      .not("email", "eq", currentUserEmail);
+
+    const total = countError || totalCount === null
+      ? recommendations.length
+      : totalCount;
+
+    const totalPages = Math.ceil(total / limit);
+
     res.status(200).json({
       success: true,
       count: recommendations.length,
-      total: recommendations.length > 0 ? skip + limit + 1 : skip, // Rough pagination cursor hack
+      total,
       page,
-      totalPages: recommendations.length === limit ? page + 1 : page,
+      totalPages,
       recommendations,
     });
   } catch (error) {


### PR DESCRIPTION
## Description
Fixes #903 — getRecommendedPartners returned fabricated pagination metadata: 	otal was skip + limit + 1 and 	otalPages was guessed based on whether results filled the page, both of which were incorrect.

## Root Cause
The developer skipped the count query for performance reasons and used heuristic placeholders that did not reflect the actual total.

## Fix
Added a proper count query on the profiles table (excluding the current user) to provide accurate 	otal and 	otalPages values. Falls back to ecommendations.length on error.

Closes #903

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Improved pagination accuracy for partner recommendations by using precise server-side count calculations instead of estimates, ensuring correct total pages display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->