### PR TITLE
Replace Next links in docs page

### DIFF
--- a/src/components/docs/page.tsx
+++ b/src/components/docs/page.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 import {
   FileText,
   Users,
@@ -55,13 +54,14 @@ export default function DocsPage() {
           <ul className="list-disc list-inside space-y-2 text-gray-700 dark:text-gray-300">
             <li>
               Read the{" "}
-              <Link
+              <a
                 href="https://github.com/durdana3105/peer-learning"
                 className="text-blue-600 hover:underline"
                 target="_blank"
+                rel="noreferrer"
               >
                 README
-              </Link>
+              </a>
             </li>
             <li>
               Set up the development environment following the repository
@@ -69,12 +69,12 @@ export default function DocsPage() {
             </li>
             <li>
               Familiarize yourself with our{" "}
-              <Link
+              <a
                 href="#code-of-conduct"
                 className="text-blue-600 hover:underline"
               >
                 Code of Conduct
-              </Link>
+              </a>
             </li>
             <li>Explore open issues and discussions on GitHub</li>
           </ul>
@@ -101,13 +101,14 @@ export default function DocsPage() {
               <li>Push and open a Pull Request</li>
             </ol>
           </div>
-          <Link
+          <a
             href="https://github.com/durdana3105/peer-learning/blob/main/CONTRIBUTING.md"
             className="inline-flex items-center gap-2 text-blue-600 hover:underline font-medium"
             target="_blank"
+            rel="noreferrer"
           >
             Read Full Contributing Guidelines →
-          </Link>
+          </a>
         </section>
 
         {/* 4. Code of Conduct */}
@@ -130,13 +131,14 @@ export default function DocsPage() {
               discrimination, offensive language, personal attacks.
             </p>
           </div>
-          <Link
+          <a
             href="https://github.com/durdana3105/peer-learning/blob/main/CODE_OF_CONDUCT.md"
             className="inline-flex items-center gap-2 text-blue-600 hover:underline font-medium mt-4"
             target="_blank"
+            rel="noreferrer"
           >
             Read Full Code of Conduct →
-          </Link>
+          </a>
         </section>
 
         {/* 5. Security & Responsible Disclosure */}
@@ -170,13 +172,14 @@ export default function DocsPage() {
             Found a bug? Have a feature idea? Please open an issue with a clear
             title, description, and reproduction steps (if applicable).
           </p>
-          <Link
+          <a
             href="https://github.com/durdana3105/peer-learning/issues"
             className="inline-flex items-center gap-2 text-blue-600 hover:underline font-medium mt-4"
             target="_blank"
+            rel="noreferrer"
           >
             Open a New Issue →
-          </Link>
+          </a>
         </section>
 
         {/* 7. Pull Request Expectations */}


### PR DESCRIPTION
## Summary
- Removes the Next.js Link import from the docs page
- Uses standard anchors for external and in-page links
- Adds rel attributes to external links opened in a new tab

## Validation
- npx tsc -p tsconfig.app.json --noEmit no longer reports the next/link module error

Closes #1460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the docs page to use standard external links for repository resources and community pages.
  * These links now open in a new tab for a smoother browsing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->