### PR TITLE
fix: protect profile photo upload route

### DIFF
--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -4,6 +4,7 @@ import path from "path";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { fileTypeFromFile } from "file-type";
+import { requireAuth } from "../middlewares/requireAuth.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -70,7 +71,7 @@ const safeUnlink = (filePath) => {
 };
 
 // User profile photo upload endpoint
-router.post("/upload-photo", uploadProfilePhoto, async (req, res) => {
+router.post("/upload-photo", requireAuth, uploadProfilePhoto, async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: "No file uploaded or invalid file type." });
   }


### PR DESCRIPTION
## Closes #932 
## Summary

Adds authentication middleware to the profile photo upload endpoint so unauthenticated users cannot upload files.

## Changes

- Imported `requireAuth` in `backend/routes/users.js`
- Added `requireAuth` before `uploadProfilePhoto` on `POST /api/users/upload-photo`

## Testing

- Verified middleware order ensures unauthenticated requests are rejected before upload handling runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Profile photo upload endpoint now requires authentication, ensuring only authorized users can upload profile images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->