### PR TITLE
fix: render markdown correctly in MarkdownRenderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "react-router-dom": "^6.30.1",
     "react-syntax-highlighter": "^16.1.1",
     "recharts": "^2.15.4",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": "^4.0.1",
     "sonner": "^1.7.4",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,29 +1,29 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
-import DOMPurify from 'dompurify';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize from 'rehype-sanitize';
+import type { PluggableList } from 'unified';
 
 interface MarkdownRendererProps {
   content: string;
   className?: string;
 }
 
-export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content, className = '' }) => {
-  // Sanitize the raw markdown/HTML content first
-  const sanitizedContent = useMemo(() => {
-    return DOMPurify.sanitize(content, {
-      ALLOWED_TAGS: [
-        'b', 'i', 'em', 'strong', 'a', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
-        'ul', 'ol', 'li', 'code', 'pre', 'blockquote', 'hr', 'br', 'span', 'div'
-      ],
-      ALLOWED_ATTR: ['href', 'target', 'rel', 'class', 'className'],
-    });
-  }, [content]);
+const remarkPlugins: PluggableList = [remarkGfm];
+const rehypePlugins: PluggableList = [rehypeSanitize];
 
-  return (
-    <div className={`prose prose-invert max-w-none ${className}`}>
-      <ReactMarkdown>{sanitizedContent}</ReactMarkdown>
-    </div>
-  );
-};
+export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
+  content,
+  className = '',
+}) => (
+  <div className={`prose prose-invert max-w-none ${className}`}>
+    <ReactMarkdown
+      remarkPlugins={remarkPlugins}
+      rehypePlugins={rehypePlugins}
+    >
+      {content}
+    </ReactMarkdown>
+  </div>
+);
 
 export default MarkdownRenderer;


### PR DESCRIPTION
# Closes #933 
# Summary

Fixes the Markdown rendering pipeline in `MarkdownRenderer` by removing the incorrect DOMPurify → ReactMarkdown chaining.

## Problem

`DOMPurify.sanitize()` returns an HTML string, but `ReactMarkdown` expects raw Markdown input. Passing sanitized HTML into `ReactMarkdown` caused formatted AI responses to render incorrectly, resulting in broken headings, lists, code blocks, and other Markdown elements.

## Changes

* Removed DOMPurify preprocessing from `MarkdownRenderer`
* Added `remark-gfm` to support GitHub Flavored Markdown features such as tables, task lists, and strikethrough
* Added `rehype-sanitize` to sanitize rendered Markdown content without altering the original Markdown input
* Passed raw Markdown content directly to `ReactMarkdown`

## Result

Markdown content now follows the correct rendering pipeline:

Markdown → ReactMarkdown → Rendered HTML

This preserves formatting while maintaining sanitization and improves the readability of AI-generated responses.

## Testing

* Verified project builds successfully with `npm run build`
* Verified linting passes with no new errors using `npm run lint`
* Confirmed dependency additions are limited to `remark-gfm` and `rehype-sanitize`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated markdown rendering with GitHub Flavored Markdown support and improved content sanitization mechanism.

* **Chores**
  * Added dependencies to support enhanced markdown processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->