### PR TITLE
Clamp focus timer duration inputs

### DIFF
--- a/src/components/FocusTimer.tsx
+++ b/src/components/FocusTimer.tsx
@@ -10,6 +10,12 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useToast } from '@/components/ui/use-toast';
 
+const clampDuration = (value: string, min: number, max: number, fallback: number) => {
+  const next = Number(value);
+  if (!Number.isFinite(next)) return fallback;
+  return Math.min(max, Math.max(min, Math.trunc(next)));
+};
+
 export default function FocusTimer() {
   const { user } = useAuth();
   const { toast } = useToast();
@@ -180,7 +186,7 @@ export default function FocusTimer() {
                   type="number" 
                   value={workDuration}
                   onChange={(e) => {
-                    const val = Number(e.target.value);
+                    const val = clampDuration(e.target.value, 1, 120, workDuration);
                     setWorkDuration(val);
                     if (!isBreak) setTimeLeft(val * 60);
                   }}
@@ -194,7 +200,7 @@ export default function FocusTimer() {
                   type="number" 
                   value={breakDuration}
                   onChange={(e) => {
-                    const val = Number(e.target.value);
+                    const val = clampDuration(e.target.value, 1, 60, breakDuration);
                     setBreakDuration(val);
                     if (isBreak) setTimeLeft(val * 60);
                   }}


### PR DESCRIPTION
﻿## Summary
- clamp typed work and break durations to the configured min/max ranges
- ignore nonnumeric input by keeping the previous valid duration
- keep the displayed timer in sync with the validated duration

## Validation
- npm run typecheck (fails on existing unrelated errors in docs, resources, and generated Supabase table types)

Closes #1592