### PR TITLE
Add skill endorsement Supabase types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -446,6 +446,30 @@ export type Database = {
         }
         Relationships: []
       }
+      skill_endorsements: {
+        Row: {
+          id: string
+          skill: string
+          endorsed_user_id: string
+          endorser_id: string
+          created_at: string
+        }
+        Insert: {
+          id?: string
+          skill: string
+          endorsed_user_id: string
+          endorser_id: string
+          created_at?: string
+        }
+        Update: {
+          id?: string
+          skill?: string
+          endorsed_user_id?: string
+          endorser_id?: string
+          created_at?: string
+        }
+        Relationships: []
+      }
       study_rooms: {
         Row: {
           id: string
@@ -626,7 +650,14 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      skill_endorsement_counts: {
+        Row: {
+          endorsed_user_id: string
+          skill: string
+          endorsement_count: number
+        }
+        Relationships: []
+      }
     }
     Functions: {
       award_activity_xp: {


### PR DESCRIPTION
## Problem
The repo has a migration for `public.skill_endorsements`, but `src/integrations/supabase/types.ts` does not include that table. As a result, `useSkillEndorsements` fails TypeScript checks.


## Fixes 
Adds generated Supabase table and view types for skill endorsements so the endorsement hook can typecheck against the existing migration. Validation: npm.cmd run typecheck no longer reports skill_endorsements errors on this branch; remaining failures are separate existing issues in docs/page.tsx and useResources. 

Fixes #1544
