### PR TITLE
Fix skill search 1227

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -186,7 +186,7 @@ export const getSupabaseDiscover = async (req, res) => {
       const safeSearch = search.trim().replace(/[^a-zA-Z0-9\s-]/g, "");
       if (safeSearch) {
         const pattern = `%${safeSearch}%`;
-        query = query.or(`name.ilike."${pattern}",skills.ilike."${pattern}"`);
+        query = query.or(`name.ilike."${pattern}",skills.ov.{${safeSearch}}`);
       }
     }
 
@@ -195,7 +195,7 @@ export const getSupabaseDiscover = async (req, res) => {
       // wildcard injection via the filter query parameter.
       const safeFilter = filter.replace(/[^a-zA-Z0-9\s-]/g, "");
       if (safeFilter) {
-        query = query.ilike("skills", `%${safeFilter}%`);
+        query = query.contains("skills", [safeFilter]);
       }
     }
 

--- a/backend/tests/supabaseDiscover.test.js
+++ b/backend/tests/supabaseDiscover.test.js
@@ -224,7 +224,7 @@ describe("getSupabaseDiscover — pagination offset calculation", () => {
     await getSupabaseDiscover(req, res);
 
     expect(capturedLimit).toBe(1000);
-    
+
     // Page 2, Limit 10 means we should get elements 10 through 19 (length 10)
     expect(res.json).toHaveBeenCalled();
     const responsePayload = res.json.mock.calls[0][0];
@@ -258,5 +258,79 @@ describe("getSupabaseDiscover — pagination offset calculation", () => {
 
     // Limit is hardcoded to 1000
     expect(capturedLimit).toBe(1000);
+  });
+});
+
+// ── Regression guard for #1227 ─────────────────────────────────────────────────────
+// skills is a text[] column; ilike is a scalar operator and cannot match inside
+// array elements. These tests assert the array-aware operators are used instead.
+describe("getSupabaseDiscover — skill array search (regression for #1227)", () => {
+  it("search uses array-overlap operator 'ov' on skills, not ilike", async () => {
+    let capturedOrArg;
+    const peers = [
+      { id: "uuid-alice", name: "Alice", skills: ["Python"], interests: [], learning_goals: [], teach_subjects: [], learn_subjects: [] },
+    ];
+
+    mockSupabase.from.mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
+        error: null,
+      }),
+      limit: vi.fn().mockImplementation(() => ({
+        or: vi.fn().mockImplementation((arg) => {
+          capturedOrArg = arg;
+          return { then: (resolve) => resolve({ data: peers, error: null }) };
+        }),
+        then: (resolve) => resolve({ data: peers, error: null }),
+      })),
+    }));
+
+    const req = { user: { id: CURRENT_USER_ID }, query: { search: "Python" } };
+    const res = createRes();
+
+    await getSupabaseDiscover(req, res);
+
+    expect(capturedOrArg).toContain("skills.ov.");
+    expect(capturedOrArg).not.toContain("skills.ilike");
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.recommendations.map((p) => p.id)).toContain("uuid-alice");
+  });
+
+  it("filter chip uses .contains() on skills, not ilike", async () => {
+    let containsArgs;
+    const peers = [
+      { id: "uuid-alice", name: "Alice", skills: ["Python"], interests: [], learning_goals: [], teach_subjects: [], learn_subjects: [] },
+    ];
+
+    mockSupabase.from.mockImplementation(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
+        error: null,
+      }),
+      limit: vi.fn().mockImplementation(() => ({
+        contains: vi.fn().mockImplementation((col, val) => {
+          containsArgs = [col, val];
+          return { then: (resolve) => resolve({ data: peers, error: null }) };
+        }),
+        then: (resolve) => resolve({ data: peers, error: null }),
+      })),
+    }));
+
+    const req = { user: { id: CURRENT_USER_ID }, query: { filter: "Python" } };
+    const res = createRes();
+
+    await getSupabaseDiscover(req, res);
+
+    expect(containsArgs).toEqual(["skills", ["Python"]]);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.recommendations.map((p) => p.id)).toContain("uuid-alice");
   });
 });


### PR DESCRIPTION
## Overview
Fixed the peer discovery skill search, which silently returned zero skill-based matches because the query used a scalar `ilike` filter on an array column.

### Description
- `backend/controllers/matchController.js`
- `backend/tests/supabaseDiscover.test.js`

### Core Motivation
`profiles.skills` is a Postgres `text[]` array column, but `getSupabaseDiscover` applied PostgREST's `ilike` operator to it — a scalar string operator that cannot match inside array elements. This meant the `OR` search clause silently degraded to a name-only search, and the filter-chip query never matched on skills at all. No error was thrown or logged, so the bug was invisible until a user searched by skill and got zero (or coincidental) results.

### Proposed Changes
1. Replaced the `skills.ilike."${pattern}"` clause in the general search `OR` query with `skills.ov.{${safeSearch}}`, PostgREST's array-overlap operator, so free-text search now correctly matches skills inside the array.
2. Replaced `query.ilike("skills", ...)` in the filter-chip query with `query.contains("skills", [safeFilter])`, the correct array-containment check for exact skill matches.
3. Added two regression tests to `supabaseDiscover.test.js` asserting the query builder is called with the array operators (`ov` / `contains`) instead of `ilike`, and that a peer whose `skills` array contains the searched/filtered term is returned.

### Related Issue
Closes #1227

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update (fixes or additions to docs)
- [ ] UI/UX improvement (changes to styling, templates, or frontend)
- [ ] Testing & Infrastructure (workflows, test scripts)

## How Has This Been Tested?
- [x] Checked changes locally
- [x] Ran project test scripts

Ran `npx vitest run backend/tests/supabaseDiscover.test.js` — all 12 tests pass, including the 2 new regression tests confirming the array operators are used and that a user with a matching skill in their `skills` array is correctly returned.

## Screenshots (if applicable)
N/A — backend query logic change, verified via automated tests.

## Checklist
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill-based search and filtering so results match array-based skill data more accurately in discovery.
  * Fixed filter chips to return the expected peers when filtering by a skill.

* **Tests**
  * Added regression coverage for skill search and filter behavior.
  * Updated pagination-related test setup to keep discovery checks reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->