### PR TITLE
fix(GroupPomodoro): clear interval before calling handleTimerComplete

### DIFF
--- a/src/components/GroupPomodoro.tsx
+++ b/src/components/GroupPomodoro.tsx
@@ -74,6 +74,7 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
         
         // Timer completed!
         if (diff === 0) {
+          clearInterval(interval);
           handleTimerComplete();
         }
       }, 1000);


### PR DESCRIPTION
Closes #939

## What

Once `diff` hits 0 it stays 0 on every tick because `Math.max(0, ...)` clamps it. This caused `handleTimerComplete` to fire on every subsequent interval tick until the Supabase state update came back and triggered a re-render.

## Fix

Added `clearInterval(interval)` inside the `if (diff === 0)` block before the `handleTimerComplete()` call. The interval variable is in scope because the `setInterval` return value is assigned to it before the callback can run, so clearing it from within the callback is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the group Pomodoro timer could continue running or behave unexpectedly after reaching zero, ensuring it properly stops at completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->