### PR TITLE
fix(#1301): clean up orphaned resource uploads

### DIFF
--- a/src/lib/__tests__/uploadResource.test.ts
+++ b/src/lib/__tests__/uploadResource.test.ts
@@ -1,1 +1,132 @@
-// Fix for #1161: Added unit tests for uploadResource
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { uploadResource } from "../uploadResource";
+import { logError } from "@/utils/logger";
+
+const mocks = vi.hoisted(() => ({
+  getUser: vi.fn(),
+  getSession: vi.fn(),
+  from: vi.fn(),
+  storageFrom: vi.fn(),
+  insert: vi.fn(),
+  single: vi.fn(),
+  remove: vi.fn(),
+  logError: vi.fn(),
+}));
+
+vi.mock("@/config/api", () => ({
+  API_BASE_URL: "http://localhost:3000",
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: mocks.logError,
+}));
+
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getUser: mocks.getUser,
+      getSession: mocks.getSession,
+    },
+    from: mocks.from,
+    storage: {
+      from: mocks.storageFrom,
+    },
+  },
+}));
+
+describe("uploadResource", () => {
+  const file = new File(["content"], "notes.pdf", { type: "application/pdf" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getUser.mockResolvedValue({
+      data: { user: { id: "user-123" } },
+    });
+    mocks.getSession.mockResolvedValue({
+      data: { session: { access_token: "token-123" } },
+    });
+    mocks.from.mockReturnValue({
+      insert: mocks.insert,
+    });
+    mocks.insert.mockReturnValue({
+      select: () => ({
+        single: mocks.single,
+      }),
+    });
+    mocks.storageFrom.mockReturnValue({
+      remove: mocks.remove,
+    });
+    mocks.remove.mockResolvedValue({ error: null });
+
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        success: true,
+        data: { path: "user-123/backend-path.pdf" },
+      }),
+    } as unknown as Response);
+  });
+
+  it("removes the uploaded storage object when metadata insert fails", async () => {
+    mocks.single.mockResolvedValue({
+      data: null,
+      error: { message: "metadata insert failed" },
+    });
+
+    const result = await uploadResource(file, "Notes", "Helpful notes", [
+      "typescript",
+    ]);
+
+    expect(result).toEqual({
+      success: false,
+      error: "metadata insert failed",
+    });
+    expect(mocks.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        file_url: "user-123/backend-path.pdf",
+      })
+    );
+    expect(mocks.storageFrom).toHaveBeenCalledWith("resources");
+    expect(mocks.remove).toHaveBeenCalledWith(["user-123/backend-path.pdf"]);
+  });
+
+  it("logs cleanup failure without replacing the metadata insert error", async () => {
+    const cleanupError = new Error("cleanup failed");
+    mocks.single.mockResolvedValue({
+      data: null,
+      error: { message: "metadata insert failed" },
+    });
+    mocks.remove.mockResolvedValue({ error: cleanupError });
+
+    const result = await uploadResource(file, "Notes", "Helpful notes", []);
+
+    expect(result).toEqual({
+      success: false,
+      error: "metadata insert failed",
+    });
+    expect(logError).toHaveBeenCalledWith(
+      cleanupError,
+      expect.objectContaining({
+        context: "uploadResource.cleanup",
+        filePath: "user-123/backend-path.pdf",
+      })
+    );
+  });
+
+  it("does not remove storage when upload fails before a path is returned", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: vi.fn().mockResolvedValue("upload failed"),
+    } as unknown as Response);
+
+    const result = await uploadResource(file, "Notes", "Helpful notes", []);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Server error: 500 - upload failed",
+    });
+    expect(mocks.remove).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/uploadResource.ts
+++ b/src/lib/uploadResource.ts
@@ -19,6 +19,13 @@ type UploadResourceResult =
   | { success: true; data: Resource }
   | { success: false; error: string };
 
+type UploadApiResponse = {
+  success: boolean;
+  data?: {
+    path?: string;
+  };
+};
+
 const getFileExtension = (filename: string) => {
   const parts = filename.split(".");
   return parts.length > 1 ? parts.pop()!.toLowerCase() : "";
@@ -72,7 +79,7 @@ export const uploadResource = async (
   const session = await supabase.auth.getSession();
   const token = session.data.session?.access_token;
 
-  let uploadResponse;
+  let uploadResponse: UploadApiResponse;
   try {
     const res = await fetch(`${API_BASE_URL}/api/upload`, {
       method: "POST",
@@ -106,13 +113,21 @@ export const uploadResource = async (
     };
   }
 
+  const uploadedPath = uploadResponse.data?.path;
+  if (!uploadedPath) {
+    return {
+      success: false,
+      error: "Upload failed: missing uploaded file path.",
+    };
+  }
+
   try {
     const { data, error } = await (supabase as any)
       .from("resources")
       .insert({
         title,
         description,
-        file_url: filePath,
+        file_url: uploadedPath,
         file_type: fileType,
         file_size: file.size,
         tags,
@@ -134,7 +149,25 @@ export const uploadResource = async (
       data: data as Resource,
     };
   } catch (err: any) {
-    logError(err, { context: "uploadResource.insert", filePath });
+    try {
+      const { error: cleanupError } = await supabase.storage
+        .from("resources")
+        .remove([uploadedPath]);
+
+      if (cleanupError) {
+        logError(cleanupError, {
+          context: "uploadResource.cleanup",
+          filePath: uploadedPath,
+        });
+      }
+    } catch (cleanupErr) {
+      logError(cleanupErr, {
+        context: "uploadResource.cleanup",
+        filePath: uploadedPath,
+      });
+    }
+
+    logError(err, { context: "uploadResource.insert", filePath: uploadedPath });
     return {
       success: false,
       error: err.message || "Failed to save resource metadata",


### PR DESCRIPTION
## Description

This PR fixes orphaned resource uploads when metadata insertion fails after a successful file upload.

Previously, the Resource Hub upload flow uploaded files to Supabase Storage before inserting metadata into the `resources` table. If the metadata insert failed, the uploaded file remained in storage without a corresponding database record.

## Related Issue

Fixes #1301

## Changes Made

* Added cleanup logic to remove uploaded storage objects when metadata insertion fails.
* Preserved the original metadata insert error after cleanup attempts.
* Added separate logging for cleanup failures using `uploadResource.cleanup`.
* Added validation for missing uploaded file paths in upload responses.
* Added unit tests covering:

  * Successful cleanup after metadata insert failure.
  * Cleanup failure logging behavior.
  * No cleanup when upload fails before a storage path is returned.

## Testing

### Passed

```bash
npm test -- src/lib/__tests__/uploadResource.test.ts
```

Result:

* 3 tests passed
* 0 failures

```bash
npx eslint src/lib/uploadResource.ts src/lib/__tests__/uploadResource.test.ts
```

Result:

* Passed

### Known Repository Issues

Full project lint/build could not be completed due to pre-existing unrelated NUL character parse errors already present in the repository, including:

* `src/pages/Dashboard.tsx`

These issues are unrelated to this PR.

## Screenshots

N/A (backend/data consistency fix)

## Checklist

* [x] Tested locally
* [x] Added/updated tests
* [x] Kept changes scoped to the issue
* [x] Linked issue with `Fixes #1301`