### PR TITLE
fix(#1220): restore correct portfolio_profiles RLS ownership checks

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -452,9 +452,9 @@ CREATE POLICY "Users can modify whiteboard states"
 --------------------------------------------------------------------------------
 -- portfolio_profiles
 CREATE POLICY "Anyone can view portfolio_profiles" 
-  ON public.portfolio_profiles FOR SELECT USING (true);
+  ON public.portfolio_profiles FOR SELECT USING (is_published = true);
 CREATE POLICY "Users can manage own portfolio_profiles" 
-  ON public.portfolio_profiles FOR ALL USING (id = auth.uid());
+  ON public.portfolio_profiles FOR ALL USING (profile_id = auth.uid());
 
 -- skills_taxonomy
 CREATE POLICY "Anyone can read skills taxonomy" 


### PR DESCRIPTION
## Summary

Fixes #1220

This PR restores the correct RLS behavior for `portfolio_profiles` after the consolidated RLS migration introduced incorrect ownership checks and overly permissive public access.

## Changes

### Before

```sql
CREATE POLICY "Anyone can view portfolio_profiles"
  ON public.portfolio_profiles FOR SELECT USING (true);

CREATE POLICY "Users can manage own portfolio_profiles"
  ON public.portfolio_profiles FOR ALL USING (id = auth.uid());
```

### After

```sql
CREATE POLICY "Anyone can view portfolio_profiles"
  ON public.portfolio_profiles FOR SELECT USING (is_published = true);

CREATE POLICY "Users can manage own portfolio_profiles"
  ON public.portfolio_profiles FOR ALL USING (profile_id = auth.uid());
```

## Why This Fix Is Needed

The consolidated migration used the wrong ownership column for `portfolio_profiles`.

- `id` is a generated portfolio row UUID.
- `profile_id` stores the owning user relationship.
- Frontend portfolio queries use `profile_id`.
- Previous portfolio RLS policies also used `profile_id`.

Using `id = auth.uid()` prevents ownership checks from working correctly because the portfolio row UUID does not match the authenticated user's ID.

Additionally, `USING (true)` allows public access to all portfolio rows, including unpublished drafts.

## Result

- Public users can only view published portfolios.
- Portfolio owners can manage their own portfolio rows.
- Ownership checks align with the schema and existing application logic.
- Behavior matches the intent of the original portfolio RLS policies.

## Validation

### Verification

- Confirmed `portfolio_profiles.id` is a generated row UUID.
- Confirmed `profile_id` is the ownership column.
- Confirmed historical policies used `profile_id`.
- Confirmed frontend portfolio queries use `profile_id`.
- Confirmed no other tables in the consolidated migration contain the same broken ownership pattern.

### Checks

- ✅ `npx tsc --noEmit`
- ⚠️ `vite build` fails due to pre-existing NUL-byte issues unrelated to this change
- ⚠️ `vitest` fails due to pre-existing NUL-byte issues unrelated to this change

These existing failures are not introduced by this PR.

## Files Changed

- `supabase/migrations/20260617000000_consolidate_rls_policies.sql`