### PR TITLE
Fix repoRoot path in docs.test.js

### DIFF
--- a/backend/tests/docs.test.js
+++ b/backend/tests/docs.test.js
@@ -12,7 +12,7 @@ import { resolve } from "path";
  * cronRoutes.js or notificationRoutes.js.
  */
 
-const repoRoot = resolve(process.cwd(), "..");
+const repoRoot = resolve(process.cwd(), "..", "..");
 const apiDoc = readFileSync(resolve(repoRoot, "docs/api.md"), "utf-8");
 const notifDoc = readFileSync(resolve(repoRoot, "docs/smart-notifications.md"), "utf-8");
 


### PR DESCRIPTION
Updated the repoRoot path in `backend/tests/docs.test.js` so the test correctly locates the documentation files.

### Changes
- Fixed repository root path resolution
- Ensured `docs/api.md` and related documentation files can be found during CI runs

### Testing
- Verified documentation tests can locate the required files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed documentation validation tests to correctly resolve paths and verify documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->