### PR TITLE
feat: add Clear Code and Copy Output buttons to LiveCodeRunner

### DIFF
--- a/src/components/studyroom/LiveCodeRunner.tsx
+++ b/src/components/studyroom/LiveCodeRunner.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { Play, Code, Share, Loader2 } from "lucide-react";
+import { Play, Code, Share, Loader2, Clipboard, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { env } from "@/env";
 
@@ -80,7 +80,18 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
     onShare(code, language.id, output);
     setIsOpen(false);
   };
-
+  const handleCopyOutput = () => {
+    if (!output) { toast.error("No output to copy"); return; }
+    navigator.clipboard.writeText(output).then(
+      () => toast.success("Output copied!"),
+      () => toast.error("Failed to copy output")
+    );
+  };
+  
+  const handleClearCode = () => {
+    setCode("");
+    setOutput("");
+  };
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>
@@ -113,6 +124,14 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
             </select>
 
             <div className="flex gap-2">
+            <button
+    type="button"
+    onClick={handleClearCode}
+    disabled={isRunning}
+   className="flex items-center gap-2 bg-gray-700 text-white px-4 py-2 rounded-lg font-medium hover:bg-gray-600 transition disabled:opacity-50"
+  >
+     <Trash2 size={16} /> Clear
+   </button>
               <button
                 onClick={runCode}
                 disabled={isRunning}
@@ -142,7 +161,18 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
               />
             </div>
             <div className="flex flex-col gap-2 h-full">
-              <label className="text-sm font-medium text-gray-400">Output</label>
+            <div className="flex items-center justify-between">
++   <label className="text-sm font-medium text-gray-400">Output</label>
+   {output && (
+     <button
+       onClick={handleCopyOutput}
+       disabled={isRunning}
+       className="flex items-center gap-1 text-xs text-gray-400 hover:text-gray-200 disabled:opacity-50"
+     >
+       <Clipboard size={13} /> Copy
+     </button>
+  )}
+ </div>
               <div className="w-full h-full bg-black text-green-400 font-mono text-sm p-4 rounded-xl border border-gray-800 overflow-y-auto whitespace-pre-wrap">
                 {output || "Output will appear here..."}
               </div>


### PR DESCRIPTION
Closes #928
Added two utility buttons to the LiveCodeRunner component in study rooms:

Clear button (Trash2 icon) — resets both the code editor and output panel in one click, replacing the tedious select-all + delete workflow
Copy button (Clipboard icon) — appears in the Output section header when output is present, uses the Clipboard API to copy output text with success/error toast feedback

Both buttons are disabled while code is running (isRunning: true) to prevent accidental state changes mid-execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Copy button to output pane for easy clipboard access with confirmation feedback
  * Added Clear button to reset both code and output simultaneously

<!-- end of auto-generated comment: release notes by coderabbit.ai -->