### PR TITLE
fix(notifications): fetch accurate unread notification count

### DIFF
--- a/src/features/notifications/useNotifications.ts
+++ b/src/features/notifications/useNotifications.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import type { Notification } from "./types";
 import { showBrowserNotification } from "./pushNotifications";
@@ -12,11 +12,27 @@ export function useNotifications(userId?: string) {
   const [loading, setLoading] = useState(false);
   const [page, setPage] = useState(0);
   const [hasMore, setHasMore] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
 
-  const unreadCount = useMemo(
-    () => notifications.filter((notification) => !notification.read).length,
-    [notifications]
-  );
+  const fetchUnreadCount = useCallback(async () => {
+    if (!userId) {
+      setUnreadCount(0);
+      return;
+    }
+
+    const { count, error } = await (supabase as any)
+      .from("notifications")
+      .select("id", { count: "exact", head: true })
+      .eq("user_id", userId)
+      .eq("read", false);
+
+    if (error) {
+      console.error("Failed to fetch unread notification count:", error);
+      return;
+    }
+
+    setUnreadCount(count || 0);
+  }, [userId]);
 
   const fetchNotifications = useCallback(
     async (nextPage = 0) => {
@@ -54,36 +70,51 @@ export function useNotifications(userId?: string) {
     [userId]
   );
 
-  const markAsRead = useCallback(async (id: string) => {
-    let previous: Notification[] = [];
+  const markAsRead = useCallback(
+    async (id: string) => {
+      let previous: Notification[] = [];
+      let wasUnread = false;
 
-    setNotifications((current) => {
-      previous = current;
-      return current.map((notification) =>
-        notification.id === id ? { ...notification, read: true } : notification
-      );
-    });
+      setNotifications((current) => {
+        previous = current;
+        const target = current.find((notification) => notification.id === id);
+        wasUnread = !!target && !target.read;
+        return current.map((notification) =>
+          notification.id === id ? { ...notification, read: true } : notification
+        );
+      });
 
-    const { error } = await (supabase as any)
-      .from("notifications")
-      .update({ read: true })
-      .eq("id", id);
+      if (wasUnread) {
+        setUnreadCount((current) => Math.max(0, current - 1));
+      }
 
-    if (error) {
-      console.error("Failed to mark notification as read:", error);
-      setNotifications(previous);
-    }
-  }, []);
+      const { error } = await (supabase as any)
+        .from("notifications")
+        .update({ read: true })
+        .eq("id", id);
+
+      if (error) {
+        console.error("Failed to mark notification as read:", error);
+        setNotifications(previous);
+        if (wasUnread) {
+          setUnreadCount((current) => current + 1);
+        }
+      }
+    },
+    []
+  );
 
   const markAllAsRead = useCallback(async () => {
     if (!userId) return;
 
     let previous: Notification[] = [];
+    const previousUnreadCount = unreadCount;
 
     setNotifications((current) => {
       previous = current;
       return current.map((notification) => ({ ...notification, read: true }));
     });
+    setUnreadCount(0);
 
     const { error } = await (supabase as any)
       .from("notifications")
@@ -94,8 +125,9 @@ export function useNotifications(userId?: string) {
     if (error) {
       console.error("Failed to mark all notifications as read:", error);
       setNotifications(previous);
+      setUnreadCount(previousUnreadCount);
     }
-  }, [userId]);
+  }, [userId, unreadCount]);
 
   const loadMore = useCallback(() => {
     if (!loading && hasMore) {
@@ -105,7 +137,8 @@ export function useNotifications(userId?: string) {
 
   useEffect(() => {
     fetchNotifications(0);
-  }, [fetchNotifications]);
+    fetchUnreadCount();
+  }, [fetchNotifications, fetchUnreadCount]);
 
   useEffect(() => {
     if (!userId) return;
@@ -130,6 +163,10 @@ export function useNotifications(userId?: string) {
 
             return [incoming, ...current];
           });
+
+          // Re-fetch the authoritative unread count rather than incrementing
+          // locally, since the loaded page may not include every notification.
+          fetchUnreadCount();
 
           // Check focus mode before showing popup
           supabase.from('profiles').select('is_in_focus_mode').eq('id', userId).single().then(({ data }) => {
@@ -159,6 +196,10 @@ export function useNotifications(userId?: string) {
               notification.id === updated.id ? updated : notification
             )
           );
+
+          // The read/unread status may have changed on a row outside the
+          // loaded page (or from another client/tab), so re-sync the count.
+          fetchUnreadCount();
         }
       )
       .subscribe((status) => {
@@ -170,7 +211,7 @@ export function useNotifications(userId?: string) {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [userId]);
+  }, [userId, fetchUnreadCount]);
 
   return {
     notifications,
@@ -180,7 +221,9 @@ export function useNotifications(userId?: string) {
     markAsRead,
     markAllAsRead,
     loadMore,
-    refresh: () => fetchNotifications(0),
+    refresh: () => {
+      fetchNotifications(0);
+      fetchUnreadCount();
+    },
   };
 }
-


### PR DESCRIPTION
## Related Issue
Closes #1500

## Description

Fixed an issue where the notification badge only displayed the number of unread notifications from the currently loaded page.

Previously, the unread count was calculated from the notifications already fetched by the hook. Since only the first 20 notifications were loaded, unread notifications on later pages were ignored, causing the badge to display an incorrect count.

## Changes Made

- Added a dedicated Supabase count query to fetch the total number of unread notifications
- Used `.select("id", { count: "exact", head: true }).eq("read", false)` to retrieve the unread count
- Updated the unread badge count independently of the paginated notifications list
- Refreshed the unread count after marking notifications as read
- Improved accuracy of the notification badge for users with many notifications

## Steps to Test

1. Create more than 20 notifications for a user
2. Mark some notifications beyond the first page as unread
3. Open the application
4. Verify the notification badge shows the total unread count
5. Mark notifications as read
6. Verify the unread badge updates correctly
7. Confirm pagination behavior remains unchanged

## Expected Result

- The notification badge reflects the total number of unread notifications.
- Unread notifications outside the first loaded page are included.
- The unread count updates correctly after notifications are marked as read.

## Files Changed

- `src/features/notifications/useNotifications.ts`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification badge accuracy by keeping the unread count in sync with server data.
  * Made “mark as read” and “mark all as read” actions update the unread count more reliably, with rollback if an update fails.
  * Updated real-time notification updates to refresh the unread count so it stays correct even when not all notifications are loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->