### PR TITLE
fix(#1456): add connect action to learner recommendations

### DIFF
--- a/src/components/recommendations/RecommendedPartners.tsx
+++ b/src/components/recommendations/RecommendedPartners.tsx
@@ -1,7 +1,9 @@
-import { Users } from "lucide-react";
+import { Check, Clock, Loader2, UserPlus, Users } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { useState } from "react";
 
 type Partner = {
   _id: string;
@@ -13,11 +15,77 @@ type Partner = {
 
 type RecommendedPartnersProps = {
   partners: Partner[];
+  connectionStatuses?: Record<string, "pending" | "accepted" | "rejected">;
+  onConnect?: (partnerId: string) => Promise<void>;
 };
 
 const RecommendedPartners = ({
   partners,
+  connectionStatuses = {},
+  onConnect,
 }: RecommendedPartnersProps) => {
+  const [loadingPartnerIds, setLoadingPartnerIds] = useState<Set<string>>(
+    new Set()
+  );
+
+  const handleConnect = async (partnerId: string) => {
+    if (!onConnect || loadingPartnerIds.has(partnerId)) return;
+
+    setLoadingPartnerIds((prev) => new Set(prev).add(partnerId));
+    try {
+      await onConnect(partnerId);
+    } finally {
+      setLoadingPartnerIds((prev) => {
+        const next = new Set(prev);
+        next.delete(partnerId);
+        return next;
+      });
+    }
+  };
+
+  const getButtonState = (partnerId: string) => {
+    const isLoading = loadingPartnerIds.has(partnerId);
+    const status = connectionStatuses[partnerId];
+
+    if (isLoading) {
+      return {
+        disabled: true,
+        icon: <Loader2 className="h-4 w-4 animate-spin" />,
+        label: "Connecting",
+      };
+    }
+
+    if (status === "accepted") {
+      return {
+        disabled: true,
+        icon: <Check className="h-4 w-4" />,
+        label: "Connected",
+      };
+    }
+
+    if (status === "pending") {
+      return {
+        disabled: true,
+        icon: <Clock className="h-4 w-4" />,
+        label: "Pending",
+      };
+    }
+
+    if (status === "rejected") {
+      return {
+        disabled: true,
+        icon: <Clock className="h-4 w-4" />,
+        label: "Unavailable",
+      };
+    }
+
+    return {
+      disabled: !onConnect,
+      icon: <UserPlus className="h-4 w-4" />,
+      label: "Connect",
+    };
+  };
+
   return (
     <Card className="border-white/10 bg-white/5">
       <CardHeader>
@@ -29,42 +97,56 @@ const RecommendedPartners = ({
 
       <CardContent className="space-y-4">
         {partners.length > 0 ? (
-          partners.map((partner) => (
-            <div
-              key={partner._id}
-              className="rounded-2xl border border-white/10 bg-slate-950/40 p-4"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="space-y-3">
-                  <div>
-                    <h3 className="font-semibold text-white">
-                      {partner.name}
-                    </h3>
+          partners.map((partner) => {
+            const buttonState = getButtonState(partner._id);
 
-                    <p className="mt-1 text-sm text-slate-300">
-                      {partner.reason}
-                    </p>
+            return (
+              <div
+                key={partner._id}
+                className="rounded-2xl border border-white/10 bg-slate-950/40 p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="space-y-3">
+                    <div>
+                      <h3 className="font-semibold text-white">
+                        {partner.name}
+                      </h3>
+
+                      <p className="mt-1 text-sm text-slate-300">
+                        {partner.reason}
+                      </p>
+                    </div>
+
+                    <div className="flex flex-wrap gap-2">
+                      {partner.skills.slice(0, 4).map((skill) => (
+                        <Badge
+                          key={skill}
+                          variant="outline"
+                          className="border-cyan-400/20 bg-cyan-400/10 text-cyan-200"
+                        >
+                          {skill}
+                        </Badge>
+                      ))}
+                    </div>
                   </div>
 
-                  <div className="flex flex-wrap gap-2">
-                    {partner.skills.slice(0, 4).map((skill) => (
-                      <Badge
-                        key={skill}
-                        variant="outline"
-                        className="border-cyan-400/20 bg-cyan-400/10 text-cyan-200"
-                      >
-                        {skill}
-                      </Badge>
-                    ))}
-                  </div>
+                  <Badge className="shrink-0 bg-cyan-400/10 text-cyan-200">
+                    {partner.compatibilityScore}% Match
+                  </Badge>
                 </div>
 
-                <Badge className="bg-cyan-400/10 text-cyan-200">
-                  {partner.compatibilityScore}% Match
-                </Badge>
+                <Button
+                  type="button"
+                  onClick={() => handleConnect(partner._id)}
+                  disabled={buttonState.disabled}
+                  className="mt-4 w-full rounded-2xl bg-gradient-to-r from-cyan-400 to-blue-500 font-semibold text-slate-950 hover:from-cyan-300 hover:to-blue-400 disabled:cursor-not-allowed disabled:bg-none disabled:bg-white/10 disabled:text-slate-400"
+                >
+                  {buttonState.icon}
+                  {buttonState.label}
+                </Button>
               </div>
-            </div>
-          ))
+            );
+          })
         ) : (
           <p className="rounded-2xl border border-dashed border-white/10 px-4 py-8 text-sm text-slate-400">
             No learning partner recommendations available yet.

--- a/src/pages/LearnerDashboard.tsx
+++ b/src/pages/LearnerDashboard.tsx
@@ -49,6 +49,8 @@ const LearnerDashboard = () => {
       return;
     }
 
+    setConnectionStatuses({});
+
     let isMounted = true;
 
     const fetchConnections = async () => {
@@ -155,10 +157,30 @@ const LearnerDashboard = () => {
 
       if (insertError) {
         if (insertError.code === "23505") {
-          setConnectionStatuses((prev) => ({
-            ...prev,
-            [partnerId]: "pending",
-          }));
+          const { data: duplicateConnections, error: duplicateLookupError } =
+            await (supabase as any)
+              .from("peer_connections")
+              .select("status")
+              .or(
+                `and(sender_id.eq.${user.id},receiver_id.eq.${partnerId}),and(sender_id.eq.${partnerId},receiver_id.eq.${user.id})`
+              )
+              .limit(1);
+
+          if (duplicateLookupError) {
+            console.error(
+              "Failed to fetch duplicate peer connection:",
+              duplicateLookupError
+            );
+          } else {
+            const duplicateConnection = duplicateConnections?.[0];
+            if (duplicateConnection?.status) {
+              setConnectionStatuses((prev) => ({
+                ...prev,
+                [partnerId]: duplicateConnection.status,
+              }));
+            }
+          }
+
           toast.info("A connection request already exists.");
           return;
         }

--- a/src/pages/LearnerDashboard.tsx
+++ b/src/pages/LearnerDashboard.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useState } from "react";
 import { useRole } from "@/contexts/RoleContext";
 import { useAuth } from "@/contexts/useAuth";
 import { useQuery } from "@tanstack/react-query";
@@ -6,6 +7,8 @@ import { Link } from "react-router-dom";
 import { Bot, Sparkles } from "lucide-react";
 import RecommendedPartners from "@/components/recommendations/RecommendedPartners";
 import { MentorshipMilestones } from "@/components/mentorship/MentorshipMilestones";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
 
 // Dashboard Widgets
 import StreakXPWidget from "@/components/dashboard/StreakXPWidget";
@@ -16,9 +19,15 @@ import SolvedDoubtsWidget from "@/components/dashboard/SolvedDoubtsWidget";
 import LearningProgress from "@/components/dashboard/LearningProgress";
 import RecentActivity from "@/components/dashboard/RecentActivity";
 
+type ConnectionStatus = "pending" | "accepted" | "rejected";
+
 const LearnerDashboard = () => {
   const { user } = useAuth();
   const { currentMode } = useRole();
+  const [connectionStatuses, setConnectionStatuses] = useState<
+    Record<string, ConnectionStatus>
+  >({});
+
   const { data: partners = [], isLoading: loadingPartners } = useQuery({
     queryKey: ["recommended-partners"],
     queryFn: async () => {
@@ -33,6 +42,140 @@ const LearnerDashboard = () => {
       return data.recommendations || [];
     },
   });
+
+  useEffect(() => {
+    if (!user?.id) {
+      setConnectionStatuses({});
+      return;
+    }
+
+    let isMounted = true;
+
+    const fetchConnections = async () => {
+      const { data, error } = await (supabase as any)
+        .from("peer_connections")
+        .select("sender_id, receiver_id, status")
+        .or(`sender_id.eq.${user.id},receiver_id.eq.${user.id}`);
+
+      if (!isMounted) return;
+
+      if (error) {
+        console.error("Failed to fetch peer connections:", error);
+        toast.error("Could not load your connection states.");
+        return;
+      }
+
+      const nextStatuses = (data || []).reduce(
+        (
+          statuses: Record<string, ConnectionStatus>,
+          connection: {
+            sender_id: string;
+            receiver_id: string;
+            status: ConnectionStatus;
+          }
+        ) => {
+          const peerId =
+            connection.sender_id === user.id
+              ? connection.receiver_id
+              : connection.sender_id;
+          statuses[peerId] = connection.status;
+          return statuses;
+        },
+        {}
+      );
+
+      setConnectionStatuses(nextStatuses);
+    };
+
+    fetchConnections();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [user?.id]);
+
+  const handleConnectPartner = useCallback(
+    async (partnerId: string) => {
+      if (!user?.id) {
+        toast.error("Please sign in to connect with learning partners.");
+        return;
+      }
+
+      if (partnerId === user.id) {
+        toast.error("You cannot connect with yourself.");
+        return;
+      }
+
+      if (connectionStatuses[partnerId]) {
+        toast.info(
+          connectionStatuses[partnerId] === "accepted"
+            ? "You are already connected with this learner."
+            : "A connection request already exists."
+        );
+        return;
+      }
+
+      const { data: existingConnections, error: lookupError } = await (
+        supabase as any
+      )
+        .from("peer_connections")
+        .select("sender_id, receiver_id, status")
+        .or(
+          `and(sender_id.eq.${user.id},receiver_id.eq.${partnerId}),and(sender_id.eq.${partnerId},receiver_id.eq.${user.id})`
+        )
+        .limit(1);
+
+      if (lookupError) {
+        console.error("Failed to check peer connection:", lookupError);
+        toast.error("Could not check this connection. Please try again.");
+        return;
+      }
+
+      const existingConnection = existingConnections?.[0];
+      if (existingConnection) {
+        setConnectionStatuses((prev) => ({
+          ...prev,
+          [partnerId]: existingConnection.status,
+        }));
+        toast.info(
+          existingConnection.status === "accepted"
+            ? "You are already connected with this learner."
+            : "A connection request already exists."
+        );
+        return;
+      }
+
+      const { error: insertError } = await (supabase as any)
+        .from("peer_connections")
+        .insert({
+          sender_id: user.id,
+          receiver_id: partnerId,
+          status: "pending",
+        });
+
+      if (insertError) {
+        if (insertError.code === "23505") {
+          setConnectionStatuses((prev) => ({
+            ...prev,
+            [partnerId]: "pending",
+          }));
+          toast.info("A connection request already exists.");
+          return;
+        }
+
+        console.error("Failed to send peer connection request:", insertError);
+        toast.error("Failed to send connection request. Please try again.");
+        return;
+      }
+
+      setConnectionStatuses((prev) => ({
+        ...prev,
+        [partnerId]: "pending",
+      }));
+      toast.success("Connection request sent.");
+    },
+    [connectionStatuses, user?.id]
+  );
 
   const displayName =
     user?.user_metadata?.name ||
@@ -113,7 +256,11 @@ const LearnerDashboard = () => {
                   <div className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-cyan-500"></div>
                 </div>
               ) : (
-                <RecommendedPartners partners={partners} />
+                <RecommendedPartners
+                  partners={partners}
+                  connectionStatuses={connectionStatuses}
+                  onConnect={handleConnectPartner}
+                />
               )}
             </section>
           </div>


### PR DESCRIPTION
## Description
Added actionable connection controls to learner dashboard recommended partner cards.

## Related Issue
Fixes #1456

## Changes Made
- Added Connect button states for recommended partners.
- Shows Pending, Connected, or Unavailable where appropriate.
- Prevents self-connections and duplicate connection requests.
- Reuses the existing `peer_connections` flow.
- Added toast feedback for success and error states.

## Testing
- `npm run lint` passed with existing warnings only.
- Targeted ESLint passed clean.
- `npm run typecheck` and `npm run build` are blocked by pre-existing unrelated TypeScript errors.
- `npm test` timed out after 2 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommended partners now include a direct connect action on each card.
  * Connection buttons reflect live status, such as connecting, connected, pending, or unavailable.

* **Bug Fixes**
  * Existing connection requests are recognized and shown correctly instead of creating duplicates.
  * Connection state now updates automatically after actions and when the page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->