### PR TITLE
Restrict resource writes to owners

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -420,15 +420,15 @@ CREATE POLICY "Users can delete own push subscriptions"
 --------------------------------------------------------------------------------
 -- 10. RESOURCES & WHITEBOARD
 --------------------------------------------------------------------------------
--- resources (Assuming existence)
+-- resources
 CREATE POLICY "Anyone can view resources" 
   ON public.resources FOR SELECT USING (true);
 CREATE POLICY "Users can insert resources" 
-  ON public.resources FOR INSERT WITH CHECK (true);
+  ON public.resources FOR INSERT WITH CHECK (uploaded_by = auth.uid());
 CREATE POLICY "Users can update resources" 
-  ON public.resources FOR UPDATE USING (true);
+  ON public.resources FOR UPDATE USING (uploaded_by = auth.uid()) WITH CHECK (uploaded_by = auth.uid());
 CREATE POLICY "Users can delete resources" 
-  ON public.resources FOR DELETE USING (true);
+  ON public.resources FOR DELETE USING (uploaded_by = auth.uid());
 
 -- saved_resources
 CREATE POLICY "Users can view own saved resources" 


### PR DESCRIPTION
## Problem
The consolidated RLS migration redefines resource policies with unrestricted checks:

```sql
CREATE POLICY "Users can insert resources"
  ON public.resources FOR INSERT WITH CHECK (true);
CREATE POLICY "Users can update resources"
  ON public.resources FOR UPDATE USING (true);
CREATE POLICY "Users can delete resources"
  ON public.resources FOR DELETE USING (true);
```

This appears to override the earlier resource ownership model from `20260518000000_resource_hub.sql`, where inserts were tied to `auth.uid() = uploaded_by` and deletes were restricted to the uploader.


## Fixes 
Restores owner-based RLS checks for resource inserts, updates, and deletes while keeping public read access. Validation: SQL-only policy change reviewed against the existing resources ownership column used by the app. 

Fixes #1547