### PR TITLE
Keep push subscriptions user-owned

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -412,7 +412,7 @@ CREATE POLICY "Users can insert push subscriptions"
   ON public.push_subscriptions FOR INSERT WITH CHECK (user_id = auth.uid());
 
 CREATE POLICY "Users can update own push subscriptions" 
-  ON public.push_subscriptions FOR UPDATE USING (user_id = auth.uid());
+  ON public.push_subscriptions FOR UPDATE USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
 
 CREATE POLICY "Users can delete own push subscriptions" 
   ON public.push_subscriptions FOR DELETE USING (user_id = auth.uid());


### PR DESCRIPTION
## Discribtion:
The consolidated push subscription update policy only has a `USING` clause:

```sql
CREATE POLICY "Users can update own push subscriptions"
  ON public.push_subscriptions FOR UPDATE USING (user_id = auth.uid());
```

Without `WITH CHECK (user_id = auth.uid())`, PostgreSQL checks ownership of the old row but does not require the updated row to remain owned by the same user.

## Fixes: 
Adds a WITH CHECK clause to push subscription updates so rows cannot be reassigned to another user. Validation: SQL-only RLS change reviewed against the push_subscriptions ownership model. 

Fixes #1551