### PR TITLE
Add missing RLS policies to system_config table

### DIFF
--- a/supabase/migrations/20260611000000_secure_system_config_table.sql
+++ b/supabase/migrations/20260611000000_secure_system_config_table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE system_config ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Allow read access for authenticated users" ON system_config FOR SELECT USING (auth.role() = 'authenticated');
+CREATE POLICY "Allow full access for admins only" ON system_config FOR ALL USING (public.has_role(auth.uid(), 'admin')) WITH CHECK (public.has_role(auth.uid(), 'admin'));


### PR DESCRIPTION
Fixes #1137

This PR implements Row Level Security (RLS) for the `system_config` table, which was previously vulnerable to unauthorized access.
- Enabled RLS on the `system_config` table.
- Added policy allowing authenticated users to `SELECT`.
- Added policy restricting `INSERT`, `UPDATE`, and `DELETE` exclusively to admin roles.

