### PR TITLE
Restrict group pomodoro controls to room creator

### DIFF
--- a/src/components/GroupPomodoro.tsx
+++ b/src/components/GroupPomodoro.tsx
@@ -13,14 +13,14 @@ const BREAK_MAX = 60;
 
 interface GroupPomodoroProps {
   roomId: string;
-  creatorId: string;
+  creatorId: string | null;
 }
 
 export default function GroupPomodoro({ roomId, creatorId }: GroupPomodoroProps) {
   const { toast } = useToast();
   const { user } = useAuth();
 
-  const isCreator = user?.id === creatorId;
+  const isCreator = creatorId !== null && user?.id === creatorId;
 
   const [timerState, setTimerState] = useState<'idle' | 'work' | 'break'>('idle');
   const [endTime, setEndTime] = useState<Date | null>(null);
@@ -89,7 +89,7 @@ export default function GroupPomodoro({ roomId, creatorId }: GroupPomodoroProps)
         ? new Date(Date.now() + clampedDuration * 60 * 1000).toISOString()
         : null;
 
-    await supabase
+    const { error } = await supabase
       .from('study_rooms' as any)
       .update({
         timer_state: newState,
@@ -98,7 +98,15 @@ export default function GroupPomodoro({ roomId, creatorId }: GroupPomodoroProps)
         timer_break_duration: brk,
       })
       .eq('id', roomId);
-  }, [clampDurations, roomId]);
+
+    if (error) {
+      toast({
+        title: 'Timer update failed',
+        description: 'Could not sync the timer. Please try again.',
+        variant: 'destructive',
+      });
+    }
+  }, [clampDurations, roomId, toast]);
 
   const handleTimerComplete = useCallback(async () => {
     if (!isCreator) return;

--- a/src/components/GroupPomodoro.tsx
+++ b/src/components/GroupPomodoro.tsx
@@ -1,17 +1,27 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/useAuth';
 import { Play, Square, Coffee, Clock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
 import { motion } from 'framer-motion';
 
+const WORK_MIN = 1;
+const WORK_MAX = 120;
+const BREAK_MIN = 1;
+const BREAK_MAX = 60;
+
 interface GroupPomodoroProps {
   roomId: string;
+  creatorId: string;
 }
 
-export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
+export default function GroupPomodoro({ roomId, creatorId }: GroupPomodoroProps) {
   const { toast } = useToast();
-  
+  const { user } = useAuth();
+
+  const isCreator = user?.id === creatorId;
+
   const [timerState, setTimerState] = useState<'idle' | 'work' | 'break'>('idle');
   const [endTime, setEndTime] = useState<Date | null>(null);
   const [timeLeft, setTimeLeft] = useState(0);
@@ -28,7 +38,7 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
         .select('timer_state, timer_end_time, timer_work_duration, timer_break_duration')
         .eq('id', roomId)
         .single();
-        
+
       if (!error && data && active) {
         // @ts-expect-error TODO: refine typing
         setTimerState(data.timer_state || 'idle');
@@ -45,9 +55,9 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
 
     const channel = supabase
       .channel(`room-timer-${roomId}`)
-      .on('postgres_changes', { 
-        event: 'UPDATE', 
-        schema: 'public', 
+      .on('postgres_changes', {
+        event: 'UPDATE',
+        schema: 'public',
         table: 'study_rooms',
         filter: `id=eq.${roomId}`
       }, (payload) => {
@@ -65,18 +75,60 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
     };
   }, [roomId]);
 
+  const clampDurations = useCallback(() => ({
+    work: Math.min(WORK_MAX, Math.max(WORK_MIN, Math.floor(workDuration))),
+    brk: Math.min(BREAK_MAX, Math.max(BREAK_MIN, Math.floor(breakDuration))),
+  }), [workDuration, breakDuration]);
+
+  const setGroupTimer = useCallback(async (newState: 'idle' | 'work' | 'break') => {
+    const { work, brk } = clampDurations();
+    const clampedDuration = newState === 'work' ? work : newState === 'break' ? brk : 0;
+
+    const newEndTime =
+      newState !== 'idle'
+        ? new Date(Date.now() + clampedDuration * 60 * 1000).toISOString()
+        : null;
+
+    await supabase
+      .from('study_rooms' as any)
+      .update({
+        timer_state: newState,
+        timer_end_time: newEndTime,
+        timer_work_duration: work,
+        timer_break_duration: brk,
+      })
+      .eq('id', roomId);
+  }, [clampDurations, roomId]);
+
+  const handleTimerComplete = useCallback(async () => {
+    if (!isCreator) return;
+
+    if (timerState === 'work') {
+      toast({
+        title: 'Group Focus Session Complete! 🎉',
+        description: 'Great job focusing! Time for a short break.',
+      });
+      await setGroupTimer('break');
+    } else if (timerState === 'break') {
+      toast({
+        title: 'Break Over!',
+        description: 'Back to focus?',
+      });
+      await setGroupTimer('idle');
+    }
+  }, [isCreator, timerState, setGroupTimer, toast]);
+
   // Countdown logic
   useEffect(() => {
     let interval: NodeJS.Timeout;
-    
+
     if (timerState !== 'idle' && endTime) {
       interval = setInterval(() => {
         const now = new Date();
         const diff = Math.max(0, Math.floor((endTime.getTime() - now.getTime()) / 1000));
-        
+
         setTimeLeft(diff);
-        
-        // Timer completed!
+
         if (diff === 0) {
           clearInterval(interval);
           handleTimerComplete();
@@ -85,46 +137,11 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
     } else {
       setTimeLeft(timerState === 'break' ? breakDuration * 60 : workDuration * 60);
     }
-    
+
     return () => {
       if (interval) clearInterval(interval);
     };
-  }, [timerState, endTime, workDuration, breakDuration]);
-
-  const handleTimerComplete = async () => {
-    if (timerState === 'work') {
-      toast({
-        title: "Group Focus Session Complete! 🎉",
-        description: `Great job focusing! Time for a short break.`,
-      });
-      await setGroupTimer('break', breakDuration);
-    } else if (timerState === 'break') {
-      toast({
-        title: "Break Over!",
-        description: "Back to focus?",
-      });
-      await setGroupTimer('idle', 0);
-    }
-  };
-
-  const setGroupTimer = async (newState: 'idle' | 'work' | 'break', durationMinutes: number) => {
-    let newEndTime = null;
-    
-    if (newState !== 'idle') {
-      const now = new Date();
-      newEndTime = new Date(now.getTime() + durationMinutes * 60 * 1000).toISOString();
-    }
-    
-    await supabase
-      .from('study_rooms' as any)
-      .update({
-        timer_state: newState,
-        timer_end_time: newEndTime,
-        timer_work_duration: workDuration,
-        timer_break_duration: breakDuration
-      })
-      .eq('id', roomId);
-  };
+  }, [timerState, endTime, workDuration, breakDuration, handleTimerComplete]);
 
   const formatTime = (seconds: number) => {
     const m = Math.floor(seconds / 60);
@@ -136,54 +153,78 @@ export default function GroupPomodoro({ roomId }: GroupPomodoroProps) {
     <div className="rounded-xl border border-white/10 bg-[#0a0f25] p-5 backdrop-blur-md">
       <div className="flex flex-col items-center justify-center space-y-4">
         <div className="flex items-center gap-2">
-          {timerState === 'work' ? <Clock size={20} className="text-red-400 animate-pulse" /> : <Coffee size={20} className="text-green-400" />}
+          {timerState === 'work' ? (
+            <Clock size={20} className="text-red-400 animate-pulse" />
+          ) : (
+            <Coffee size={20} className="text-green-400" />
+          )}
           <h3 className="font-semibold text-lg text-white">
-            {timerState === 'work' ? 'Group Focus' : timerState === 'break' ? 'Group Break' : 'Group Pomodoro'}
+            {timerState === 'work'
+              ? 'Group Focus'
+              : timerState === 'break'
+              ? 'Group Break'
+              : 'Group Pomodoro'}
           </h3>
         </div>
-        
-        <div className={`text-6xl font-mono font-bold tracking-widest ${timerState === 'work' ? 'text-red-400' : timerState === 'break' ? 'text-green-400' : 'text-slate-300'}`}>
+
+        <div
+          className={`text-6xl font-mono font-bold tracking-widest ${
+            timerState === 'work'
+              ? 'text-red-400'
+              : timerState === 'break'
+              ? 'text-green-400'
+              : 'text-slate-300'
+          }`}
+        >
           {formatTime(timeLeft)}
         </div>
-        
-        <div className="flex gap-3 pt-4 w-full">
-          {timerState === 'idle' ? (
-            <Button 
-              onClick={() => setGroupTimer('work', workDuration)}
-              className="flex-1 font-semibold bg-red-500 hover:bg-red-600"
-            >
-              <Play size={16} className="mr-2" /> Start Focus
-            </Button>
-          ) : (
-            <Button 
-              onClick={() => setGroupTimer('idle', 0)}
-              className="flex-1 font-semibold bg-slate-700 hover:bg-slate-600"
-            >
-              <Square size={16} className="mr-2" /> Stop Sync Timer
-            </Button>
-          )}
-        </div>
 
-        {timerState === 'idle' && (
+        {isCreator && (
+          <div className="flex gap-3 pt-4 w-full">
+            {timerState === 'idle' ? (
+              <Button
+                onClick={() => setGroupTimer('work')}
+                className="flex-1 font-semibold bg-red-500 hover:bg-red-600"
+              >
+                <Play size={16} className="mr-2" /> Start Focus
+              </Button>
+            ) : (
+              <Button
+                onClick={() => setGroupTimer('idle')}
+                className="flex-1 font-semibold bg-slate-700 hover:bg-slate-600"
+              >
+                <Square size={16} className="mr-2" /> Stop Sync Timer
+              </Button>
+            )}
+          </div>
+        )}
+
+        {isCreator && timerState === 'idle' && (
           <div className="flex justify-between w-full mt-4 border-t border-white/10 pt-4 px-2">
             <div className="flex flex-col items-center">
               <span className="text-xs text-slate-400 mb-1">Work (min)</span>
-              <input 
-                type="number" 
+              <input
+                type="number"
                 value={workDuration}
-                onChange={(e) => setWorkDuration(Number(e.target.value))}
+                onChange={(e) =>
+                  setWorkDuration(Math.min(WORK_MAX, Math.max(WORK_MIN, Number(e.target.value))))
+                }
                 className="w-16 bg-black/40 border border-white/10 rounded px-2 py-1 text-sm text-center focus:outline-none focus:border-cyan-500 text-white"
-                min="1" max="120"
+                min={WORK_MIN}
+                max={WORK_MAX}
               />
             </div>
             <div className="flex flex-col items-center">
               <span className="text-xs text-slate-400 mb-1">Break (min)</span>
-              <input 
-                type="number" 
+              <input
+                type="number"
                 value={breakDuration}
-                onChange={(e) => setBreakDuration(Number(e.target.value))}
+                onChange={(e) =>
+                  setBreakDuration(Math.min(BREAK_MAX, Math.max(BREAK_MIN, Number(e.target.value))))
+                }
                 className="w-16 bg-black/40 border border-white/10 rounded px-2 py-1 text-sm text-center focus:outline-none focus:border-cyan-500 text-white"
-                min="1" max="60"
+                min={BREAK_MIN}
+                max={BREAK_MAX}
               />
             </div>
           </div>

--- a/src/components/Room.tsx
+++ b/src/components/Room.tsx
@@ -326,7 +326,7 @@ export default function Room() {
               </div>
             </div>
             
-            <GroupPomodoro roomId={id!} />
+           <GroupPomodoro roomId={id!} creatorId={room.created_by} />
           </div>
 
         </div>


### PR DESCRIPTION
## Closes #934 

## Summary

Fixes an issue where any participant in a study room could start, stop, or reset the shared Group Pomodoro timer.

## Changes

- Added creatorId prop to GroupPomodoro
- Restrict timer controls to the room creator
- Prevent non-creators from triggering timer transitions when sessions complete
- Clamp work and break durations before database writes
- Reuse existing room.created_by value from Room.tsx instead of performing another query

## Security

The existing study_rooms RLS policies continue to enforce creator-only updates at the database level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Group timer advancement is now restricted to the creator of the timer session.
  * Group Pomodoro now receives the room creator information, enabling creator-only control and duration input behavior.
  * Improved timer completion handling to ensure countdown updates and completion logic run reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->