### PR TITLE
fix(sessions): award XP only after successful session join

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -220,6 +220,10 @@ export function useSessions(user: any) {
       } else {
         toast({ title: "Success! 🎉", description: "You have joined the session." });
 
+        // Only award XP here, after join_session has actually succeeded and
+        // confirmed the user as a participant. This is the single source of
+        // truth for "session_join" XP — handleJoinVideo must NOT award it,
+        // since opening the video does not by itself confirm participation.
         if (!existingParticipant) {
           awardedSessionsRef.current.add(sessionId);
           awardXP({ activity: "session_join" });
@@ -314,13 +318,14 @@ export function useSessions(user: any) {
     }
   }, [selectedSession, messages]);
 
+  // NOTE: This no longer awards "session_join" XP. Opening the video call is
+  // not proof of confirmed participation — only a successful `join_session`
+  // RPC call (handled in handleJoinSession) confirms that, so that's the
+  // only place XP is granted. This closes the XP-farming hole where a user
+  // could click "Join Video" without ever clicking "Join Session".
   const handleJoinVideo = useCallback(() => {
     setIsVideoActive(true);
-    if (selectedSession && !awardedSessionsRef.current.has(selectedSession.id)) {
-      awardedSessionsRef.current.add(selectedSession.id);
-      awardXP({ activity: 'session_join' });
-    }
-  }, [awardXP, selectedSession]);
+  }, []);
 
   return {
     sessions,


### PR DESCRIPTION
## Related Issue
Closes #1403

## Description

Fixed an issue where users could receive session XP by clicking **Join Video** without successfully joining the session.

Previously, the `handleJoinVideo` function directly awarded `session_join` XP regardless of whether the user had successfully joined the session. This allowed users to earn XP without confirmed participation.

## Changes Made

- Removed XP awarding logic from `handleJoinVideo`
- Awarded `session_join` XP only after a successful `join_session` operation
- Ensured XP is granted only for confirmed session participation
- Prevented users from earning XP by directly opening the video
- Preserved existing video join functionality

## Steps to Test

1. Open the Sessions page
2. Select a session
3. Click **Join Video** without clicking **Join Session**
4. Verify no XP is awarded
5. Click **Join Session**
6. Verify the session join succeeds
7. Verify XP is awarded only after the successful join
8. Confirm video joining still works as expected

## Expected Result

- Users receive XP only after successfully joining a session.
- Clicking **Join Video** alone does not award XP.
- XP accurately reflects confirmed session participation.

## Files Changed

- `src/hooks/useSessions.ts`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted session join behavior so participation rewards are granted only after a successful join confirmation.
  * Prevented rewards from being awarded just by opening the video interface, making XP tracking more accurate.

* **Chores**
  * Updated ignored files to keep local dependencies out of version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->