### PR TITLE
fix(#1300): guard contact form storage writes

### DIFF
--- a/src/pages/Contact.test.tsx
+++ b/src/pages/Contact.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Contact from "./Contact";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+
+vi.mock("framer-motion", () => ({
+  motion: {
+    div: ({ children, className }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div className={className}>{children}</div>
+    ),
+  },
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: vi.fn(),
+}));
+
+describe("Contact", () => {
+  const toast = vi.fn();
+  const insert = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+
+    (useToast as any).mockReturnValue({ toast });
+    (supabase.from as any).mockReturnValue({ insert });
+    insert.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows success when local contact submission storage cannot be updated", async () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage unavailable");
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(
+      <MemoryRouter>
+        <Contact />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/first name/i), {
+      target: { value: "Ada" },
+    });
+    fireEvent.change(screen.getByLabelText(/last name/i), {
+      target: { value: "Lovelace" },
+    });
+    fireEvent.change(screen.getByLabelText(/email address/i), {
+      target: { value: "ada@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText(/subject/i), {
+      target: { value: "Hello" },
+    });
+    fireEvent.change(screen.getByLabelText(/message/i), {
+      target: { value: "I would like to learn more." },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /send message/i }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringMatching(/^Message Sent!/),
+        })
+      );
+    });
+
+    expect(toast).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Submission Failed",
+      })
+    );
+  });
+});

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -49,7 +49,11 @@ const getSubmissionRecord = (): SubmissionRecord => {
 };
 
 const saveSubmissionRecord = (record: SubmissionRecord) => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+  } catch (error) {
+    console.warn("Unable to save contact submission locally.", error);
+  }
 };
 
 const checkRateLimit = (


### PR DESCRIPTION
## Description

This PR fixes a false failure scenario in the Contact form submission flow.

Previously, `saveSubmissionRecord()` called `localStorage.setItem()` without error handling. If browser storage was blocked, unavailable, or quota-restricted, the storage write could throw after a successful Supabase insert and incorrectly trigger the form's failure path.

The fix wraps the local storage write in a `try/catch` block and logs a non-fatal warning, ensuring that successful contact message submissions are not affected by local storage failures.

A test has also been added to verify that when `localStorage.setItem()` throws, the Contact form still shows a successful submission message and does not display a failure notification.

## Related Issue

Fixes #1300

## Changes Made

* Added error handling around `localStorage.setItem()` in `saveSubmissionRecord()`.
* Prevented storage write failures from bubbling into the contact form submission error path.
* Added a test covering the scenario where `localStorage.setItem()` throws after a successful Supabase insert.
* Verified that successful submissions still display the success toast and do not show the failure toast.

## Screenshots (if UI change)

No UI changes.

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I have tested my changes locally
* [x] No new console errors
* [x] Linked the issue with 'Fixes #1300'