### PR TITLE
Enforce server-side role validation for session creation

### DIFF
--- a/supabase/migrations/20260611000005_fix_session_creation_role.sql
+++ b/supabase/migrations/20260611000005_fix_session_creation_role.sql
@@ -1,0 +1,1 @@
+DROP POLICY IF EXISTS "Mentors can create sessions" ON sessions; CREATE POLICY "Mentors can create sessions" ON sessions FOR INSERT WITH CHECK (mentor_id = auth.uid() AND (SELECT is_mentor FROM profiles WHERE id = auth.uid() AND is_mentor = true LIMIT 1) IS NOT NULL);


### PR DESCRIPTION
Fixes #1142

This PR prevents unauthorized users from elevating privileges to create mentoring sessions.
- Modified the `sessions` insert RLS policy to validate mentor status using secure, server-side role checks.
- Removed reliance on unverified frontend flags.
- Prevents standard learners from bypassing role restrictions.
