### PR TITLE
fix(LiveCodeRunner): cap output at 4KB and share at 1KB to prevent browser freeze

### DIFF
--- a/src/components/studyroom/LiveCodeRunner.tsx
+++ b/src/components/studyroom/LiveCodeRunner.tsx
@@ -6,6 +6,9 @@ import { env } from "@/env";
 
 const PISTON_API_URL = env.VITE_PISTON_API_URL ?? "https://emkc.org/api/v2/piston/execute";
 
+const MAX_OUTPUT_CHARS = 4096;
+const MAX_SHARE_CHARS = 1024;
+
 interface LiveCodeRunnerProps {
   onShare: (code: string, language: string, output: string) => void;
 }
@@ -52,13 +55,20 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
 
       const data = await response.json();
 
+      const truncate = (raw: string) =>
+        raw.length > MAX_OUTPUT_CHARS
+          ? raw.slice(0, MAX_OUTPUT_CHARS) + `\n\n[Output truncated — ${raw.length.toLocaleString()} characters total]`
+          : raw;
+
       if (data.compile && data.compile.code !== 0) {
-        setOutput(`Compilation Error:\n${data.compile.output}`);
+        setOutput(truncate(`Compilation Error:\n${data.compile.output}`));
       } else if (data.run) {
-        if (data.run.code !== 0) {
-          setOutput(`Runtime Error (Exit Code: ${data.run.code}):\n${data.run.output}`);
+        if (data.run.signal === "SIGKILL") {
+          setOutput("Execution timed out or memory limit exceeded.");
+        } else if (data.run.code !== 0) {
+          setOutput(truncate(`Runtime Error (Exit Code: ${data.run.code}):\n${data.run.output}`));
         } else {
-          setOutput(data.run.output || "Program finished with no output.");
+          setOutput(truncate(data.run.output || "Program finished with no output."));
         }
       } else {
         setOutput(data.message || "An unknown error occurred.");
@@ -77,7 +87,11 @@ export function LiveCodeRunner({ onShare }: LiveCodeRunnerProps) {
       toast.error("Nothing to share");
       return;
     }
-    onShare(code, language.id, output);
+    const shareOutput =
+      output.length > MAX_SHARE_CHARS
+        ? output.slice(0, MAX_SHARE_CHARS) + "... [truncated]"
+        : output;
+    onShare(code, language.id, shareOutput);
     setIsOpen(false);
   };
 


### PR DESCRIPTION
Fixes #1230

## What changed

`LiveCodeRunner` was storing and rendering the full Piston API response (up to 64 KB) with no length cap. `whitespace-pre-wrap` on that volume of text triggers expensive browser layout recalculations, freezing the tab. The Share button then broadcast the entire string to every participant in the study room.

**`runCode()`** — added a `truncate` helper that slices output at 4096 characters and appends a notice with the total character count. Applied to success output, runtime errors, and compilation errors.

**SIGKILL handling** — if `data.run.signal === "SIGKILL"`, we now show "Execution timed out or memory limit exceeded." instead of displaying partial output.

**`handleShare()`** — caps the output at 1024 characters before passing it to `onShare`, so the chat message sent to room participants stays small.

## Testing

Run `print("A" * 60000)` in the Python runner — output should be cut to 4096 chars with a truncation notice. Click Share — the chat message should contain at most 1024 chars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overly large execution results from overflowing the interface by truncating displayed output.
  * Limited shared output size and added a clear truncation indicator when content is shortened.
  * Improved error handling for failed runs, including clearer reporting for timeout or memory-limit exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->