### PR TITLE
[GSSoC'26] fix: add error handling to session chat sendMessage

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -248,15 +248,21 @@ export function useSessions(user: any) {
       });
     }
 
-    await (supabase as any)
-      .from("messages")
-      .insert({
-        session_id: selectedSession.id,
-        user_id: user?.id,
-        username: user?.user_metadata?.full_name || "Anonymous",
-        message: msgText,
-      });
-  }, [selectedSession, user]);
+    try {
+      const { error } = await (supabase as any)
+        .from("messages")
+        .insert({
+          session_id: selectedSession.id,
+          user_id: user?.id,
+          username: user?.user_metadata?.full_name || "Anonymous",
+          message: msgText,
+        });
+
+      if (error) throw error;
+    } catch (err: any) {
+      toast({ title: "Failed to send message", description: err.message || "An unexpected error occurred.", variant: "destructive" });
+    }
+  }, [selectedSession, user, toast]);
 
   const sendTypingEvent = useCallback(() => {
     if (channelRef.current) {


### PR DESCRIPTION
## Description

- Wrapped `sendMessage` Supabase insert in try/catch block with error toast feedback
- Follows the same error handling pattern used by `handleJoinSession` in the same file
- Users now see a "Failed to send message" toast with the error detail if the insert fails

## Files Changed

- `src/hooks/useSessions.ts`: Added try/catch around supabase insert; show destructive toast on failure; added `toast` to dependency array

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

```bash
npx tsc --noEmit --project tsconfig.app.json
```

Result: No type errors.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1183
