### PR TITLE
Clean up resource uploads through backend

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -6,6 +6,16 @@ import { HttpError } from "../utils/httpError.js";
 
 // Ensure files do not exceed 50MB
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
+const SAFE_PATH_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+
+const isUserScopedPath = (filePath, userId) => {
+  if (!userId || typeof filePath !== "string") return false;
+
+  const segments = filePath.split("/");
+  if (segments.length < 2 || segments[0] !== userId) return false;
+
+  return segments.every((segment) => segment && segment !== "." && segment !== ".." && SAFE_PATH_SEGMENT.test(segment));
+};
 
 // Use os.tmpdir() to avoid buffering the whole file in memory.
 // It uses the disk to stream the file, keeping memory usage low.
@@ -106,6 +116,36 @@ export const handleUpload = async (req, res, next) => {
     if (req.file && req.file.path && fs.existsSync(req.file.path)) {
       fs.unlinkSync(req.file.path);
     }
+    next(err);
+  }
+};
+
+export const handleDeleteUpload = async (req, res, next) => {
+  try {
+    const { folder = "resources", filePath } = req.body ?? {};
+    const allowedBuckets = ["resources", "avatars", "profiles"];
+
+    if (!allowedBuckets.includes(folder)) {
+      throw new HttpError(400, "Invalid destination folder.");
+    }
+
+    if (!isUserScopedPath(filePath, req.user?.id)) {
+      throw new HttpError(400, "filePath must stay within the authenticated user's folder.");
+    }
+
+    const supabaseAdmin = getSupabaseAdmin();
+    if (!supabaseAdmin) {
+      throw new HttpError(500, "Supabase configuration is missing");
+    }
+
+    const { error } = await supabaseAdmin.storage.from(folder).remove([filePath]);
+    if (error) {
+      console.error("Supabase Storage Cleanup Error:", error);
+      throw new HttpError(500, "Failed to remove uploaded file.");
+    }
+
+    res.status(200).json({ success: true });
+  } catch (err) {
     next(err);
   }
 };

--- a/backend/routers/uploadRoutes.js
+++ b/backend/routers/uploadRoutes.js
@@ -1,10 +1,11 @@
 import express from "express";
-import { uploadMiddleware, handleUpload } from "../controllers/uploadController.js";
+import { uploadMiddleware, handleUpload, handleDeleteUpload } from "../controllers/uploadController.js";
 import { requireAuth } from "../middlewares/requireAuth.js";
 
 const router = express.Router();
 
 // Only authenticated users can upload files
 router.post("/", requireAuth, uploadMiddleware, handleUpload);
+router.delete("/", requireAuth, express.json(), handleDeleteUpload);
 
 export default router;

--- a/src/lib/__tests__/uploadResource.test.ts
+++ b/src/lib/__tests__/uploadResource.test.ts
@@ -68,7 +68,7 @@ describe("uploadResource", () => {
     } as unknown as Response);
   });
 
-  it("removes the uploaded storage object when metadata insert fails", async () => {
+  it("calls the backend cleanup endpoint when metadata insert fails", async () => {
     mocks.single.mockResolvedValue({
       data: null,
       error: { message: "metadata insert failed" },
@@ -87,17 +87,36 @@ describe("uploadResource", () => {
         file_url: "user-123/backend-path.pdf",
       })
     );
-    expect(mocks.storageFrom).toHaveBeenCalledWith("resources");
-    expect(mocks.remove).toHaveBeenCalledWith(["user-123/backend-path.pdf"]);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:3000/api/upload",
+      expect.objectContaining({
+        method: "DELETE",
+        body: JSON.stringify({
+          folder: "resources",
+          filePath: "user-123/backend-path.pdf",
+        }),
+      })
+    );
   });
 
   it("logs cleanup failure without replacing the metadata insert error", async () => {
-    const cleanupError = new Error("cleanup failed");
     mocks.single.mockResolvedValue({
       data: null,
       error: { message: "metadata insert failed" },
     });
-    mocks.remove.mockResolvedValue({ error: cleanupError });
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          success: true,
+          data: { path: "user-123/backend-path.pdf" },
+        }),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      } as unknown as Response);
 
     const result = await uploadResource(file, "Notes", "Helpful notes", []);
 
@@ -106,7 +125,9 @@ describe("uploadResource", () => {
       error: "metadata insert failed",
     });
     expect(logError).toHaveBeenCalledWith(
-      cleanupError,
+      expect.objectContaining({
+        message: "Cleanup failed with status 500",
+      }),
       expect.objectContaining({
         context: "uploadResource.cleanup",
         filePath: "user-123/backend-path.pdf",

--- a/src/lib/uploadResource.ts
+++ b/src/lib/uploadResource.ts
@@ -34,6 +34,21 @@ const getFileExtension = (filename: string) => {
 const sanitizeFilename = (filename: string) =>
   filename.replace(/[^a-zA-Z0-9._-]/g, "_");
 
+const cleanupUploadedResource = async (filePath: string, token?: string) => {
+  const res = await fetch(`${API_BASE_URL}/api/upload`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ folder: "resources", filePath }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Cleanup failed with status ${res.status}`);
+  }
+};
+
 /**
  * Uploads a file to the custom Express API and then creates a corresponding metadata record in the Supabase 'resources' table.
  * This dual-upload strategy ensures files are stored securely while maintaining queryable metadata.
@@ -160,16 +175,7 @@ export const uploadResource = async (
     };
   } catch (err: any) {
     try {
-      const { error: cleanupError } = await supabase.storage
-        .from("resources")
-        .remove([uploadedPath]);
-
-      if (cleanupError) {
-        logError(cleanupError, {
-          context: "uploadResource.cleanup",
-          filePath: uploadedPath,
-        });
-      }
+      await cleanupUploadedResource(uploadedPath, token);
     } catch (cleanupErr) {
       logError(cleanupErr, {
         context: "uploadResource.cleanup",


### PR DESCRIPTION
﻿## Summary
- add an authenticated backend cleanup endpoint for uploaded files
- use the backend cleanup path when resource metadata creation fails
- update resource upload tests for the cleanup request

## Validation
- npm test -- --runInBand src/lib/__tests__/uploadResource.test.ts
- npm test -- --runInBand backend/tests/uploadPhoto.test.js

Closes #1600