### PR TITLE
refactor: improve resource hub loading placeholders

### DIFF
--- a/src/pages/ResourceHub.tsx
+++ b/src/pages/ResourceHub.tsx
@@ -89,7 +89,7 @@ const ResourceHub = () => {
   );
 
   const renderSkeletons = () =>
-    Array.from({ length: 3 }).map((_, index) => (
+    Array.from({ length: 6 }).map((_, index) => (
       <Card key={index} className="flex h-full flex-col">
         <CardContent className="space-y-4 p-6">
           <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary

Closes #1049 

This PR improves the Resource Hub loading experience by increasing the number of skeleton placeholders displayed while resources are being fetched. The updated loading state better matches the layout and density of the actual resource grid, creating a more consistent user experience across the application.

## Changes Made

- Increased the number of loading skeleton cards rendered during data fetching.
- Improved visual consistency with other pages that display multiple rows of placeholders while loading.
- Preserved existing loading behavior and functionality.

## Why This Change?

The previous loading state displayed only a single row of skeleton cards, which could make the page feel sparse while resources were loading. Showing additional placeholders provides a more complete loading experience and better reflects the final content layout.

## Benefits

- More consistent loading experience across pages.
- Improved perceived performance.
- Better visual continuity between loading and loaded states.
- No impact on existing functionality.

## Testing

- [x] Resource Hub loads successfully.
- [x] Additional skeleton cards are displayed during loading.
- [x] Resources render correctly after loading completes.
- [x] No functional regressions observed.

## Type of Change

- [x] Refactor
- [x] UI/Design Improvement
- [x] Performance Perception Improvement
- [ ] Bug Fix
- [ ] Breaking Change

### Files Modified

- `src/pages/ResourceHub.tsx`

### Expected Labels

type:design, type:performance, type:refactor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the number of loading placeholder cards displayed in the Resource Hub from 3 to 6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->