### PR TITLE
fix(whiteboard): enforce ownership on undo/clear and fix undo broadcast storm

### DIFF
--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -25,6 +25,8 @@ export default function Canvas({ roomId }: Props) {
 
   const { user } = useAuth();
 
+  const [hostId, setHostId] = useState<string | null>(null);
+
   const [tool, setTool] = useState<ToolType>("pen");
 
   const [color, setColor] = useState("#ffffff");
@@ -138,17 +140,22 @@ export default function Canvas({ roomId }: Props) {
   };
 
   const pushEvent = (event: WhiteboardEvent) => {
-    strokesRef.current.push(event);
+    const ownedEvent: WhiteboardEvent = {
+      ...event,
+      user_id: user?.id,
+    };
+
+    strokesRef.current.push(ownedEvent);
 
     const ctx = getContext();
 
     if (!ctx) return;
 
-    drawEvent(ctx, event);
+    drawEvent(ctx, ownedEvent);
 
-    broadcastEvent(event);
+    broadcastEvent(ownedEvent);
 
-    persistEvent(event);
+    persistEvent(ownedEvent);
   };
 
   useEffect(() => {
@@ -163,6 +170,16 @@ export default function Canvas({ roomId }: Props) {
 
   useEffect(() => {
     const initializeBoard = async () => {
+      const { data: room } = await supabase
+        .from("study_rooms" as any)
+        .select("created_by")
+        .eq("id", roomId)
+        .single();
+
+      if (room) {
+        setHostId((room as any).created_by);
+      }
+
       const { data } = await supabase
         .from("whiteboard_events" as any)
         .select("*")
@@ -192,6 +209,18 @@ export default function Canvas({ roomId }: Props) {
           if (payload.senderId === user?.id) return;
 
           const event: WhiteboardEvent = payload;
+
+          if (event.type === "undo") {
+            strokesRef.current = strokesRef.current.filter(
+              (stroke) =>
+                stroke.payload?.strokeId !==
+                event.payload?.strokeId
+            );
+
+            replayCanvas();
+
+            return;
+          }
 
           strokesRef.current.push(event);
 
@@ -297,6 +326,8 @@ export default function Canvas({ roomId }: Props) {
   let lastStrokeId: string | undefined;
 
   for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].user_id !== user?.id) continue;
+
     const strokeId =
       events[i].payload?.strokeId;
 
@@ -322,22 +353,23 @@ export default function Canvas({ roomId }: Props) {
     .from("whiteboard_events" as any)
     .delete()
     .eq("room_id", roomId)
+    .eq("user_id", user?.id)
     .eq(
       "payload->>strokeId",
       lastStrokeId
     );
 
   broadcastEvent({
-    type: "clear",
-    payload: {},
+    type: "undo",
+    payload: {
+      strokeId: lastStrokeId,
+    },
   });
-
-  for (const event of updated) {
-    broadcastEvent(event);
-  }
 };
 
   const clearBoard = async () => {
+  if (user?.id !== hostId) return;
+
   const ctx = getContext();
 
   if (!ctx) return;
@@ -406,12 +438,14 @@ export default function Canvas({ roomId }: Props) {
     Undo
   </button>
 
-  <button
-    onClick={clearBoard}
-    className="px-3 py-1 rounded text-sm bg-red-600 text-white hover:bg-red-700"
-  >
-    Clear
-  </button>
+  {user?.id === hostId && (
+    <button
+      onClick={clearBoard}
+      className="px-3 py-1 rounded text-sm bg-red-600 text-white hover:bg-red-700"
+    >
+      Clear
+    </button>
+  )}
 </div>
       </div>
 

--- a/src/components/Whiteboard/types.ts
+++ b/src/components/Whiteboard/types.ts
@@ -6,7 +6,8 @@ export type WhiteboardEventType =
   | "draw-start"
   | "draw-move"
   | "draw-end"
-  | "clear";
+  | "clear"
+  | "undo";
 
 export type Point = {
   x: number;


### PR DESCRIPTION
Closes #1226

The whiteboard let any room participant delete other people's drawings, and Undo flooded the Realtime channel.

Changes in `Canvas.tsx`:

- Undo now only targets the current user's own strokes. The loop skips events where `user_id` isn't the current user, and the delete query gets `.eq("user_id", user?.id)`. Local events are tagged with `user_id` in `pushEvent` so ownership is checkable.
- Clear is now host-only. The board fetches `created_by` from `study_rooms` on init, the Clear button is hidden for non-hosts, and `clearBoard` early-returns if `user?.id !== hostId`.
- Undo no longer replays the whole board. It broadcasts a single `{ type: "undo", payload: { strokeId } }` event; remote clients filter their local strokes by `strokeId` and replay once, instead of receiving N+1 messages per click.

Added an `"undo"` variant to `WhiteboardEventType`.

Tested locally with lint and tsc, both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added undo support for whiteboard strokes.
  * Whiteboard actions now preserve stroke ownership for more reliable collaboration.

* **Bug Fixes**
  * Clear is now available only to the room host.
  * Undo now applies only to the current user’s own strokes.
  * Undo events are handled correctly during live updates, keeping the canvas in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->