### PR TITLE
Add direct message schema types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -207,6 +207,8 @@ export type Database = {
           content: string | null
           created_at: string | null
           id: string
+          message: string | null
+          read_at: string | null
           receiver_id: string | null
           sender_id: string | null
           text: string | null
@@ -215,6 +217,8 @@ export type Database = {
           content?: string | null
           created_at?: string | null
           id?: string
+          message?: string | null
+          read_at?: string | null
           receiver_id?: string | null
           sender_id?: string | null
           text?: string | null
@@ -223,6 +227,8 @@ export type Database = {
           content?: string | null
           created_at?: string | null
           id?: string
+          message?: string | null
+          read_at?: string | null
           receiver_id?: string | null
           sender_id?: string | null
           text?: string | null
@@ -654,6 +660,10 @@ export type Database = {
       }
       join_session: {
         Args: { p_session_id: string }
+        Returns: undefined
+      }
+      mark_messages_as_read: {
+        Args: { message_ids: string[] }
         Returns: undefined
       }
       tick_session_statuses: {


### PR DESCRIPTION
## Summary
- Adds the missing direct-message fields to the generated Supabase messages type
- Adds the mark_messages_as_read RPC signature used by the message hook

## Validation
- npx tsc -p tsconfig.app.json --noEmit no longer reports the useMessages message-column or RPC errors

Closes #1463