### PR TITLE
Restrict avatar upload file types

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -9,6 +9,13 @@ type AvatarUploadProps = {
   onUploadError: (error: string) => void;
 };
 
+const ALLOWED_AVATAR_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+]);
+
 export const AvatarUpload: React.FC<AvatarUploadProps> = ({
   currentAvatarUrl,
   onUploadSuccess,
@@ -23,7 +30,7 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
     const file = event.target.files?.[0];
     if (!file) return;
 
-    if (!file.type.startsWith("image/")) {
+    if (!ALLOWED_AVATAR_TYPES.has(file.type)) {
       onUploadError(
         "Please select a valid image file (JPG, PNG, GIF, or WebP)."
       );
@@ -124,7 +131,7 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
       <input
         type="file"
         ref={fileInputRef}
-        accept="image/*"
+        accept="image/jpeg,image/png,image/gif,image/webp"
         onChange={handleFileChange}
         className="hidden"
       />


### PR DESCRIPTION
﻿## Summary
- restrict avatar uploads to JPG, PNG, GIF, and WebP on the client
- update the file picker accept list to match the supported avatar formats

## Validation
- npm run typecheck (fails on existing unrelated errors in docs, resources, and generated Supabase table types)

Closes #1596