### PR TITLE
Harden peer connection updates

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -330,7 +330,10 @@ CREATE POLICY "Users can insert peer connection requests"
   ON public.peer_connections FOR INSERT WITH CHECK (auth.uid() = sender_id);
 
 CREATE POLICY "Users can update peer connections" 
-  ON public.peer_connections FOR UPDATE USING (auth.uid() = receiver_id);
+  ON public.peer_connections FOR UPDATE USING (auth.uid() = receiver_id) WITH CHECK (
+    auth.uid() = receiver_id
+    AND status IN ('accepted', 'rejected')
+  );
 
 CREATE POLICY "Users can delete peer connections" 
   ON public.peer_connections FOR DELETE USING (auth.uid() = sender_id OR auth.uid() = receiver_id);


### PR DESCRIPTION
## Problem
Earlier migrations harden `peer_connections` so users cannot spoof connection state or mutate fields outside the intended status transition. The consolidated migration later recreates the update policy as:

```sql
CREATE POLICY "Users can update peer connections"
  ON public.peer_connections FOR UPDATE USING (auth.uid() = receiver_id);
```

There is no `WITH CHECK`, and the policy no longer constrains which columns or statuses can be changed.

## Fixes
Restores the peer_connections update WITH CHECK clause so receivers can only move requests to accepted or rejected. Validation: SQL-only policy change matched to the existing hardened peer connection migration. 

Fixes #1550