### PR TITLE
Upgrade backend nodemailer

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,7 +18,7 @@
         "express-rate-limit": "^8.5.2",
         "file-type": "^22.0.1",
         "multer": "^2.1.1",
-        "nodemailer": "^8.0.5",
+        "nodemailer": "^9.0.3",
         "openai": "^6.34.0",
         "zod": "^3.25.76"
       },
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.11.tgz",
-      "integrity": "sha512-nrO/pDAUKl+wXX+lx16tDLbnm0fW6sK/x8mgohaCpg+CdCEl482bD4tCuAZk2DyliruiNTIZxRCoWkDqJEnAiA==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "express-rate-limit": "^8.5.2",
     "file-type": "^22.0.1",
     "multer": "^2.1.1",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^9.0.3",
     "openai": "^6.34.0",
     "@supabase/supabase-js": "^2.102.1",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Summary
- Upgrades the backend nodemailer dependency to the patched 9.x line
- Refreshes the backend lockfile for the dependency update

## Validation
- npm install --package-lock-only
- npm audit --json

Closes #1466