### PR TITLE
Add has_role RPC type

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -634,6 +634,13 @@ export type Database = {
         }
         Returns: number
       }
+      has_role: {
+        Args: {
+          _role: string
+          _user_id: string
+        }
+        Returns: boolean
+      }
       invite_to_study_room: {
         Args: {
           p_room_id: string


### PR DESCRIPTION
## Summary
- Adds the has_role RPC signature to the generated Supabase types
- Gives navbar admin detection a boolean RPC result

## Validation
- npx tsc -p tsconfig.app.json --noEmit no longer reports the useNavbarProfile has_role errors

Closes #1465