### PR TITLE
test: add end-to-end coverage proving /api/chat requires authentication

### DIFF
--- a/backend/tests/chatRoute.auth.integration.test.js
+++ b/backend/tests/chatRoute.auth.integration.test.js
@@ -1,0 +1,123 @@
+import crypto from "crypto";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Regression coverage for #1526: POST /api/chat previously had no
+// integration test proving requireAuth actually gates the route before a
+// request reaches OpenRouter. requireAuth itself is already unit-tested in
+// isolation (requireAuth.test.js), but nothing exercised the real Express
+// app to confirm chatRoutes.js wires it in correctly.
+
+const JWT_SECRET = "chat-auth-route-test-secret";
+
+const base64UrlEncode = (value) =>
+  Buffer.from(JSON.stringify(value))
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+const createLocalJwt = (payload, secret = JWT_SECRET) => {
+  const header = base64UrlEncode({ alg: "HS256", typ: "JWT" });
+  const body = base64UrlEncode(payload);
+  const signature = crypto
+    .createHmac("sha256", secret)
+    .update(`${header}.${body}`)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=/g, "");
+
+  return `${header}.${body}.${signature}`;
+};
+
+let mockCreateCompletion;
+
+vi.mock("openai", () => ({
+  default: class {
+    constructor() {
+      this.chat = {
+        completions: {
+          create: (...args) => mockCreateCompletion(...args),
+        },
+      };
+    }
+  },
+}));
+
+describe("POST /api/chat — authentication is enforced (#1526)", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SUPABASE_JWT_SECRET", JWT_SECRET);
+    mockCreateCompletion = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "mock reply" } }],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("rejects unauthenticated requests before reaching OpenRouter", async () => {
+    const { default: app } = await import("../app.js");
+
+    const response = await request(app)
+      .post("/api/chat")
+      .send({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(response.status).toBe(401);
+    expect(mockCreateCompletion).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests with an invalid or forged token", async () => {
+    const { default: app } = await import("../app.js");
+
+    const response = await request(app)
+      .post("/api/chat")
+      .set("Authorization", "Bearer not-a-real-jwt")
+      .send({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(response.status).toBe(401);
+    expect(mockCreateCompletion).not.toHaveBeenCalled();
+  });
+
+  it("rejects a token signed with the wrong secret", async () => {
+    const { default: app } = await import("../app.js");
+    const token = createLocalJwt(
+      {
+        sub: "chat-auth-user-1",
+        email: "attacker@example.com",
+        exp: Math.floor(Date.now() / 1000) + 60,
+        role: "authenticated",
+      },
+      "wrong-secret",
+    );
+
+    const response = await request(app)
+      .post("/api/chat")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(response.status).toBe(401);
+    expect(mockCreateCompletion).not.toHaveBeenCalled();
+  });
+
+  it("serves an authenticated request with a validly signed token", async () => {
+    const { default: app } = await import("../app.js");
+    const token = createLocalJwt({
+      sub: "chat-auth-user-2",
+      email: "learner@example.com",
+      exp: Math.floor(Date.now() / 1000) + 60,
+      role: "authenticated",
+    });
+
+    const response = await request(app)
+      .post("/api/chat")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ messages: [{ role: "user", content: "hello" }] });
+
+    expect(response.status).toBe(200);
+    expect(response.body.reply).toBe("mock reply");
+    expect(mockCreateCompletion).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1526

## Context

I investigated this issue and found `/api/chat` already requires authentication — `requireAuth` is applied ahead of the handler in `backend/routers/chatRoutes.js`, and it correctly verifies the Supabase JWT (local HMAC verification, rejecting missing/invalid/expired tokens with 401). There's no live bypass matching the issue as filed today.

What *was* missing: `requireAuth` had unit tests in isolation (`requireAuth.test.js`) but nothing exercised the actual `POST /api/chat` route end-to-end to prove the real Express app wires the middleware in correctly.

## Changes

- `backend/tests/chatRoute.auth.integration.test.js`: hits the real app via supertest, covering:
  - no `Authorization` header -> 401, OpenRouter never called
  - malformed token -> 401
  - validly-formed but wrongly-signed token -> 401
  - correctly-signed token -> 200, OpenRouter called once

This locks in the fix as a regression guard: a future refactor that accidentally drops `requireAuth` from the middleware chain will fail this test instead of silently reopening the vulnerability.

## Testing

- `npx vitest run backend/tests/chatRoute.auth.integration.test.js` — 4/4 pass
- `npx vitest run` (full suite) — no new failures; 1 pre-existing unrelated failure in `Contact.test.tsx` present identically on `main`
- `npm run lint` — 0 errors