### PR TITLE
fix(#1447): validate peer review submission URLs

### DIFF
--- a/src/pages/ReviewSubmission.tsx
+++ b/src/pages/ReviewSubmission.tsx
@@ -5,6 +5,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/components/ui/use-toast";
+import { getSafePeerReviewSubmissionUrl } from "@/utils/peerReviewUrl";
 import { ArrowLeft, Send, Star, ExternalLink, Code } from "lucide-react";
 
 export default function ReviewSubmission() {
@@ -117,6 +118,8 @@ export default function ReviewSubmission() {
   const isAnon = submission.is_anonymous;
   const authorName = isAnon ? "Anonymous Learner" : (submission.profiles?.name || "Unknown");
   const avatar = isAnon ? `https://api.dicebear.com/9.x/bottts/svg?seed=${submission.id}` : (submission.profiles?.avatar_url || `https://api.dicebear.com/9.x/avataaars/svg?seed=${authorName}`);
+  const contentUrlText = typeof submission.content_url === "string" ? submission.content_url.trim() : "";
+  const safeContentUrl = getSafePeerReviewSubmissionUrl(submission.content_url);
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">
@@ -143,13 +146,17 @@ export default function ReviewSubmission() {
               </div>
             )}
 
-            {submission.content_url && (
+            {contentUrlText && (
               <div className="mb-6">
                 <h3 className="text-sm font-medium text-slate-500 uppercase tracking-wider mb-2">Link</h3>
-                <a href={submission.content_url} target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-cyan-400 hover:text-cyan-300">
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  {submission.content_url}
-                </a>
+                {safeContentUrl ? (
+                  <a href={safeContentUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center text-cyan-400 hover:text-cyan-300">
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    {contentUrlText}
+                  </a>
+                ) : (
+                  <p className="text-slate-200 break-all">{contentUrlText}</p>
+                )}
               </div>
             )}
 

--- a/src/pages/SubmitForReview.tsx
+++ b/src/pages/SubmitForReview.tsx
@@ -8,6 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/use-toast";
+import { getSafePeerReviewSubmissionUrl } from "@/utils/peerReviewUrl";
 import { ArrowLeft, Send } from "lucide-react";
 import { Link } from "react-router-dom";
 
@@ -28,8 +29,18 @@ export default function SubmitForReview() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
-    
-    if (!formData.title || (!formData.content_url && !formData.content)) {
+    const safeContentUrl = getSafePeerReviewSubmissionUrl(formData.content_url);
+
+    if (safeContentUrl === null) {
+      toast({
+        title: "Validation Error",
+        description: "Please enter a valid http:// or https:// link.",
+        variant: "destructive"
+      });
+      return;
+    }
+
+    if (!formData.title || (!safeContentUrl && !formData.content)) {
       toast({
         title: "Validation Error",
         description: "Please provide a title and either a link or text content.",
@@ -46,7 +57,7 @@ export default function SubmitForReview() {
         user_id: user.id,
         title: formData.title,
         description: formData.description,
-        content_url: formData.content_url,
+        content_url: safeContentUrl,
         content: formData.content,
         is_anonymous: formData.is_anonymous,
         status: 'pending'

--- a/src/test/peerReviewUrl.test.ts
+++ b/src/test/peerReviewUrl.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  getSafePeerReviewSubmissionUrl,
+  isValidPeerReviewSubmissionUrl,
+} from "@/utils/peerReviewUrl";
+
+describe("peer review submission URL validation", () => {
+  it("accepts https URLs", () => {
+    expect(isValidPeerReviewSubmissionUrl("https://example.com")).toBe(true);
+    expect(getSafePeerReviewSubmissionUrl("https://example.com")).toBe("https://example.com");
+  });
+
+  it("accepts http URLs", () => {
+    expect(isValidPeerReviewSubmissionUrl("http://example.com")).toBe(true);
+    expect(getSafePeerReviewSubmissionUrl("http://example.com")).toBe("http://example.com");
+  });
+
+  it("accepts an empty string as optional", () => {
+    expect(isValidPeerReviewSubmissionUrl("")).toBe(true);
+    expect(getSafePeerReviewSubmissionUrl("")).toBe("");
+  });
+
+  it("rejects javascript URLs", () => {
+    expect(isValidPeerReviewSubmissionUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data URLs", () => {
+    expect(isValidPeerReviewSubmissionUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("rejects invalid URLs", () => {
+    expect(isValidPeerReviewSubmissionUrl("not-a-url")).toBe(false);
+  });
+});

--- a/src/utils/peerReviewUrl.ts
+++ b/src/utils/peerReviewUrl.ts
@@ -1,0 +1,20 @@
+const SAFE_PEER_REVIEW_URL_PROTOCOLS = new Set(["http:", "https:"]);
+
+export function getSafePeerReviewSubmissionUrl(value: string | null | undefined): string | null {
+  const trimmedValue = value?.trim() ?? "";
+
+  if (!trimmedValue) {
+    return "";
+  }
+
+  try {
+    const url = new URL(trimmedValue);
+    return SAFE_PEER_REVIEW_URL_PROTOCOLS.has(url.protocol) ? trimmedValue : null;
+  } catch {
+    return null;
+  }
+}
+
+export function isValidPeerReviewSubmissionUrl(value: string | null | undefined): boolean {
+  return getSafePeerReviewSubmissionUrl(value) !== null;
+}


### PR DESCRIPTION
## Description

Fixes a peer review URL validation issue by ensuring only safe `http://` and `https://` links are accepted and rendered.

### Changes Made

- Added a reusable URL validation helper for peer review submissions.
- Validates `content_url` using `new URL(...)`.
- Allows only `http:` and `https:` protocols.
- Rejects unsafe schemes such as `javascript:` and `data:`.
- Trims URLs before saving them to the database.
- Prevents form submission when an invalid URL is provided and displays a validation error.
- Ensures the review page only renders clickable links for validated URLs.
- Falls back to rendering invalid stored values as plain text instead of an active link.
- Added unit tests covering valid, invalid, and unsafe URL inputs.

### Files Changed

- `src/pages/SubmitForReview.tsx`
- `src/pages/ReviewSubmission.tsx`
- `src/utils/peerReviewUrl.ts`
- `src/test/peerReviewUrl.test.ts`

## Related Issue

Closes #1447

## Testing

- ✅ `npm.cmd test` passed (202 tests)
- ✅ `npm.cmd run lint` passed (no errors)
- ✅ `npm.cmd run build` passed

## Security Impact

This change adds defense-in-depth validation for peer review submission links and prevents unsafe URL schemes from being stored and rendered as clickable links.