### PR TITLE
Show doubt upvote failures

### DIFF
--- a/src/pages/AnonymousDoubts.tsx
+++ b/src/pages/AnonymousDoubts.tsx
@@ -88,6 +88,7 @@ export default function AnonymousDoubts() {
         doubts.map((d) => (d.id === id ? { ...d, upvotes: doubt.upvotes } : d))
       );
       setVotedIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+      toast.error("Failed to upvote doubt. Please try again.");
     }
   };
 


### PR DESCRIPTION
﻿## Summary
- show a toast when a doubt upvote update fails
- keep the existing optimistic rollback and allow retrying the vote

## Validation
- reviewed the existing optimistic upvote error path

Closes #1589