### PR TITLE
Fix: Milestone overdue notifications ignored by upsert conflict rules (#954)

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -267,12 +267,13 @@ export const sendMentorshipCheckinReminders = async (req, res, next) => {
       
       const isOverdue = new Date(m.due_date) < now;
       const title = isOverdue ? "Milestone Overdue" : "Milestone Due Soon";
+      const type = isOverdue ? "mentorship_reminder_overdue" : "mentorship_reminder";
       const body = `The milestone "${m.title}" for goal "${path.goal}" is ${isOverdue ? 'overdue' : 'due soon'}. Check in with your mentor/mentee!`;
 
       // Notify mentor
       notifications.push({
         user_id: path.mentor_id,
-        type: "mentorship_reminder",
+        type,
         title,
         body,
         entity_id: m.id,
@@ -282,7 +283,7 @@ export const sendMentorshipCheckinReminders = async (req, res, next) => {
       // Notify mentee
       notifications.push({
         user_id: path.mentee_id,
-        type: "mentorship_reminder",
+        type,
         title,
         body,
         entity_id: m.id,

--- a/supabase/migrations/20260703000000_add_overdue_notification_type.sql
+++ b/supabase/migrations/20260703000000_add_overdue_notification_type.sql
@@ -1,0 +1,2 @@
+ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'mentorship_reminder';
+ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'mentorship_reminder_overdue';


### PR DESCRIPTION
Fixes #954

### Description
Fixed an issue where overdue milestone notifications were not being created due to an upsert conflict. The cron job now assigns a distinct 'type' (\mentorship_reminder_overdue\) to overdue notifications, ensuring they no longer conflict with previously sent 'Due Soon' notifications (\mentorship_reminder\).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications for mentorship check-ins now distinguish overdue reminders from upcoming ones.
  * Users will see a more accurate reminder type when a milestone has passed, while the message content stays the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->