### PR TITLE
fix: add 300-character limit and live counter to Profile bio textarea

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -24,7 +24,7 @@ const avatars = [
   "https://api.dicebear.com/7.x/adventurer/svg?seed=David",
   "https://api.dicebear.com/7.x/adventurer/svg?seed=Sophia",
 ];
-
+const MAX_BIO_CHARS = 300;
 const Profile = () => {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -86,7 +86,10 @@ const Profile = () => {
         toast.error("Your session has expired. Please log in again.");
         return;
       }
-
+if (profile.bio.length > MAX_BIO_CHARS) {
+        toast.error(`Bio must be ${MAX_BIO_CHARS} characters or fewer.`);
+        return;
+      }
       const { error } = await supabase
         .from("profiles")
         .update({
@@ -248,22 +251,33 @@ const Profile = () => {
             </div>
           </div>
 
-          {/* BIO */}
+{/* BIO */}
           <div className="mt-6">
             <label className="block text-sm text-gray-400 mb-2">Bio</label>
-
-            <textarea
-              rows={5}
-              value={profile.bio}
-              onChange={(e) =>
-                setProfile({
-                  ...profile,
-                  bio: e.target.value,
-                })
-              }
-              placeholder="Tell others about yourself..."
-              className="w-full bg-white/5 border border-white/10 rounded-2xl p-4 outline-none focus:border-cyan-400 transition resize-none"
-            />
+            <div className="relative">
+              <textarea
+                rows={5}
+                value={profile.bio}
+                onChange={(e) => {
+                  if (e.target.value.length <= MAX_BIO_CHARS) {
+                    setProfile({ ...profile, bio: e.target.value });
+                  }
+                }}
+                placeholder="Tell others about yourself..."
+                className="w-full bg-white/5 border border-white/10 rounded-2xl p-4 outline-none focus:border-cyan-400 transition resize-none"
+              />
+              <span
+                className={`absolute bottom-3 right-4 text-xs ${
+                  profile.bio.length >= MAX_BIO_CHARS
+                    ? "text-red-400"
+                    : profile.bio.length >= MAX_BIO_CHARS * 0.9
+                    ? "text-amber-400"
+                    : "text-gray-500"
+                }`}
+              >
+                {profile.bio.length}/{MAX_BIO_CHARS}
+              </span>
+            </div>
           </div>
 
           {/* DYNAMIC STATS */}


### PR DESCRIPTION
Fixes #1002

## What changed
- Added `MAX_BIO_CHARS = 300` constant
- Wrapped the bio textarea in a relative div and added a live `X/300` counter in the bottom-right corner
- Counter turns amber at 90% (270 chars) and red at the limit (300 chars)
- `onChange` clamps input so the user cannot type past 300 characters
- `handleSave` has an additional guard that shows a toast error if the bio somehow exceeds the limit

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the project style
- [x] No additional dependencies added
- [x] Constraint enforced at both UI and handler level