### PR TITLE
Run typecheck before production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run typecheck && vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "typecheck": "tsc -p tsconfig.app.json --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",


### PR DESCRIPTION
## Summary
- Adds a dedicated typecheck script for the app TypeScript project
- Runs typecheck before Vite production builds so type errors stop the build before assets are emitted

## Validation
- npm run build now enters typecheck first and fails on the existing TypeScript errors instead of completing the Vite build

Closes #1459