### PR TITLE
fix(presence): prevent realtime channel leak during setup

### DIFF
--- a/src/hooks/useRoomPresence.ts
+++ b/src/hooks/useRoomPresence.ts
@@ -11,10 +11,17 @@ export function useRoomPresence(id: string | undefined, user: User | null, fetch
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let roomChannel: any;
+    let cancelled = false;
 
     const initializeChat = async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data } = await supabase.from('profiles' as any).select('name').eq('id', user.id).single() as any;
+
+      // The effect may have been cleaned up (user left/switched rooms) while
+      // this request was in flight. Bail out before creating/subscribing to
+      // a channel that would otherwise leak.
+      if (cancelled) return;
+
       const displayName = data?.name || user.email?.split('@')[0] || 'Student';
 
       roomChannel = supabase.channel(`room_${id}`, {
@@ -43,11 +50,17 @@ export function useRoomPresence(id: string | undefined, user: User | null, fetch
           fetchMessages(); 
         })
         .subscribe(async (status: string) => {
-         if (status === 'SUBSCRIBED') {
+          if (status === 'SUBSCRIBED') {
+            // Guard again: cleanup could have run between subscribe() being
+            // called and this callback firing.
+            if (cancelled) return;
+
             await roomChannel.track({
               user_id: user.id,
               name: displayName
             });
+
+            if (cancelled) return;
 
             setActivities((prev) => [
               `${displayName} joined the room`,
@@ -60,6 +73,8 @@ export function useRoomPresence(id: string | undefined, user: User | null, fetch
     initializeChat();
 
     return () => {
+      cancelled = true;
+
       setActivities((prev) => [
         `${user?.email?.split("@")[0] || "User"} left the room`,
         ...prev,


### PR DESCRIPTION
## Related Issue
Closes #1499

## Description

Fixed a race condition in the room presence hook where a Supabase realtime channel could still be created after the user had already left the room.

Previously, the hook fetched the user profile before creating the realtime channel. If the component unmounted during the profile fetch, the cleanup executed before the channel existed. Once the asynchronous request completed, the channel was still created and subscribed, resulting in stale realtime subscriptions.

## Changes Made

- Added a `cancelled` flag inside the `useEffect`
- Prevented channel creation if the effect was cancelled before setup completed
- Removed the realtime channel only when it had been successfully created
- Prevented stale presence subscriptions and duplicate activity updates
- Improved cleanup during rapid room switches

## Steps to Test

1. Open a study room
2. Quickly leave the room before the profile request finishes
3. Re-enter the same room or switch to another room
4. Verify only one realtime channel is active
5. Confirm there are no duplicate presence or activity updates
6. Repeat multiple times to ensure cleanup works consistently

## Expected Result

- No realtime channels remain after leaving a room.
- Presence updates occur only for the active room.
- Duplicate join/leave events are not generated.

## Files Changed

- `src/hooks/useRoomPresence.ts`

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update