### PR TITLE
fix(#1298): allow requests without Origin header in CORS middleware

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -50,12 +50,16 @@ const allowedOrigins = new Set(buildAllowedOrigins());
 
 app.use(cors({
   origin: (origin, callback) => {
-    // Strictly require origin to match the whitelist to prevent no-origin bypasses
-    if (allowedOrigins.has(origin)) {
-      callback(null, true);
-    } else {
-      callback(new Error(`CORS: origin '${origin}' is not allowed`));
+    // Non-browser requests such as curl or health checks may omit Origin.
+    if (!origin) {
+      return callback(null, true);
     }
+
+    if (allowedOrigins.has(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(new Error(`CORS: origin '${origin}' is not allowed`));
   },
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE'],


### PR DESCRIPTION
## Description

This PR fixes the backend CORS middleware to allow requests that do not include an `Origin` header.

Previously, legitimate non-browser requests such as health checks, monitoring services, server-to-server communication, webhooks, and CLI tools (e.g., `curl`) were rejected before reaching their route handlers because the CORS whitelist check treated `undefined` origins as disallowed.

The change allows requests with no `Origin` header while preserving the existing whitelist validation for browser requests that provide an `Origin`.

## Related Issue

Fixes #1298

## Changes Made

* Updated the CORS `origin` callback in `backend/app.js`.
* Added an early return to allow requests when `origin` is undefined/null.
* Preserved existing whitelist validation using `allowedOrigins`.
* Preserved the existing error behavior for disallowed origins.
* Kept the change minimal and scoped to backend CORS logic only.

## Screenshots (if UI change)

Not applicable (Backend-only change).

### Manual Verification

**No Origin Header**

```bash
curl http://localhost:5055/health
```

Result: `200 OK`

**Allowed Origin**

```bash
curl -H "Origin: http://localhost:3000" http://localhost:5055/health
```

Result: `200 OK`

**Disallowed Origin**

```bash
curl -H "Origin: https://example.com" http://localhost:5055/health
```

Result: Request rejected with existing CORS error.

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I have tested my changes locally
* [x] No new console errors
* [x] Linked the issue with 'Fixes #1298'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so clients without an `Origin` header are no longer blocked by cross-origin checks.
  * Continued enforcement of the approved origin list for requests that do include an `Origin` header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->