### PR TITLE
[GSSoC'26] fix: persist upvote to database in AnonymousDoubts

### DIFF
--- a/src/pages/AnonymousDoubts.tsx
+++ b/src/pages/AnonymousDoubts.tsx
@@ -23,6 +23,7 @@ export default function AnonymousDoubts() {
   const [submitting, setSubmitting] = useState(false);
   const [search, setSearch] = useState("");
   const [sortOrder, setSortOrder] = useState<"newest" | "top">("newest");
+  const [votedIds, setVotedIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     fetchDoubts();
@@ -69,10 +70,25 @@ export default function AnonymousDoubts() {
     setSubmitting(false);
   };
 
-  const upvote = (id: string) => {
+  const upvote = async (id: string) => {
+    if (votedIds.has(id)) return;
+    const doubt = doubts.find((d) => d.id === id);
+    if (!doubt) return;
+    const newCount = doubt.upvotes + 1;
+    setVotedIds((prev) => new Set(prev).add(id));
     setDoubts(
-      doubts.map((d) => (d.id === id ? { ...d, upvotes: d.upvotes + 1 } : d))
+      doubts.map((d) => (d.id === id ? { ...d, upvotes: newCount } : d))
     );
+    const { error } = await (supabase as any)
+      .from("doubts")
+      .update({ upvotes: newCount })
+      .eq("id", id);
+    if (error) {
+      setDoubts(
+        doubts.map((d) => (d.id === id ? { ...d, upvotes: doubt.upvotes } : d))
+      );
+      setVotedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+    }
   };
 
   const visibleDoubts = useMemo(() => {


### PR DESCRIPTION
## Description

- `upvote` function now persists the upvote to the database via `supabase.from("doubts").update()`
- Added `votedIds` set to prevent duplicate voting within a session
- Added rollback: if the DB call fails, the local upvote count reverts and the vote is removed from votedIds
- Unauthenticated users still see the upvote button; the local count updates optimistically but the DB call may fail for anonymous users (no user_id)

## Files Changed

- `src/pages/AnonymousDoubts.tsx`: Made upvote async with DB persistence; added votedIds dedup set; added rollback on error

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level2`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

```bash
npx tsc --noEmit --project tsconfig.app.json
```

Result: No type errors in changed file.

## Known Limitations

- Session-level dedup only (votedIds resets on page refresh). A `doubt_votes` table or RPC would be needed for persistent dedup across sessions.

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1182
