### PR TITLE
fix(ai): prevent prompt injection in mock interview endpoint

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -292,6 +292,11 @@ export const conductMockInterview = async (req, res, next) => {
     if (typeof role !== "string" || !role.trim()) {
       return res.status(400).json({ error: "Role is required" });
     }
+    
+    const safeRole = role.replace(/[^a-zA-Z0-9\s-]/g, "").trim().slice(0, 100);
+    if (!safeRole) {
+      return res.status(400).json({ error: "Invalid role provided" });
+    }
 
     const latestMessage = messages[messages.length - 1].content;
     if (typeof latestMessage !== "string" || latestMessage.length > 2000) {
@@ -303,7 +308,7 @@ export const conductMockInterview = async (req, res, next) => {
     const openRouterMessages = [
       {
         role: "system",
-        content: `You are acting as a strict but fair ${role} conducting a mock interview for a candidate. 
+        content: `You are acting as a strict but fair ${safeRole} conducting a mock interview for a candidate. 
         Follow these rules:
         1. Ask ONLY ONE question at a time.
         2. Wait for the candidate's response before proceeding.

--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -59,7 +59,7 @@ export const dispatchPushNotifications = async (req, res, next) => {
     // Atomically claim a batch of pending notifications so concurrent invocations
     // cannot double-deliver the same notification (race-condition prevention).
     const claimedAt = new Date().toISOString();
-    const { data: notifications, error } = await supabase
+    const { data: notifications, error: claimError } = await supabase
       .from("notifications")
       .update({ push_claimed_at: claimedAt })
       .is("push_claimed_at", null)
@@ -81,6 +81,13 @@ export const dispatchPushNotifications = async (req, res, next) => {
       .in("user_id", userIds);
 
     if (subError) {
+      const notificationIds = notifications.map((n) => n.id);
+      if (notificationIds.length > 0) {
+        await supabase
+          .from("notifications")
+          .update({ push_claimed_at: null })
+          .in("id", notificationIds);
+      }
       return res.status(500).json({ error: subError.message });
     }
 

--- a/backend/tests/dispatchPushNotifications.test.js
+++ b/backend/tests/dispatchPushNotifications.test.js
@@ -55,6 +55,12 @@ const makeSupabaseMock = () => {
           return resolve({ data: batch.map(r => ({ ...r })), error: null });
         }
 
+        if (table === "notifications" && _operation === "update" && _filters["id__in"]) {
+          const ids = _filters["id__in"];
+          ids.forEach(id => claimedIds.delete(id));
+          return resolve({ data: null, error: null });
+        }
+
         if (table === "notifications" && _operation === "update" && _filters["id"]) {
           // push_sent_at stamp
           const row = dbRows.find((r) => r.id === _filters["id"]);
@@ -83,8 +89,22 @@ const makeSupabaseMock = () => {
 };
 
 // ─── Module mocks ────────────────────────────────────────────────────────────
+let forceSubscriptionError = false;
 vi.mock("@supabase/supabase-js", () => ({
-  createClient: () => makeSupabaseMock(),
+  createClient: () => {
+    const mock = makeSupabaseMock();
+    const originalFrom = mock.from.bind(mock);
+    mock.from = (table) => {
+      if (table === "push_subscriptions" && forceSubscriptionError) {
+        forceSubscriptionError = false; // only fail once
+        const fakeChain = new Promise((resolve) => resolve({ data: null, error: { message: "DB error" } }));
+        Object.assign(fakeChain, { select: () => fakeChain, in: () => fakeChain });
+        return fakeChain;
+      }
+      return originalFrom(table);
+    };
+    return mock;
+  },
 }));
 
 // Slow sendNotification (~150 ms) to widen the race window
@@ -183,20 +203,7 @@ describe("dispatchPushNotifications — race condition", () => {
   });
 
   it("claimed notifications remain retryable after subscription fetch error", async () => {
-  // Inject a subscription-fetch failure on the first call
-  const supabaseMock = makeSupabaseMock();
-  const originalFrom = supabaseMock.from.bind(supabaseMock);
-
-  vi.spyOn(supabaseMock, "from").mockImplementationOnce((table) => {
-    if (table === "push_subscriptions") {
-      return {
-        select: () => ({
-          in: () => Promise.resolve({ data: null, error: { message: "DB error" } }),
-        }),
-      };
-    }
-    return originalFrom(table);
-  });
+  forceSubscriptionError = true;
 
   // First call: subscription fetch fails → should 500
   const res1 = await request(app).post("/dispatch");
@@ -206,7 +213,7 @@ describe("dispatchPushNotifications — race condition", () => {
   const stillPending = dbRows.filter((r) => r.push_sent_at == null);
   expect(stillPending.length).toBeGreaterThan(0);
 
-  // Second call: mock restored, stale claim timeout allows re-claim → should succeed
+  // Second call: mock restored, rollback allows re-claim → should succeed
   const res2 = await request(app).post("/dispatch");
   expect(res2.status).toBe(200);
   expect(res2.body.processed).toBeGreaterThan(0);

--- a/backend/tests/docs.test.js
+++ b/backend/tests/docs.test.js
@@ -12,7 +12,13 @@ import { resolve } from "path";
  * cronRoutes.js or notificationRoutes.js.
  */
 
-const repoRoot = resolve(process.cwd(), "..");
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const repoRoot = resolve(__dirname, "../../");
 const apiDoc = readFileSync(resolve(repoRoot, "docs/api.md"), "utf-8");
 const notifDoc = readFileSync(resolve(repoRoot, "docs/smart-notifications.md"), "utf-8");
 


### PR DESCRIPTION
Fixes #955 by strictly sanitizing and limiting the length of the \ole\ parameter before interpolating it into the system prompt for the mock interview generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock interview input handling by sanitizing the role value before using it in the generated prompt, with clearer rejection of invalid/empty inputs.
  * Prevented push notification “claimed” states from getting stuck when subscription fetching fails, ensuring affected notifications can be retried in subsequent dispatch runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->