### PR TITLE
fix(privacy): remove peer email address from SuggestedPartners

### DIFF
--- a/src/components/SuggestedPartners.tsx
+++ b/src/components/SuggestedPartners.tsx
@@ -4,7 +4,6 @@ import { API_BASE_URL } from "@/config/api";
 interface Partner {
   _id: string;
   name: string;
-  email: string;
   skills: string[];
   interests: string[];
   compatibilityScore: number;
@@ -56,10 +55,6 @@ const SuggestedPartners = () => {
                 {partner.compatibilityScore}% Match
               </span>
             </div>
-
-            <p className="text-sm text-gray-400 mb-2">
-              {partner.email}
-            </p>
 
             <div className="mb-3">
               <h4 className="font-medium text-white mb-1">


### PR DESCRIPTION
Closes #942

`partner.email` was rendered in a `<p>` tag on the dashboard, exposing every user's email address to all authenticated visitors. The `Partner` interface included `email` which pulled it from the backend recommendations payload.

Removed `email` from the `Partner` interface and deleted the rendering line. Peer contact should go through the in-app messaging system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Email addresses are no longer displayed on suggested partner cards. All other information including compatibility scores, skills, interests, and connection options remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->