### PR TITLE
Reset focus timer after stopping break

### DIFF
--- a/src/components/FocusTimer.tsx
+++ b/src/components/FocusTimer.tsx
@@ -103,8 +103,9 @@ export default function FocusTimer() {
     const newIsActive = !isActive;
     setIsActive(newIsActive);
     
-    if (!newIsActive && !isBreak) {
-      // Stopped manually during work
+    if (!newIsActive) {
+      // Reset manual stops to the next work session, even if the current mode is break.
+      setIsBreak(false);
       setTimeLeft(workDuration * 60);
     }
     


### PR DESCRIPTION
﻿## Summary
- reset break mode when the Focus Timer is stopped manually
- restore the next timer start to the configured work duration

## Validation
- reviewed the manual stop path in FocusTimer

Closes #1593