### PR TITLE
Allow doubt upvote updates

### DIFF
--- a/supabase/migrations/20260704000002_allow_doubt_upvotes.sql
+++ b/supabase/migrations/20260704000002_allow_doubt_upvotes.sql
@@ -1,0 +1,18 @@
+ALTER TABLE public.doubts
+DROP CONSTRAINT IF EXISTS doubts_upvotes_nonnegative_check;
+
+ALTER TABLE public.doubts
+ADD CONSTRAINT doubts_upvotes_nonnegative_check
+CHECK (upvotes >= 0);
+
+DROP POLICY IF EXISTS "authenticated users can update doubt upvotes" ON public.doubts;
+
+CREATE POLICY "authenticated users can update doubt upvotes"
+  ON public.doubts
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() IS NOT NULL)
+  WITH CHECK (auth.uid() IS NOT NULL AND upvotes >= 0);
+
+REVOKE UPDATE ON TABLE public.doubts FROM anon, authenticated;
+GRANT UPDATE (upvotes) ON TABLE public.doubts TO authenticated;


### PR DESCRIPTION
﻿## Summary
- add an authenticated update policy for doubt upvotes
- grant updates only on the upvotes column
- enforce nonnegative upvote counts in the database

## Validation
- reviewed migration against the existing anonymous doubts schema

Closes #1588