### PR TITLE
Fix saved resource query typing

### DIFF
--- a/src/hooks/useResources.ts
+++ b/src/hooks/useResources.ts
@@ -63,12 +63,10 @@ export const useResources = (filters?: ResourceFilters) => {
           return;
         }
         
-        const { data: savedData, error: savedError } = await safeSupabaseCall(
+        const savedData = await safeSupabaseCall<SavedResource[]>(
           () => (supabase as any).from("saved_resources").select("resource_id").eq("user_id", user.id).abortSignal(controller.signal)
         );
-        
-        if (savedError) throw savedError;
-        
+
         savedResourceIds =
           (savedData as SavedResource[] | null)?.map(
             (item) => item.resource_id


### PR DESCRIPTION
## Summary
- updates `useResources` to consume the unwrapped return value from `safeSupabaseCall`
- removes the stale `savedError` branch because the helper already throws Supabase errors

## Validation
- `npm run typecheck` no longer reports the `src/hooks/useResources.ts` safeSupabaseCall errors
- typecheck still reports pre-existing failures in `src/components/docs/page.tsx` and `src/hooks/useSkillEndorsements.ts`

Fixes #1543
