### PR TITLE
Feat/notifications mark all read

### DIFF
--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -68,7 +68,19 @@ export const NotificationsDropdown = () => {
       prev.map((n) => (n.id === id ? { ...n, read: true } : n))
     );
   };
-
+  const markAllAsRead = async () => {
+        const unreadIds = notifications.filter((n) => !n.read).map((n) => n.id);
+      if (unreadIds.length === 0) return;
+    
+        await (supabase as any)
+          .from("notifications")
+          .update({ read: true })
+          .in("id", unreadIds);
+    
+        setNotifications((prev) =>
+          prev.map((n) => (unreadIds.includes(n.id) ? { ...n, read: true } : n))
+        );
+     };
   const unreadCount = notifications.filter((n) => !n.read).length;
 
   return (
@@ -79,7 +91,9 @@ export const NotificationsDropdown = () => {
       >
         <Bell size={20} />
         {unreadCount > 0 && (
-          <span className="absolute top-0 right-0 w-2.5 h-2.5 bg-red-500 rounded-full border border-[#0B0F19]"></span>
+          <span className="absolute -top-1 -right-1 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-red-500 text-white text-[10px] font-bold rounded-full border border-[#0B0F19]">
+                      {unreadCount > 9 ? "9+" : unreadCount}
+                   </span>
         )}
       </button>
 
@@ -88,9 +102,17 @@ export const NotificationsDropdown = () => {
           <div className="p-4 border-b border-white/10 flex justify-between items-center bg-white/5">
             <h3 className="font-bold text-white">Notifications</h3>
             {unreadCount > 0 && (
-              <span className="text-xs bg-cyan-500/20 text-cyan-400 px-2 py-1 rounded-full">
-                {unreadCount} new
-              </span>
+              <div className="flex items-center gap-2">
+                            <span className="text-xs bg-cyan-500/20 text-cyan-400 px-2 py-1 rounded-full">
+                              {unreadCount} new
+                            </span>
+                            <button
+                              onClick={markAllAsRead}
+                               className="text-xs text-gray-400 hover:text-cyan-400 font-medium transition"
+                             >
+                               Mark all read
+                         </button>
+                          </div>
             )}
           </div>
 

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -25,6 +25,8 @@ const filters = [
   "Python",
 ];
 
+const PAGE_SIZE = 12;
+
 const containerVariants = {
   hidden: {},
   show: {
@@ -118,6 +120,8 @@ const Discover = () => {
   const [onlineUsers, setOnlineUsers] = useState<string[]>([]);
   const [connections, setConnections] = useState<string[]>([]);
 
+  const [page, setPage] = useState(1);
+
   // DEBOUNCE SEARCH
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -125,6 +129,12 @@ const Discover = () => {
     }, 400);
     return () => clearTimeout(timer);
   }, [search]);
+
+  // RESET PAGINATION whenever the active search/filter changes so users
+  // always land on page 1 of the new result set
+  useEffect(() => {
+    setPage(1);
+  }, [debouncedSearch, selectedFilter]);
 
   // 1. FETCH INITIAL DATA (User Profile & Connections) - Runs ONCE on mount
   useEffect(() => {
@@ -232,6 +242,18 @@ const Discover = () => {
   }, [currentUser?.id]);
 
   // Match scoring has been moved to the Node.js backend to prevent O(N) payload bloat and severe UI jank
+
+  // Client-side pagination: slice the already-fetched filteredUsers array
+  // into pages of PAGE_SIZE instead of rendering all 100 cards at once.
+  const pagedUsers = useMemo(() => {
+    return filteredUsers.slice(0, page * PAGE_SIZE);
+  }, [filteredUsers, page]);
+
+  const remainingCount = filteredUsers.length - pagedUsers.length;
+
+  const handleLoadMore = useCallback(() => {
+    setPage((prev) => prev + 1);
+  }, []);
 
   const handleConnect = useCallback(async (peerId: string) => {
     if (!currentUser || connections.includes(peerId)) return;
@@ -396,22 +418,35 @@ const Discover = () => {
             </p>
           </div>
         ) : (
-          <motion.div
-            variants={containerVariants}
-            initial="hidden"
-            animate="show"
-            className="grid md:grid-cols-3 gap-6"
-          >
-            {filteredUsers.map((u) => (
-              <DiscoverPeerCard
-                key={u.id}
-                user={u}
-                isOnline={onlineUsers.includes(u.id)}
-                onConnect={handleConnect}
-                isConnected={connections.includes(u.id)}
-              />
-            ))}
-          </motion.div>
+          <>
+            <motion.div
+              variants={containerVariants}
+              initial="hidden"
+              animate="show"
+              className="grid md:grid-cols-3 gap-6"
+            >
+              {pagedUsers.map((u) => (
+                <DiscoverPeerCard
+                  key={u.id}
+                  user={u}
+                  isOnline={onlineUsers.includes(u.id)}
+                  onConnect={handleConnect}
+                  isConnected={connections.includes(u.id)}
+                />
+              ))}
+            </motion.div>
+
+            {remainingCount > 0 && (
+              <div className="flex justify-center mt-10">
+                <button
+                  onClick={handleLoadMore}
+                  className="px-8 py-3 rounded-2xl font-bold bg-white/5 border border-white/10 hover:border-cyan-400/40 hover:bg-white/10 transition"
+                >
+                  Load More ({remainingCount} remaining)
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>
@@ -419,4 +454,3 @@ const Discover = () => {
 };
 
 export default Discover;
-


### PR DESCRIPTION
Fixes #1001.
Currently, the NotificationsDropdown component only allows users to dismiss notifications one at a time by clicking each individually, with no bulk action, and the unread indicator on the bell icon is just a small red dot with no count. This PR adds a "Mark all read" button in the dropdown header that calls a single Supabase .update().in() to mark all unread notifications as read in one round trip, then reflects that locally without a refetch. It also replaces the dot badge with a numeric bubble showing the exact unread count, capped at "9+" for cleanliness. 