### PR TITLE
Align AI schema message limits

### DIFF
--- a/backend/validation/schemas.js
+++ b/backend/validation/schemas.js
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 const allowedChatModels = ["openai/gpt-3.5-turbo", "openai/gpt-4o-mini"];
+const MAX_ASK_MESSAGES = 10;
+const MAX_SUMMARY_MESSAGES = 50;
 
 const chatMessageSchema = z.object({
   role: z.enum(["user", "assistant", "system"]),
@@ -89,7 +91,7 @@ export const aiSchemas = {
           role: z.string().optional(),
           content: z.string().trim().min(1).max(4000),
         })
-      ).min(1).max(50),
+      ).min(1).max(MAX_ASK_MESSAGES),
       systemPrompt: z.string().optional(),
       model: z.string().optional()
     }),
@@ -137,7 +139,7 @@ export const aiSchemas = {
   generateSessionSummary: {
     body: z
       .object({
-        messages: z.array(summarizeMessageSchema).min(1).max(100),
+        messages: z.array(summarizeMessageSchema).min(1).max(MAX_SUMMARY_MESSAGES),
       })
       .superRefine((data, ctx) => {
         const totalLength = data.messages.reduce(


### PR DESCRIPTION
## Summary

- Added named validation constants for AI message limits.
- Aligned `askAI` validation with the controller's 10-message limit.
- Aligned summary validation with the controller's 50-message limit.

## Validation

- `node --check backend/validation/schemas.js`

Closes #1385
