### PR TITLE
fix(#1448): restrict mentorship RLS to participants

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -290,21 +290,27 @@ CREATE POLICY "Admins can update all mentor apps"
   ON public.mentors FOR UPDATE USING (public.has_role(auth.uid(), 'admin'));
 
 -- mentorship_paths & mentorship_milestones
-CREATE POLICY "Users can view own mentorship paths"
+CREATE POLICY "Users and admins can view mentorship paths"
   ON public.mentorship_paths FOR SELECT USING (
-    auth.uid() = mentor_id OR auth.uid() = mentee_id
+    auth.uid() = mentor_id
+    OR auth.uid() = mentee_id
+    OR public.has_role(auth.uid(), 'admin')
   );
 
 CREATE POLICY "Mentors can manage their paths" 
   ON public.mentorship_paths FOR ALL USING (mentor_id = auth.uid());
 
-CREATE POLICY "Users can view own mentorship milestones"
+CREATE POLICY "Users and admins can view mentorship milestones"
   ON public.mentorship_milestones FOR SELECT USING (
     EXISTS (
       SELECT 1
       FROM public.mentorship_paths mp
       WHERE mp.id = mentorship_milestones.path_id
-        AND (mp.mentor_id = auth.uid() OR mp.mentee_id = auth.uid())
+        AND (
+          auth.uid() = mp.mentor_id
+          OR auth.uid() = mp.mentee_id
+          OR public.has_role(auth.uid(), 'admin')
+        )
     )
   );
 

--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -290,14 +290,23 @@ CREATE POLICY "Admins can update all mentor apps"
   ON public.mentors FOR UPDATE USING (public.has_role(auth.uid(), 'admin'));
 
 -- mentorship_paths & mentorship_milestones
-CREATE POLICY "Anyone can view mentorship paths" 
-  ON public.mentorship_paths FOR SELECT USING (true);
+CREATE POLICY "Users can view own mentorship paths"
+  ON public.mentorship_paths FOR SELECT USING (
+    auth.uid() = mentor_id OR auth.uid() = mentee_id
+  );
 
 CREATE POLICY "Mentors can manage their paths" 
   ON public.mentorship_paths FOR ALL USING (mentor_id = auth.uid());
 
-CREATE POLICY "Anyone can view milestones" 
-  ON public.mentorship_milestones FOR SELECT USING (true);
+CREATE POLICY "Users can view own mentorship milestones"
+  ON public.mentorship_milestones FOR SELECT USING (
+    EXISTS (
+      SELECT 1
+      FROM public.mentorship_paths mp
+      WHERE mp.id = mentorship_milestones.path_id
+        AND (mp.mentor_id = auth.uid() OR mp.mentee_id = auth.uid())
+    )
+  );
 
 CREATE POLICY "Mentors can manage milestones" 
   ON public.mentorship_milestones FOR ALL USING (


### PR DESCRIPTION
## Description

This PR fixes a mentorship data exposure issue introduced by the consolidated RLS migration.

The previous policies allowed all authenticated users to read records from `mentorship_paths` and `mentorship_milestones` using `USING (true)`. As a result, users who were not participants in a mentorship could access mentorship goals, milestone details, descriptions, and due dates.

This change restores participant-based access control so that only the mentor or mentee associated with a mentorship can view its path and milestones.

## Related Issue

Fixes #1448

## Changes Made

* Replaced the public read policy on `mentorship_paths`.
* Restricted `mentorship_paths` SELECT access to:

  * `auth.uid() = mentor_id`
  * OR `auth.uid() = mentee_id`
* Replaced the public read policy on `mentorship_milestones`.
* Restricted `mentorship_milestones` SELECT access through the related mentorship path using an `EXISTS` check.
* Preserved existing non-related RLS behavior and kept the change limited to the affected policies.

## Screenshots (if UI change)

Not applicable – database/RLS policy change.

## Checklist

* [x] I have read CONTRIBUTING.md
* [x] I have tested my changes locally
* [x] No new console errors
* [x] Linked the issue with 'Fixes #'

### Validation

* ✅ `npm.cmd run lint`
* ✅ `npm.cmd test` (196 tests passed)
* ✅ `git diff --check`
* ⚠️ `npx.cmd supabase db lint` could not be executed because a local Supabase Postgres instance was not running on `127.0.0.1:54322`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened visibility for mentorship paths and milestones so only participants can view their own records.
  * Replaced broad public read access with user-specific access checks for more appropriate privacy.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->