### PR TITLE
Run backend tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
           NODE_ENV: test
           SUPABASE_JWT_SECRET: dummy-secret-for-ci
           FRONTEND_URL: http://localhost:5173
+
+      - name: Run Backend Tests
+        run: cd backend && npm test
+        env:
+          NODE_ENV: test
+          SUPABASE_JWT_SECRET: dummy-secret-for-ci
+          FRONTEND_URL: http://localhost:5173

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch server.ts",
-    "start": "tsx server.ts"
+    "start": "tsx server.ts",
+    "test": "npm --prefix .. run test -- --project backend"
   },
   "dependencies": {
     "axios": "^1.16.1",


### PR DESCRIPTION
## Summary

- Added a backend package `test` script that runs the backend Vitest project from the root config.
- Added an explicit CI step for backend tests after backend dependencies are installed.

## Validation

- `cd backend && npm ci`
- `cd backend && npm test`

Closes #1386
