### PR TITLE
Align resource upload type validation

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -1,6 +1,7 @@
 import multer from "multer";
 import os from "os";
 import fs from "fs";
+import path from "path";
 import { getSupabaseAdmin } from "../utils/supabase.js";
 import { HttpError } from "../utils/httpError.js";
 
@@ -21,19 +22,40 @@ const upload = multer({
     // The issue says: "Unrestricted image upload... check file.mimetype.startsWith('image/')"
     // But since uploadResource also uploads pdf, docx, etc., we should support both or define it dynamically.
     // Let's accept images and common document types since this endpoint is used for both.
-    const allowedResourceTypes = [
+    const allowedResourceTypes = new Set([
+      "application/javascript",
+      "application/octet-stream",
       "application/pdf",
+      "application/typescript",
       "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/zip",
-      "text/plain",
-      "text/markdown",
-      "text/javascript",
-      "text/x-python",
+      "application/x-javascript",
       "application/x-python-code",
-      "application/typescript"
-    ];
+      "application/x-zip-compressed",
+      "application/zip",
+      "text/javascript",
+      "text/markdown",
+      "text/plain",
+      "text/x-markdown",
+      "text/x-python",
+      "text/x-typescript",
+      "video/mp2t"
+    ]);
+    const allowedResourceExtensions = new Set([
+      ".docx",
+      ".js",
+      ".md",
+      ".pdf",
+      ".py",
+      ".ts",
+      ".txt",
+      ".zip"
+    ]);
+    const extension = path.extname(file.originalname).toLowerCase();
+    const isAllowedResource =
+      allowedResourceExtensions.has(extension) &&
+      allowedResourceTypes.has(file.mimetype);
 
-    if (file.mimetype.startsWith("image/") || allowedResourceTypes.includes(file.mimetype)) {
+    if (file.mimetype.startsWith("image/") || isAllowedResource) {
       cb(null, true);
     } else {
       cb(new HttpError(415, "Unsupported Media Type"));


### PR DESCRIPTION
## Discribtion
The resource upload UI accepts file extensions like `.js`, `.ts`, `.py`, `.md`, and `.txt` based on extension in `src/lib/uploadResource.ts` and `src/components/resources/UploadDialog.tsx`.

The backend upload middleware then validates `file.mimetype` against a small allowlist:

```js
text/javascript,
text/x-python,
application/x-python-code,
application/typescript
```

Browsers and operating systems often report these files with different MIME values, for example `application/javascript` for JavaScript or `video/mp2t` for TypeScript. Those files pass the frontend extension check but can fail backend validation with 415.


## Fixes 
Expands backend upload validation to accept the MIME values commonly reported for the resource extensions advertised by the frontend, while keeping extension checks for resource uploads. Validation: npm.cmd run lint passes with existing warnings. 

Fixes #1545