### PR TITLE
Sync direct message read updates

### DIFF
--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -316,7 +316,7 @@ export function useMessages(
       .on(
         "postgres_changes",
         {
-          event: "INSERT",
+          event: "*",
           schema: "public",
           table: "messages",
         },
@@ -331,6 +331,12 @@ export function useMessages(
           }
 
           setMessages((previous) => {
+            if (payload.eventType === "UPDATE") {
+              return previous.map((message) =>
+                message.id === nextMessage.id ? { ...message, ...nextMessage } : message
+              );
+            }
+
             if (previous.some((message) => message.id === nextMessage.id)) {
               return previous;
             }


### PR DESCRIPTION
﻿## Summary
- listen for message update events in the direct-message realtime subscription
- merge read-state changes into the local message list without duplicating messages

## Validation
- npm run typecheck (fails on existing unrelated errors in docs, resources, and generated Supabase table types)

Closes #1603