### PR TITLE
Fix: Global WebSocket Broadcast Leak in Sessions (#593)

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -114,7 +114,7 @@ export function useSessions(user: any) {
     channelRef.current = roomChannel;
 
     roomChannel
-      .on("postgres_changes", { event: "INSERT", schema: "public", table: "messages" }, (payload: any) => {
+      .on("postgres_changes", { event: "INSERT", schema: "public", table: "messages", filter: `session_id=eq.${selectedSession.id}` }, (payload: any) => {
         if (payload.new.session_id === selectedSession.id) {
           setMessages((prev) => [...prev, payload.new]);
         }

--- a/src/pages/Contact.test.tsx
+++ b/src/pages/Contact.test.tsx
@@ -29,7 +29,7 @@ describe("Contact", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    localStorage.clear();
+    localStorage?.clear();
 
     (useToast as any).mockReturnValue({ toast });
     (supabase.from as any).mockReturnValue({ insert });


### PR DESCRIPTION
Fixes #593

### Description
Added a server-side filter to the postgres_changes listener in useSessions.ts for the messages table. This ensures the client only receives payloads for the specific session they joined, rather than receiving a global broadcast of all messages across the entire platform.

Also fixed a test failure in Contact.test.tsx related to an undefined localStorage in the test environment.
