### PR TITLE
feat(cron): add weekly focus time reset endpoint

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -304,3 +304,22 @@ export const sendMentorshipCheckinReminders = async (req, res, next) => {
     next(error);
   }
 };
+
+export const resetWeeklyFocusTime = async (req, res, next) => {
+  try {
+    const supabase = getSupabaseClient();
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({ focus_time_this_week: 0 })
+      .neq("focus_time_this_week", 0);
+
+    if (error) {
+      return res.status(500).json({ error: error.message });
+    }
+
+    res.json({ reset: true });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/routers/cronRoutes.js
+++ b/backend/routers/cronRoutes.js
@@ -4,6 +4,7 @@ import {
   dispatchPushNotifications,
   sendSessionReminders,
   sendMentorshipCheckinReminders,
+  resetWeeklyFocusTime,
 } from "../controllers/cronController.js";
 import { asyncHandler } from "../utils/asyncHandler.js";
 
@@ -35,6 +36,12 @@ router.post(
   "/mentorship-reminders",
   requireCronSecret,
   asyncHandler(sendMentorshipCheckinReminders)
+);
+
+router.post(
+  "/reset-weekly-focus",
+  requireCronSecret,
+  asyncHandler(resetWeeklyFocusTime)
 );
 
 export default router;


### PR DESCRIPTION
Closes #943

`focus_time_this_week` was never reset, so it accumulated as a monotonically increasing lifetime total while the Dashboard displayed it as a weekly metric. There was no cron task, trigger, or scheduled function to clear it.

Added `POST /api/cron/reset-weekly-focus` to `cronController.js` and wired it into `cronRoutes.js` behind the existing `requireCronSecret` middleware. The handler runs `UPDATE profiles SET focus_time_this_week = 0 WHERE focus_time_this_week != 0` — skipping already-zero rows to avoid unnecessary writes.

To complete the fix: schedule this endpoint to fire every Monday at 00:00 UTC via whatever cron provider the deployment uses (Vercel Cron, GitHub Actions, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekly focus time metrics now automatically reset for all users, enabling fresh tracking each week.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->