### PR TITLE
fix(#1446): prevent self-reviews in peer review

### DIFF
--- a/supabase/migrations/20260702000000_prevent_peer_review_self_reviews.sql
+++ b/supabase/migrations/20260702000000_prevent_peer_review_self_reviews.sql
@@ -1,0 +1,16 @@
+-- Prevent users from reviewing their own peer review submissions.
+DROP POLICY IF EXISTS "Users can insert reviews" ON public.peer_reviews;
+
+CREATE POLICY "Users can insert reviews"
+  ON public.peer_reviews
+  FOR INSERT
+  WITH CHECK (
+    reviewer_id = auth.uid()
+    AND EXISTS (
+      SELECT 1
+      FROM public.peer_submissions ps
+      WHERE ps.id = peer_reviews.submission_id
+        AND ps.user_id IS NOT NULL
+        AND ps.user_id <> auth.uid()
+    )
+  );


### PR DESCRIPTION
### Summary

This PR prevents users from reviewing their own peer review submissions at the database level.

Previously, the frontend hid the review form for submission owners, but the `peer_reviews` INSERT RLS policy only validated `reviewer_id = auth.uid()`. An authenticated user could bypass the UI and directly insert a review for their own submission through Supabase APIs.

### Changes

* Added a new Supabase migration to update the `peer_reviews` INSERT policy.
* Preserved the existing requirement that `reviewer_id = auth.uid()`.
* Added validation that the referenced submission belongs to a different user.
* Prevented self-review creation through direct database/API calls.

### Testing

* `npm.cmd test`
* `npm.cmd run lint`
* `npm.cmd run build`

### Closes

Closes #1446