### PR TITLE
feat: add secure-by-default private storage helpers

### DIFF
--- a/backend/tests/privateStorage.test.js
+++ b/backend/tests/privateStorage.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { HttpError } from "../utils/httpError.js";
+
+const mockGetBucket = vi.fn();
+const mockCreateBucket = vi.fn();
+const mockCreateSignedUrl = vi.fn();
+const mockFrom = vi.fn(() => ({ createSignedUrl: mockCreateSignedUrl }));
+
+vi.mock("../utils/supabase.js", () => ({
+  getSupabaseAdmin: () => ({
+    storage: {
+      getBucket: mockGetBucket,
+      createBucket: mockCreateBucket,
+      from: mockFrom,
+    },
+  }),
+}));
+
+const { ensurePrivateBucket, getSignedFileUrl } = await import("../utils/privateStorage.js");
+
+describe("ensurePrivateBucket (#1529)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a new bucket with public:false when it does not exist", async () => {
+    mockGetBucket.mockResolvedValue({
+      data: null,
+      error: { message: "Bucket not found" },
+    });
+    mockCreateBucket.mockResolvedValue({
+      data: { name: "session-replays" },
+      error: null,
+    });
+
+    await ensurePrivateBucket("session-replays");
+
+    expect(mockCreateBucket).toHaveBeenCalledWith("session-replays", { public: false });
+  });
+
+  it("is a no-op when the bucket already exists and is private", async () => {
+    mockGetBucket.mockResolvedValue({
+      data: { name: "session-replays", public: false },
+      error: null,
+    });
+
+    const result = await ensurePrivateBucket("session-replays");
+
+    expect(mockCreateBucket).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ public: false });
+  });
+
+  it("warns but does not throw when an existing bucket is unexpectedly public", async () => {
+    mockGetBucket.mockResolvedValue({
+      data: { name: "legacy-bucket", public: true },
+      error: null,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(ensurePrivateBucket("legacy-bucket")).resolves.toBeDefined();
+    expect(mockCreateBucket).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("PUBLIC"));
+
+    warnSpy.mockRestore();
+  });
+
+  it("throws an HttpError if bucket creation fails", async () => {
+    mockGetBucket.mockResolvedValue({
+      data: null,
+      error: { message: "Bucket not found" },
+    });
+    mockCreateBucket.mockResolvedValue({
+      data: null,
+      error: { message: "storage quota exceeded" },
+    });
+
+    await expect(ensurePrivateBucket("session-replays")).rejects.toThrow(HttpError);
+  });
+
+  it("rejects a missing bucket name", async () => {
+    await expect(ensurePrivateBucket()).rejects.toThrow(HttpError);
+  });
+});
+
+describe("getSignedFileUrl (#1529)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a signed URL scoped to the requested bucket and path", async () => {
+    mockCreateSignedUrl.mockResolvedValue({
+      data: { signedUrl: "https://project.supabase.co/storage/v1/object/sign/session-replays/abc?token=xyz" },
+      error: null,
+    });
+
+    const url = await getSignedFileUrl("session-replays", "abc.webm", 1800);
+
+    expect(mockFrom).toHaveBeenCalledWith("session-replays");
+    expect(mockCreateSignedUrl).toHaveBeenCalledWith("abc.webm", 1800);
+    expect(url).toContain("token=xyz");
+  });
+
+  it("defaults to a 1 hour expiry when none is given", async () => {
+    mockCreateSignedUrl.mockResolvedValue({
+      data: { signedUrl: "https://example.com/signed" },
+      error: null,
+    });
+
+    await getSignedFileUrl("session-replays", "abc.webm");
+
+    expect(mockCreateSignedUrl).toHaveBeenCalledWith("abc.webm", 3600);
+  });
+
+  it("throws an HttpError when Supabase fails to sign the URL", async () => {
+    mockCreateSignedUrl.mockResolvedValue({
+      data: null,
+      error: { message: "Object not found" },
+    });
+
+    await expect(getSignedFileUrl("session-replays", "missing.webm")).rejects.toThrow(HttpError);
+  });
+
+  it("rejects a missing bucket name or file path", async () => {
+    await expect(getSignedFileUrl("", "abc.webm")).rejects.toThrow(HttpError);
+    await expect(getSignedFileUrl("session-replays", "")).rejects.toThrow(HttpError);
+  });
+});

--- a/backend/utils/privateStorage.js
+++ b/backend/utils/privateStorage.js
@@ -1,0 +1,84 @@
+import { getSupabaseAdmin } from "./supabase.js";
+import { HttpError } from "./httpError.js";
+
+/**
+ * Secure-by-default helpers for Supabase Storage buckets that must never be
+ * publicly readable (session replay recordings, private attachments, etc).
+ *
+ * Context (#1529): new Supabase Storage buckets default to public unless
+ * explicitly created with `public: false`, and this repo has no feature
+ * that stores session replay recordings yet. This module exists so that
+ * whenever that feature is built, it starts from a private-by-default,
+ * signed-URL access pattern instead of relying on a developer remembering
+ * to pass the right flag at bucket-creation time.
+ */
+
+const DEFAULT_SIGNED_URL_TTL_SECONDS = 3600;
+
+/**
+ * Ensures a Storage bucket exists and is private. Safe to call on every
+ * startup / request — no-ops if the bucket already exists.
+ *
+ * Does NOT flip an existing public bucket to private (that requires an
+ * explicit, deliberate migration since it can break already-issued public
+ * links); it only guarantees buckets it creates are private from the start.
+ */
+export async function ensurePrivateBucket(bucketName) {
+  if (!bucketName || typeof bucketName !== "string") {
+    throw new HttpError(500, "ensurePrivateBucket requires a bucket name");
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+
+  const { data: existing, error: listError } = await supabaseAdmin.storage.getBucket(bucketName);
+
+  if (listError && listError.message && !/not found/i.test(listError.message)) {
+    throw new HttpError(500, `Failed to check storage bucket "${bucketName}"`);
+  }
+
+  if (existing) {
+    if (existing.public) {
+      console.warn(
+        `[security] Storage bucket "${bucketName}" already exists and is PUBLIC. ` +
+          "ensurePrivateBucket will not flip it automatically; migrate it deliberately."
+      );
+    }
+    return existing;
+  }
+
+  const { data, error } = await supabaseAdmin.storage.createBucket(bucketName, {
+    public: false,
+  });
+
+  if (error) {
+    throw new HttpError(500, `Failed to create private storage bucket "${bucketName}"`);
+  }
+
+  return data;
+}
+
+/**
+ * Returns a time-limited signed URL for a private object. Throws HttpError
+ * if the object cannot be signed (missing, bucket misconfigured, etc.).
+ */
+export async function getSignedFileUrl(
+  bucketName,
+  filePath,
+  expiresInSeconds = DEFAULT_SIGNED_URL_TTL_SECONDS
+) {
+  if (!bucketName || !filePath) {
+    throw new HttpError(500, "getSignedFileUrl requires a bucket name and file path");
+  }
+
+  const supabaseAdmin = getSupabaseAdmin();
+
+  const { data, error } = await supabaseAdmin.storage
+    .from(bucketName)
+    .createSignedUrl(filePath, expiresInSeconds);
+
+  if (error || !data?.signedUrl) {
+    throw new HttpError(500, `Failed to generate signed URL for "${filePath}"`);
+  }
+
+  return data.signedUrl;
+}


### PR DESCRIPTION
## Summary

Fixes #1529

## Context

I investigated this issue and found that this repo doesn't currently implement session replay recordings at all — there's no bucket, upload path, or feature anywhere in `src` or `backend` matching what's described. The issue is filed against a feature that doesn't exist yet.

Its underlying concern is legitimate though: Supabase Storage buckets default to public unless explicitly created with `public: false`, so whenever a recording (or any other private-file) feature is built here, it's one missed flag away from being world-readable — exactly the failure mode the issue describes.

## Changes

- `backend/utils/privateStorage.js`:
  - `ensurePrivateBucket(name)`: idempotently creates a bucket with `public: false`. If a bucket of that name already exists and is public, it warns rather than silently flipping it — changing visibility on an existing bucket can break already-issued public links and should be a deliberate migration, not an automatic side effect.
  - `getSignedFileUrl(bucket, path, expiresInSeconds)`: wraps `storage.from(bucket).createSignedUrl(...)` with input validation and a normalized `HttpError` on failure.

Neither function is wired into a route yet, since there's no replay feature to attach them to. This is the secure foundation described in the issue's own proposed fix (private bucket + signed URLs), ready for whoever builds session replay recording to use from day one instead of hitting the Supabase default-public trap.

## Testing

- `npx vitest run backend/tests/privateStorage.test.js` — 9/9 pass
- `npx vitest run` (full suite) — no new failures; 1 pre-existing unrelated failure in `Contact.test.tsx` present identically on `main`
- `npm run lint` — 0 errors