### PR TITLE
Add mentorship notification types

### DIFF
--- a/src/features/notifications/types.ts
+++ b/src/features/notifications/types.ts
@@ -1,6 +1,8 @@
 export type NotificationType =
   | "message"
   | "session_reminder"
+  | "mentorship_reminder"
+  | "mentorship_reminder_overdue"
   | "announcement"
   | "system";
 


### PR DESCRIPTION
## Problem
The database enum is extended with new notification values:

```sql
ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'mentorship_reminder';
ALTER TYPE public.notification_type ADD VALUE IF NOT EXISTS 'mentorship_reminder_overdue';
```

But the frontend type union still only allows:

```ts
export type NotificationType =
  | message
  | session_reminder
  | announcement
  | system;
```


## Fixes 
Adds mentorship reminder notification variants to the frontend notification type union so it matches the database enum and backend cron producer. Validation: npm.cmd run typecheck still fails on separate existing issues in docs/page.tsx, useResources, and skill endorsement types; this branch adds no new type errors. 

Fixes #1546