### PR TITLE
[GSSoC'26] fix: eliminate duplicate database query in Messages

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -68,20 +68,6 @@ const normalizeProfile = (row: ProfileRow | UserRow): ProfileSummary => ({
   last_seen: "last_seen" in row ? row.last_seen : null,
 });
 
-const mergeProfiles = (profiles: ProfileSummary[], users: UserRow[]) => {
-  const map = new Map<string, ProfileSummary>();
-
-  for (const user of users) {
-    map.set(user.id, normalizeProfile(user));
-  }
-
-  for (const profile of profiles) {
-    map.set(profile.id, profile);
-  }
-
-  return Array.from(map.values());
-};
-
 const isThreadMessage = (message: MessageRow, currentUserId: string, otherUserId: string) => {
   return (
     (message.sender_id === currentUserId && message.receiver_id === otherUserId) ||
@@ -181,39 +167,18 @@ export function useMessages(
       setError(null);
 
       try {
-        const [{ data: profileData, error: profileError }, { data: userData, error: userError }] =
-          await Promise.all([
-            supabase
-              .from("profiles")
-              .select("*")
-              .neq("id", currentUserId)
-              .order("name", { ascending: true })
-              .limit(100),
-            supabase
-              .from("profiles")
-              .select("*")
-              .neq("id", currentUserId)
-              .order("name", { ascending: true })
-              .limit(100),
-          ]);
+        const { data: profileData, error: profileError } = await supabase
+          .from("profiles")
+          .select("*")
+          .neq("id", currentUserId)
+          .order("name", { ascending: true })
+          .limit(100);
 
-        const mergedUsers = mergeProfiles(
-          (profileData ?? []).map((row) => row as ProfileSummary),
-          (userData ?? []) as UserRow[]
-        );
+        const profiles = (profileData ?? []) as ProfileSummary[];
+        setProfiles(profiles);
 
-        if (mergedUsers.length > 0) {
-          setProfiles(mergedUsers);
-        } else {
-          setProfiles([]);
-        }
-
-        if (profileError && !userData?.length) {
+        if (profileError) {
           throw new Error(profileError.message);
-        }
-
-        if (userError && !profileData?.length) {
-          throw new Error(userError.message);
         }
       } catch (err: any) {
         logError(err, { context: "useMessages.getUsers" });


### PR DESCRIPTION
## Description

- Replaced duplicate `Promise.all` with a single Supabase query to the `profiles` table
- Profiles are guaranteed to exist for every authenticated user (created in `AuthContext.ensureProfileExists`), so the separate `users` table query was redundant
- Removed the now-unused `mergeProfiles` function (dead code)
- Reduces database round-trips from 2 to 1 per Messages page load

## Files Changed

- `src/pages/Messages.tsx`: Replaced Promise.all(profiles + users) with single profiles query; removed mergeProfiles function

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```bash
npm run build
```

Result: Build succeeds.

## Known Limitations

- The `Chat.tsx` page has a similar two-query pattern but was not in scope for this issue. It can be addressed separately if needed.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1180
