### PR TITLE
Handle chatbot history load failures

### DIFF
--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -1,6 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { API_BASE_URL } from "@/config/api";
+import { logError } from "@/utils/logger";
+import { toast } from "sonner";
 
 export type Message = {
   role: "user" | "assistant";
@@ -48,11 +50,17 @@ export function useChatbot() {
       const { data: { session } } = await supabase.auth.getSession();
       if (!session?.user) return;
 
-      const { data } = await (supabase as any)
+      const { data, error } = await (supabase as any)
         .from("chat_messages")
         .select("*")
         .eq("user_id", session.user.id)
         .order("created_at", { ascending: true });
+
+      if (error) {
+        logError(error, { context: "useChatbot.loadChats" });
+        toast.error("Failed to load chat history.");
+        return;
+      }
 
       if (data) setMessages(data as any as Message[]);
     };


### PR DESCRIPTION
﻿## Summary
- handle errors from the chat history query
- log the failed load and notify the user instead of showing an empty history silently

## Validation
- npm run typecheck (fails on existing unrelated errors in docs, resources, and generated Supabase table types)

Closes #1601