### PR TITLE
fix: add navigation to login hero CTA buttons

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -154,12 +154,16 @@ const Login = () => {
           </p>
 
           <div className="mt-8 flex gap-4">
-            <Button className="rounded-xl bg-gradient-to-r from-cyan-400 to-blue-500 px-8 py-6 text-black font-semibold hover:scale-105 transition-all">
+            <Button 
+              onClick={() => navigate("/signup")}
+              className="rounded-xl bg-gradient-to-r from-cyan-400 to-blue-500 px-8 py-6 text-black font-semibold hover:scale-105 transition-all"
+            >
               Join as Learner
             </Button>
 
             <Button
               variant="outline"
+              onClick={() => navigate("/become-mentor")}
               className="rounded-xl border-cyan-400/20 bg-white/5 px-8 py-6 text-cyan-300 hover:bg-cyan-500/10"
             >
               Become a Mentor


### PR DESCRIPTION
Fixes #1077

## Summary
Added navigation functionality to the Login page hero CTA buttons so users can access the intended learner and mentor flows directly from the Login page.

## Changes Made
- Added navigation to the "Join as Learner" button using `navigate("/signup")`
- Added navigation to the "Become a Mentor" button using `navigate("/become-mentor")`
- Preserved existing UI, styling, and layout

## Root Cause
The CTA buttons were rendered as interactive Button components but had no associated click handlers or routing logic. As a result, they appeared clickable while performing no action.

## Testing
- Verified "Join as Learner" navigates to `/signup`
- Verified "Become a Mentor" navigates to `/become-mentor`
- Confirmed both routes exist in the application's routing configuration
- Confirmed no console errors or routing warnings
- Successfully passed `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enabled "Join as Learner" and "Become a Mentor" buttons on the login page to navigate to their respective signup flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->