### PR TITLE
Restore contact message rate limit

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -487,7 +487,10 @@ CREATE POLICY "Users can insert doubts"
 CREATE POLICY "Admins can view contact messages" 
   ON public.contact_messages FOR SELECT USING (public.has_role(auth.uid(), 'admin'));
 CREATE POLICY "Anyone can insert contact messages" 
-  ON public.contact_messages FOR INSERT WITH CHECK (true);
+  ON public.contact_messages FOR INSERT WITH CHECK (
+    public.contact_recent_count(email, 10) < 3
+    AND NOT public.contact_duplicate_exists(email, message, 10)
+  );
 
 -- users table (if it exists outside auth schema)
 DO $$


### PR DESCRIPTION
## Issue Discribtion
`20260602000010_create_contact_messages.sql` creates a contact form insert policy that enforces per-email rate limiting and duplicate-message prevention through helper functions.

Later, `20260617000000_consolidate_rls_policies.sql` adds a broader policy:

```sql
CREATE POLICY "Anyone can insert contact messages"
  ON public.contact_messages FOR INSERT WITH CHECK (true);
```

Because permissive RLS policies are ORed together, the unrestricted policy allows rows that the original rate-limited policy would reject.


## Fixes: 
Updates the consolidated contact_messages insert policy to preserve the database rate limit and duplicate-message checks. Validation: SQL-only policy change matched to the existing contact_recent_count and contact_duplicate_exists helpers. 

Fixes #1549