### PR TITLE
fix(aipage): guard against null auth session before AI API request

### DIFF
--- a/src/pages/aipage.tsx
+++ b/src/pages/aipage.tsx
@@ -37,6 +37,17 @@ const AIPage = () => {
 
     try {
       const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        setMessages((prev: any) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: "Please log in to use the AI assistant. 🔐",
+          },
+        ]);
+        setLoading(false);
+        return;
+      }
       
       const formattedMessages = [...messages, userMessage].map((msg: any) => ({
         role: msg.role,


### PR DESCRIPTION
FIXES #1190
In src/pages/aipage.tsx, the sendMessage function calls supabase.auth.getSession() but never checks whether the returned session is null — which happens whenever a user is unauthenticated or their session has expired — causing session?.access_token to silently resolve to undefined and the fetch to go out with the header Authorization: Bearer undefined, which the backend rejects with a cryptic error that surfaces to the user only as the generic "AI Recommendation Engine failed 😔" message with no actionable guidance. This fix adds an early-return guard immediately after getSession(): if session is falsy, a friendly "Please log in to use the AI assistant 🔐" message is appended to the chat, setLoading(false) is called to clean up the spinner, and the function returns before the fetch is ever attempted — the authenticated happy path is completely unchanged, no new imports are required, and the total diff is under ten lines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authentication verification to AI message functionality. If no session is active, users now receive a login prompt instead of encountering an error, improving the experience when accessing AI features without authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->