### PR TITLE
Log room chat activity after send succeeds

### DIFF
--- a/src/components/Room/Room.tsx
+++ b/src/components/Room/Room.tsx
@@ -21,7 +21,7 @@ export default function Room() {
 
   // We need a ref for setActivities to pass to useRoomPresence since it's initialized after
   const [activities, setActivities] = React.useState<string[]>([]);
-  const { messages, handleSendMessage, fetchMessages } = useRoomChat(id, user, setActivities);
+  const { messages, handleSendMessage, fetchMessages } = useRoomChat(id, user);
   const { participants } = useRoomPresence(id, user, fetchMessages, setActivities);
 
   // Overwrite the chat's setActivities so it can update the feed
@@ -31,8 +31,10 @@ export default function Room() {
 
   // Let's create a combined message handler that updates activities
   const onSendMessage = React.useCallback(async (newMessage: string) => {
-    await handleSendMessage(newMessage);
-    setActivities((prev) => [`You sent a message`, ...prev]);
+    const sent = await handleSendMessage(newMessage);
+    if (sent) {
+      setActivities((prev) => [`You sent a message`, ...prev]);
+    }
   }, [handleSendMessage]);
 
   if (!room)

--- a/src/hooks/useRoomChat.ts
+++ b/src/hooks/useRoomChat.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { User } from "@supabase/supabase-js";
 
-export function useRoomChat(id: string | undefined, user: User | null, setActivities: React.Dispatch<React.SetStateAction<string[]>>) {
+export function useRoomChat(id: string | undefined, user: User | null) {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [messages, setMessages] = useState<any[]>([]);
 
@@ -28,12 +28,7 @@ export function useRoomChat(id: string | undefined, user: User | null, setActivi
   }, [fetchMessages]);
 
   const handleSendMessage = useCallback(async (newMessage: string) => {
-    if (!newMessage.trim() || !user || !id) return;
-
-    setActivities((prev) => [
-      `You sent a message`,
-      ...prev,
-    ]);
+    if (!newMessage.trim() || !user || !id) return false;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await supabase.from('study_room_messages' as any).insert([
@@ -43,8 +38,11 @@ export function useRoomChat(id: string | undefined, user: User | null, setActivi
     if (error) {
       console.error("Database insert error:", error);
       toast.error("Failed to send message. Please try again.");
+      return false;
     }
-  }, [id, user, setActivities]);
+
+    return true;
+  }, [id, user]);
 
   return { messages, handleSendMessage, fetchMessages };
 }


### PR DESCRIPTION
﻿## Summary
- return send success from the study room chat hook
- add the activity feed entry only after a message insert succeeds
- avoid duplicate sent-message activity entries

## Validation
- npm run typecheck (process exited without diagnostics after the normal project-wide baseline was already observed)

Closes #1604

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sending a chat message now only adds the “You sent a message” activity when the message is actually sent successfully.
  * Blank messages and missing room/user details are now ignored instead of creating misleading activity entries.
  * Chat activity updates are now more reliable when message sending fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->