### PR TITLE
Validate session seat limits

### DIFF
--- a/src/hooks/useCreateSession.ts
+++ b/src/hooks/useCreateSession.ts
@@ -18,7 +18,16 @@ export const formSchema = z
     time: z.string().min(1, "Time is required."),
     durationPreset: z.number().optional(),
     durationCustom: z.string().optional(),
-    seatLimit: z.string().optional(),
+    seatLimit: z
+      .string()
+      .optional()
+      .refine(
+        (value) => {
+          const trimmed = value?.trim();
+          return !trimmed || /^[1-9]\d*$/.test(trimmed);
+        },
+        { message: "Seat limit must be a positive whole number." }
+      ),
   })
   .refine(
     (v) => {
@@ -85,7 +94,8 @@ export function useCreateSession({ onSuccess, setOpen }: UseCreateSessionProps) 
       scheduledAt.setHours(hours, minutes, 0, 0);
 
       const durationMinutes = resolveDurationMinutes(values);
-      const seatLimit = values.seatLimit && values.seatLimit.trim() !== "" ? parseInt(values.seatLimit, 10) : null;
+      const trimmedSeatLimit = values.seatLimit?.trim();
+      const seatLimit = trimmedSeatLimit ? parseInt(trimmedSeatLimit, 10) : null;
 
       const { error } = await supabase.from("sessions").insert({
         title: values.title,

--- a/supabase/migrations/20260704000001_validate_session_seat_limits.sql
+++ b/supabase/migrations/20260704000001_validate_session_seat_limits.sql
@@ -1,0 +1,11 @@
+UPDATE public.sessions
+SET seat_limit = NULL
+WHERE seat_limit IS NOT NULL
+  AND seat_limit < 1;
+
+ALTER TABLE public.sessions
+DROP CONSTRAINT IF EXISTS sessions_seat_limit_check;
+
+ALTER TABLE public.sessions
+ADD CONSTRAINT sessions_seat_limit_check
+CHECK (seat_limit IS NULL OR seat_limit >= 1);


### PR DESCRIPTION
﻿## Summary
- validate optional session seat limits as positive whole numbers in the form schema
- parse only the trimmed validated value during submit
- add a database check constraint for persisted seat limits

## Validation
- npm run typecheck (fails on existing unrelated errors in docs, resources, and generated Supabase table types)

Closes #1605