### PR TITLE
Fix: Remove insecure proxy fallback and prevent IP spoofing vulnerability

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -21,8 +21,8 @@ if (process.env.TRUSTED_PROXIES) {
   app.set("trust proxy", process.env.TRUSTED_PROXIES.split(",").map(s => s.trim()));
   console.log(`[security] trust proxy enabled for subnets: ${process.env.TRUSTED_PROXIES}`);
 } else if (process.env.TRUST_PROXY === "true") {
-  app.set("trust proxy", 1);
-  console.warn("[security] trust proxy enabled with hop-count 1. Consider setting TRUSTED_PROXIES for explicit subnet whitelisting.");
+  console.error("[security] FATAL: TRUST_PROXY=true is insecure without TRUSTED_PROXIES. Provide comma-separated subnet ranges via TRUSTED_PROXIES.");
+  process.exit(1);
 }
 
 // SECURITY: Build a strict CORS origin whitelist.


### PR DESCRIPTION
This PR addresses the critical IP spoofing vulnerability reported in issue #855 by entirely removing the insecure fallback behavior inside backend/app.js where app.set("trust proxy", 1) was used when TRUST_PROXY=true without subnet definitions. To ensure the application cannot be deployed in a dangerously vulnerable state where malicious actors could inject arbitrary IP addresses into the X-Forwarded-For header and bypass rate limiting, the server will now log a fatal security error and strictly run process.exit(1) if proxy trusting is requested but explicit comma-separated subnet ranges are not provided via the TRUSTED_PROXIES environment variable.

Closes #855 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security configuration validation to prevent insecure proxy trust defaults. The server now terminates with an error instead of silently running with potentially unsafe settings when proxy configuration is incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->