### PR TITLE
fix(#1444): enable dashboard community card navigation

### DIFF
--- a/src/components/dashboard/CommunitiesWidget.tsx
+++ b/src/components/dashboard/CommunitiesWidget.tsx
@@ -23,18 +23,11 @@ export default function CommunitiesWidget() {
 
       <div className="space-y-3 flex-1">
         {joinedCommunities.map((community) => (
-          <div
+          <Link
             key={community.id}
+            to="/discover"
             className="flex items-center justify-between p-3 rounded-2xl bg-slate-800/50 border border-slate-700/30 hover:border-slate-600 transition-colors group cursor-pointer"
-            role="button"
-            tabIndex={0}
-            onClick={() => { /* Navigate to community */ }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                // Navigate to community
-              }
-            }}
+            aria-label={`Explore ${community.name} on Discover`}
           >
             <div className="flex items-center gap-3">
               <div className={`w-10 h-10 rounded-xl ${community.color} flex items-center justify-center text-white font-bold text-lg shadow-inner`}>
@@ -55,7 +48,7 @@ export default function CommunitiesWidget() {
                 <span className="text-xs text-slate-300">{community.active} active</span>
               </div>
             </div>
-          </div>
+          </Link>
         ))}
       </div>
 


### PR DESCRIPTION
## Description
This PR fixes inactive community cards in the learner dashboard Communities widget.

The cards previously looked clickable and had placeholder mouse/keyboard handlers, but did not perform any action. They now use React Router `Link` components and navigate to the existing `/discover` route.

## Related Issue
Fixes #1444

## Changes Made
- Replaced fake clickable `div` community cards with accessible `Link` components
- Routed community cards to `/discover`
- Removed placeholder navigation handlers
- Added an `aria-label` for clearer accessible navigation

## Testing
- npm.cmd run lint passed with existing warnings only
- npm.cmd run build passed
- npm.cmd run test passed: 27 files, 196 tests