### PR TITLE
Update cronController.js

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -65,7 +65,7 @@ export const dispatchPushNotifications = async (req, res, next) => {
       .is("push_claimed_at", null)
       .select("id,user_id,title,body,action_url");
 
-    if (claimError) {
+    if (Error) {
       return res.status(500).json({ error: claimError.message });
     }
 


### PR DESCRIPTION
Fixes a ReferenceError in dispatchPushNotifications (cronController.js).

The error-handling check after the atomic claim query referenced an
undefined variable `claimError` instead of `error`, causing every call
to throw a ReferenceError and return a 500, even when the claim query
succeeded.

Change: `if (claimError)` → `if (error)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in the push notification dispatch system to ensure accurate error reporting when notifications fail to process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->