### PR TITLE
fix(calendar): use session duration for ICS events

### DIFF
--- a/src/components/sessions/SessionList.tsx
+++ b/src/components/sessions/SessionList.tsx
@@ -108,7 +108,7 @@ export function SessionList({
                     s.title || "Peer Learning Session",
                     s.description || "Join us for a collaborative learning session.",
                     s.scheduled_at ? new Date(s.scheduled_at) : new Date(),
-                    1
+                    s.duration_minutes || 60
                   );
                 }}
                 className="bg-white/10 border border-white/10 hover:bg-white/20 p-3 rounded-2xl transition text-white"


### PR DESCRIPTION
## Related Issue
Closes #967

## Description
Fixed the "Add to Calendar" functionality to use the actual session duration when generating ICS calendar events.

Previously, the calendar export always passed `1` as the duration value to `generateICS()`, causing every downloaded calendar event to last only one minute regardless of the session's actual length.

## Changes Made
- Replaced the hardcoded duration value with `s.duration_minutes`
- Added a fallback duration of `60` minutes when session duration is unavailable
- Ensured exported calendar events match the actual session length

## Testing
1. Open the Sessions page
2. Click the calendar icon for a session with a known duration
3. Import the downloaded `.ics` file into a calendar app
4. Verify the event duration matches the session duration
5. Verify sessions without a duration use the 60-minute fallback

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Add to Calendar" feature to generate calendar events with accurate session durations instead of incorrect default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->