### PR TITLE
fix(#1449): remove unused mentor file input

### DIFF
--- a/src/components/mentor/MentorForm.tsx
+++ b/src/components/mentor/MentorForm.tsx
@@ -294,10 +294,6 @@ export default function MentorForm() {
               }
               className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
-            <input
-              type="file"
-              className="w-full rounded-2xl border border-white/10 bg-white/5 p-4"
-            />
           </div>
         )}
         {/* STEP 4 */}


### PR DESCRIPTION
## Description
Removes the unused file input from the mentor application Experience step because selected files were not stored, uploaded, validated, or submitted.

## Related Issue
Fixes #1449

## Changes Made
- Removed the unused `<input type="file" />` from `MentorForm.tsx`
- Kept existing mentor submission behavior unchanged

## Testing
- `npm.cmd run lint` passed with existing warnings only
- `npx.cmd eslint src\components\mentor\MentorForm.tsx` passed with one pre-existing unused eslint-disable warning
- `npm.cmd run typecheck` failed due to unrelated existing TypeScript issues
- `npm.cmd run build` failed due to unrelated existing TypeScript issues

## Notes
Untracked `dist/` and `uploads/` were left untouched.