### PR TITLE
fix(#1302): replace invalid password strength Tailwind classes

### DIFF
--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -282,13 +282,13 @@ const Signup = () => {
 
             {password && (
               <div className="mt-2">
-              <div className="h-2 w-full bg-state-700 rounded">
+              <div className="h-2 w-full bg-slate-700 rounded">
                 <div
                   className ={`h-2 rounded transition-all duration-300 ${passwordStrength.color}`}
                   style={{ width: `${(passwordStrength.label === "Weak" ? 33 : passwordStrength.label === "Medium" ? 66 : 100)}%` }}
                 />
               </div>
-              <p className="text-sm text-state-300 mt-1">Password Strength: {passwordStrength.label}</p>
+              <p className="text-sm text-slate-300 mt-1">Password Strength: {passwordStrength.label}</p>
               <div className="mt-2 text-sm space-y-1">
                 <p className={password.length >= 8 ? "text-green-400" : "text-red-400"}>
                   {password.length >= 8 ? "✓" : "✗"} At least 8 characters


### PR DESCRIPTION
## Description

This PR fixes invalid Tailwind utility classes used in the Signup password-strength indicator.

The component was using `bg-state-700` and `text-state-300`, but these classes are not defined in the project's Tailwind configuration or CSS utilities. As a result, the intended muted background and text styling were not applied.

The invalid classes have been replaced with valid Tailwind slate utilities:

* `bg-state-700` → `bg-slate-700`
* `text-state-300` → `text-slate-300`

## Related Issue

Fixes #1302

## Changes Made

* Updated the password-strength progress track background class.
* Updated the password-strength label text color class.
* Removed all occurrences of the invalid `state-*` Tailwind classes from `Signup.tsx`.
* Kept the change scoped to the Signup page without modifying any password validation or authentication logic.

## Testing

* ✅ `git diff --check` passed
* ✅ Verified no remaining occurrences of `bg-state-700` or `text-state-300` in `src`
* ⚠️ `npm run lint` failed due to unrelated pre-existing parse/binary-file errors
* ⚠️ `npm run build` failed due to an unrelated null-byte parse error in `src/pages/Dashboard.tsx`

## Screenshots

UI-only styling fix. The password-strength indicator now renders with valid muted background and text styling.