### PR TITLE
feat(: add client-side pagination with Load More button

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -25,6 +25,8 @@ const filters = [
   "Python",
 ];
 
+const PAGE_SIZE = 12;
+
 const containerVariants = {
   hidden: {},
   show: {
@@ -118,6 +120,8 @@ const Discover = () => {
   const [onlineUsers, setOnlineUsers] = useState<string[]>([]);
   const [connections, setConnections] = useState<string[]>([]);
 
+  const [page, setPage] = useState(1);
+
   // DEBOUNCE SEARCH
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -125,6 +129,12 @@ const Discover = () => {
     }, 400);
     return () => clearTimeout(timer);
   }, [search]);
+
+  // RESET PAGINATION whenever the active search/filter changes so users
+  // always land on page 1 of the new result set
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch, selectedFilter]);
 
   // 1. FETCH INITIAL DATA (User Profile & Connections) - Runs ONCE on mount
   useEffect(() => {
@@ -232,6 +242,18 @@ const Discover = () => {
   }, [currentUser?.id]);
 
   // Match scoring has been moved to the Node.js backend to prevent O(N) payload bloat and severe UI jank
+
+  // Client-side pagination: slice the already-fetched filteredUsers array
+  // into pages of PAGE_SIZE instead of rendering all 100 cards at once.
+  const pagedUsers = useMemo(() => {
+    return filteredUsers.slice(0, page * PAGE_SIZE);
+  }, [filteredUsers, page]);
+
+  const remainingCount = filteredUsers.length - pagedUsers.length;
+
+  const handleLoadMore = useCallback(() => {
+    setPage((prev) => prev + 1);
+  }, []);
 
   const handleConnect = useCallback(async (peerId: string) => {
     if (!currentUser || connections.includes(peerId)) return;
@@ -396,22 +418,35 @@ const Discover = () => {
             </p>
           </div>
         ) : (
-          <motion.div
-            variants={containerVariants}
-            initial="hidden"
-            animate="show"
-            className="grid md:grid-cols-3 gap-6"
-          >
-            {filteredUsers.map((u) => (
-              <DiscoverPeerCard
-                key={u.id}
-                user={u}
-                isOnline={onlineUsers.includes(u.id)}
-                onConnect={handleConnect}
-                isConnected={connections.includes(u.id)}
-              />
-            ))}
-          </motion.div>
+          <>
+            <motion.div
+              variants={containerVariants}
+              initial="hidden"
+              animate="show"
+              className="grid md:grid-cols-3 gap-6"
+            >
+              {pagedUsers.map((u) => (
+                <DiscoverPeerCard
+                  key={u.id}
+                  user={u}
+                  isOnline={onlineUsers.includes(u.id)}
+                  onConnect={handleConnect}
+                  isConnected={connections.includes(u.id)}
+                />
+              ))}
+            </motion.div>
+
+            {remainingCount > 0 && (
+              <div className="flex justify-center mt-10">
+                <button
+                  onClick={handleLoadMore}
+                  className="px-8 py-3 rounded-2xl font-bold bg-white/5 border border-white/10 hover:border-cyan-400/40 hover:bg-white/10 transition"
+                >
+                  Load More ({remainingCount} remaining)
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -419,4 +454,3 @@ const Discover = () => {
 };
 
 export default Discover;
-


### PR DESCRIPTION
 Fixes #1005.
The Discover page currently fetches up to 100 peers from the backend and renders all of them in a single grid dump, with no pagination or way to navigate results in batches. This PR adds client-side pagination with a PAGE_SIZE of 12 cards per page — a pagedUsers slice is derived with useMemo from the full filteredUsers array, and a "Load More (N remaining)" button is rendered below the grid when more results exist. The page counter resets to 1 whenever the search or filter changes so users always start from the top of new results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented pagination for the recommended peers list with a "Load More" button to view additional results progressively.
  * Pagination automatically resets when applying search filters or changing preferences, ensuring relevant results display from the start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->