### PR TITLE
Restrict skill taxonomy inserts

### DIFF
--- a/supabase/migrations/20260617000000_consolidate_rls_policies.sql
+++ b/supabase/migrations/20260617000000_consolidate_rls_policies.sql
@@ -474,8 +474,8 @@ CREATE POLICY "Users can manage own portfolio_profiles"
 -- skills_taxonomy
 CREATE POLICY "Anyone can read skills taxonomy" 
   ON public.skills_taxonomy FOR SELECT USING (true);
-CREATE POLICY "Anyone can insert skills taxonomy" 
-  ON public.skills_taxonomy FOR INSERT WITH CHECK (true);
+CREATE POLICY "Admins can insert skills taxonomy" 
+  ON public.skills_taxonomy FOR INSERT WITH CHECK (public.has_role(auth.uid(), 'admin'));
 
 -- doubts
 CREATE POLICY "Anyone can view doubts" 


### PR DESCRIPTION
## Issue:
The consolidated RLS migration allows unrestricted inserts into `skills_taxonomy`:

```sql
CREATE POLICY "Anyone can insert skills taxonomy"
  ON public.skills_taxonomy FOR INSERT WITH CHECK (true);
```

## Fixes: 
Keeps public reads for skills taxonomy but restricts new taxonomy entries to admins. Validation: SQL-only policy change reviewed against the existing role helper. 
Fixes #1552