### PR TITLE
fix(db): replace non-existent 'users' table with 'profiles'

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -57,7 +57,7 @@ const Navbar = () => {
       }
 
         const { data: profile } = await supabase
-          .from("users")
+          .from("profiles")
           .select("name")
           .eq("id", user.id)
           .single();

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -167,7 +167,7 @@ export function useMessages(currentUserId?: string | null) {
             .order("name", { ascending: true })
             .limit(100),
           supabase
-            .from("users")
+            .from("profiles")
             .select("*")
             .neq("id", currentUserId)
             .order("name", { ascending: true })

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -186,7 +186,7 @@ const Chat = () => {
           .order("name", { ascending: true })
           .limit(100),
         supabase
-          .from("users")
+          .from("profiles")
           .select("*")
           .neq("id", currentUser.id)
           .order("name", { ascending: true })


### PR DESCRIPTION
Closes #940

Three files queried `supabase.from("users")` which doesn't exist in the public schema — all 88 migrations create and use a `profiles` table. The query returned `{ data: null }` silently, so the `if (profile)` guard suppressed the error and users always saw "User" in the navbar.

Changed `from("users")` to `from("profiles")` in:
- `src/components/Navbar.tsx` — profile name fetch
- `src/hooks/useMessages.ts` — sender name lookup
- `src/pages/Chat.tsx` — sender name lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal user profile data retrieval logic across multiple components including navigation features, user messaging, and chat interactions. Updates standardize how user information is fetched and processed throughout the application, streamlining data handling patterns, aligning database query structures, and improving consistency across different areas of the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->