### PR TITLE
Enhancement/1202 ai rate limiting

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -85,9 +85,10 @@ const apiLimiter = rateLimit({
 // Stricter rate limiter for AI to prevent OPENROUTER_API_KEY exhaustion
 const aiLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 20, // limit each IP to 20 AI requests per windowMs
+  max: 10, // limit each IP to 10 AI requests per windowMs
   standardHeaders: true,
   legacyHeaders: false,
+  message: { error: "Too many AI requests from this IP, please try again after 15 minutes" }
 });
 
 app.use("/api", apiLimiter);


### PR DESCRIPTION
Fixes #1202

## Description
Updated the `aiLimiter` middleware to be more restrictive and provide a clearer error message to prevent API key exhaustion and abuse.

## Changes Made
- Reduced the allowed requests in `backend/app.js` from 20 down to 10 per 15-minute window for the AI endpoint.
- Added a standard JSON `message` payload detailing the rate limit to provide better feedback to the frontend client when the limit is breached.
