### PR TITLE
fix: redesign the footer of landing page

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -10,6 +10,11 @@ import { Hero } from "@/components/landing/Hero";
 import { Features } from "@/components/landing/Features";
 import { Communities } from "@/components/landing/Communities";
 import { Testimonials } from "@/components/landing/Testimonials";
+import { BookOpen, 
+  LayoutGrid,
+  Users,
+  LifeBuoy,
+  ShieldCheck, } from "lucide-react";
 
 const faqs = [
   {
@@ -321,65 +326,128 @@ export default function Landing() {
       </section>
 
       {/* Footer */}
-      <footer className="border-t border-white/10 bg-[#020617]/70 px-6 py-12 backdrop-blur-2xl">
-        <div className="container flex flex-col items-center justify-between gap-8 md:flex-row">
-          <div>
-            <h3 className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-3xl font-black text-transparent">
-              PeerLearn
-            </h3>
+      <footer className="border-t border-white/10 bg-[#020617]/70 px-6 py-12 backdrop-blur-2xl flex flex-col gap-5">
+        <div className="container flex flex-col justify-around gap-8 md:flex-row">
+          <div className="flex flex-col justify-center items-start max-w-md gap-3">
+            <Link
+          to="/"
+          className="flex items-center gap-2"
+          aria-label="PeerLearn home page"
+        >
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-r from-cyan-500 to-blue-600 shadow-lg shadow-cyan-500/30">
+            <BookOpen
+              className="h-5 w-5 text-white"
+              aria-hidden="true"
+            />
+          </div>
+          <h2 className="text-xl font-bold text-white">
+            Peer
+            <span className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-transparent">
+              Learn
+            </span>
+          </h2>
+        </Link>
 
             <p className="mt-3 text-slate-400">
               Built for collaborative student learning.
             </p>
-          </div>
+            <p>
+              Join live mentorship sessions, build projects with classmates, solve doubts instantly, and become part of a futuristic collaborative learning community.
+            </p>
 
-          <div className="flex flex-wrap gap-8 text-slate-300">
-            <a href="#features" className="transition hover:text-cyan-400">
-              Features
-            </a>
-
-            <a href="#community" className="transition hover:text-cyan-400">
-              Communities
-            </a>
-
-            <a href="#faq" className="transition hover:text-cyan-400">
-              FAQ
-            </a>
-
-            <Link to="/contact" className="transition hover:text-cyan-400">
-              Contact Us
+            <Link 
+            to="https://github.com/durdana3105/peer-learning"
+            className="border border-gray-500 rounded-sm p-1"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 30 30">
+    <path fill="#ffffff" d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z"/>
+</svg>
             </Link>
 
+          </div>
+
+          <div className="flex flex-wrap gap-10 text-slate-300">
+
+            <div className="flex flex-col gap-3">
+              <h2 className="text-cyan-500 text-xl flex items-center gap-1"><LayoutGrid/>Platform</h2>
+
+              <div className="flex flex-col justify-center items-start gap-3">
+            <a href="/login" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Login
+            </a>
+            <a href="#features" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Features
+            </a>
+            <button
+              type="button"
+              onClick={openPreferences}
+              className="transition hover:text-cyan-400 hover:translate-x-1"
+            >
+              › Cookie Settings
+            </button>
+
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <h2 className="text-cyan-500 text-xl flex items-center gap-1"><Users/>Community</h2>
+              <div className="flex flex-col justify-center items-start gap-3">
+            <a href="#community" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Communities
+            </a>
+            <a href="https://github.com/durdana3105/peer-learning/discussions" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Discussions
+            </a>
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <h2 className="text-cyan-500 text-xl flex items-center gap-1"><LifeBuoy/>Support</h2>
+              <div className="flex flex-col justify-center items-start gap-3">
+            <a href="#faq" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › FAQ
+            </a>
+            <Link to="/contact" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Contact Us
+            </Link>
+            <Link to="https://github.com/durdana3105/peer-learning/issues" className="transition hover:text-cyan-400 hover:translate-x-1">
+              › Report an issue
+            </Link>
+
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3">
+              <h2 className="text-cyan-500 text-xl flex items-center gap-1"><ShieldCheck/>Legal</h2>
+              <div className="flex flex-col justify-center items-start gap-3">
             <Link
               to="/privacy-policy"
-              className="transition hover:text-cyan-400"
+              className="transition hover:text-cyan-400 hover:translate-x-1"
             >
-              Privacy Policy
+              › Privacy Policy
             </Link>
 
             <Link
               to="/cookies-policy"
-              className="transition hover:text-cyan-400"
+              className="transition hover:text-cyan-400 hover:translate-x-1"
             >
-              Cookies Policy
+              › Cookies Policy
             </Link>
-                        <Link
+            <Link
               to="/terms-and-conditions"
-              className="transition hover:text-cyan-400"
+              className="transition hover:text-cyan-400 hover:translate-x-1"
             >
-              Terms & Conditions
+              › Terms & Conditions
             </Link>
-            <button
-              type="button"
-              onClick={openPreferences}
-              className="transition hover:text-cyan-400"
-            >
-              Cookie Settings
-            </button>
-          </div>
 
-          <div className="text-slate-500">© 2026 PeerLearn</div>
+              </div>
+            </div>
+          </div>
         </div>
+        <div className="border">
+
+        </div>
+          <div className="text-slate-500 text-center">© 2026 PeerLearn. All rights reserved.</div>
       </footer>
     </motion.div>
   );

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -355,11 +355,12 @@ export default function Landing() {
               Join live mentorship sessions, build projects with classmates, solve doubts instantly, and become part of a futuristic collaborative learning community.
             </p>
 
-            <Link 
+             <Link
             to="https://github.com/durdana3105/peer-learning"
+            aria-label="PeerLearn GitHub repository"
             className="border border-gray-500 rounded-sm p-1"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 30 30">
+              <svg xmlns="http://www.w3.org/2000/svg" width="36" height="36" viewBox="0 0 30 30" aria-hidden="true">
     <path fill="#ffffff" d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z"/>
 </svg>
             </Link>
@@ -372,9 +373,9 @@ export default function Landing() {
               <h2 className="text-cyan-500 text-xl flex items-center gap-1"><LayoutGrid/>Platform</h2>
 
               <div className="flex flex-col justify-center items-start gap-3">
-            <a href="/login" className="transition hover:text-cyan-400 hover:translate-x-1">
+            <Link to="/login" className="transition hover:text-cyan-400 hover:translate-x-1">
               › Login
-            </a>
+            </Link>
             <a href="#features" className="transition hover:text-cyan-400 hover:translate-x-1">
               › Features
             </a>


### PR DESCRIPTION
Closes #1071

## Description
This PR redesigns the footer of the landing page. 

## Screenshot
<img width="1917" height="496" alt="image" src="https://github.com/user-attachments/assets/e32df0bb-eb88-4f95-8f94-c78836fda356" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features / Improvements**
  * Redesigns the landing page footer with a branded header and icon-based, multi-column link sections (Platform, Community, Support, Legal).
  * Adds a GitHub link to the footer.
  * Updates footer navigation to include a new login link.
  * Refreshes the footer copyright to “© 2026 PeerLearn. All rights reserved.”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->