### PR TITLE
Fix Portfolio.tsx compilation failure caused by missing try block

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -304,6 +304,7 @@ const Portfolio = () => {
       });
     }, 10_000);
 
+    try {
       const { error } = await (supabase as any)
         .from("portfolio_profiles")
         .upsert(payload, { onConflict: "profile_id" });


### PR DESCRIPTION
## Summary

Fixes #1223

The `savePortfolio` function in `src/pages/Portfolio.tsx` contained a `catch`/`finally` block without a corresponding `try` block, causing Vite/esbuild to fail with:

```text
Expected ";" but found "catch"
```

## Changes

- Added the missing `try` block around the portfolio save operation.
- Restored valid `try`/`catch`/`finally` control flow in `savePortfolio`.

## Root Cause

The database upsert and success-handling logic were intended to be wrapped in a `try` block, but the `try` keyword was missing. This left the `catch` and `finally` blocks orphaned, resulting in a syntax error during compilation.

## Validation

- Verified the syntax error is resolved.
- Confirmed `src/pages/Portfolio.tsx` compiles successfully with esbuild.
- Verified only `src/pages/Portfolio.tsx` was modified.
- No unrelated changes were included.

## Issue

Closes #1223