### PR TITLE
fix: address six bugs (#1614, #1599, #1598, #1605, #1604, #1596)

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -1,6 +1,7 @@
 import multer from "multer";
 import os from "os";
 import fs from "fs";
+import path from "path";
 import { getSupabaseAdmin } from "../utils/supabase.js";
 import { HttpError } from "../utils/httpError.js";
 
@@ -33,7 +34,7 @@ const upload = multer({
       "application/typescript"
     ];
 
-    if (file.mimetype.startsWith("image/") || allowedResourceTypes.includes(file.mimetype)) {
+    if ((file.mimetype.startsWith("image/") && file.mimetype !== "image/svg+xml") || allowedResourceTypes.includes(file.mimetype)) {
       cb(null, true);
     } else {
       cb(new HttpError(415, "Unsupported Media Type"));
@@ -63,6 +64,13 @@ export const handleUpload = async (req, res, next) => {
     if (!allowedBuckets.includes(folder)) {
       fs.unlinkSync(file.path);
       throw new HttpError(400, "Invalid destination folder.");
+    }
+
+    // Sanitize filePath: prevent path traversal
+    const sanitizedPath = path.normalize(filePath).replace(/^(\.\.(\/|\\|$))+/, "");
+    if (sanitizedPath !== filePath) {
+      fs.unlinkSync(file.path);
+      throw new HttpError(400, "Invalid file path.");
     }
 
     const supabaseAdmin = getSupabaseAdmin();

--- a/backend/routers/chatRoutes.js
+++ b/backend/routers/chatRoutes.js
@@ -46,9 +46,13 @@ router.post(
       MAX_TOKENS_CAP
     );
 
+    // Filter out any system messages from the client to prevent prompt injection
+    const clientMessages = req.body.messages.filter(
+      (m: { role: string }) => m.role !== "system"
+    );
     const chatMessages = [
       { role: "system", content: SYSTEM_PROMPT },
-      ...req.body.messages,
+      ...clientMessages,
     ];
 
     const response = await openrouter.chat.completions.create({

--- a/src/components/mentor/MentorForm.tsx
+++ b/src/components/mentor/MentorForm.tsx
@@ -199,34 +199,37 @@ export default function MentorForm() {
             <input
               placeholder="Full Name"
               value={formData.full_name}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData({
                   ...formData,
                   full_name: e.target.value,
-                })
-              }
+                });
+                setError("");
+              }}
               className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
             <input
               placeholder="College Name"
               value={formData.college}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData({
                   ...formData,
                   college: e.target.value,
-                })
-              }
+                });
+                setError("");
+              }}
               className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
             <textarea
               placeholder="Short Bio"
               value={formData.bio}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData({
                   ...formData,
                   bio: e.target.value,
-                })
-              }
+                });
+                setError("");
+              }}
               className="h-32 w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
           </div>
@@ -305,23 +308,25 @@ export default function MentorForm() {
             <input
               placeholder="https://github.com/Username"
               value={formData.github}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData({
                   ...formData,
                   github: e.target.value,
-                })
-              }
+                });
+                setError("");
+              }}
               className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
             <input
               placeholder="https://www.linkedin.com/in/Username"
               value={formData.linkedin}
-              onChange={(e) =>
+              onChange={(e) => {
                 setFormData({
                   ...formData,
                   linkedin: e.target.value,
-                })
-              }
+                });
+                setError("");
+              }}
               className="w-full rounded-2xl border border-white/10 bg-white/5 p-4 outline-none transition focus:border-cyan-400"
             />
             <input

--- a/src/hooks/useCreateSession.ts
+++ b/src/hooks/useCreateSession.ts
@@ -18,7 +18,10 @@ export const formSchema = z
     time: z.string().min(1, "Time is required."),
     durationPreset: z.number().optional(),
     durationCustom: z.string().optional(),
-    seatLimit: z.string().optional(),
+    seatLimit: z.string().optional().refine(
+      (val) => val === undefined || val === "" || (/^\d+$/.test(val) && parseInt(val, 10) >= 1 && parseInt(val, 10) <= 1000),
+      { message: "Seat limit must be a number between 1 and 1000" }
+    ),
   })
   .refine(
     (v) => {

--- a/src/hooks/useRoomChat.ts
+++ b/src/hooks/useRoomChat.ts
@@ -30,11 +30,6 @@ export function useRoomChat(id: string | undefined, user: User | null, setActivi
   const handleSendMessage = useCallback(async (newMessage: string) => {
     if (!newMessage.trim() || !user || !id) return;
 
-    setActivities((prev) => [
-      `You sent a message`,
-      ...prev,
-    ]);
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await supabase.from('study_room_messages' as any).insert([
       { room_id: id, profile_id: user.id, content: newMessage }
@@ -43,7 +38,13 @@ export function useRoomChat(id: string | undefined, user: User | null, setActivi
     if (error) {
       console.error("Database insert error:", error);
       toast.error("Failed to send message. Please try again.");
+      return;
     }
+
+    setActivities((prev) => [
+      `You sent a message`,
+      ...prev,
+    ]);
   }, [id, user, setActivities]);
 
   return { messages, handleSendMessage, fetchMessages };


### PR DESCRIPTION
## Fixes six bugs in peer-learning

### #1614 — Validation error message doesn't clear after fixing input
Added setError("") to every input's onChange handler so validation errors clear reactively when the user corrects their input.

### #1599 — Upload endpoint allows arbitrary storage paths
Added path traversal sanitization to filePath param using path.normalize() and rejection of paths containing ..

### #1598 — Chat completion accepts client system messages
Filter out any messages with role: "system" from client payload before constructing the completion request, preventing prompt injection.

### #1605 — Session creation accepts invalid seat limits
Added Zod validation for seatLimit field: must be a positive integer between 1 and 1000.

### #1604 — Room chat records activity before send succeeds
Moved setActivities call to after the Supabase insert succeeds, and added return on failure to prevent phantom activity entries.

### #1596 — Avatar upload accepts SVG client-side but backend rejects
Explicitly reject image/svg+xml MIME type in the upload controller file filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload safety by rejecting unsafe file paths and blocking SVG image uploads.
  * Prevented client-provided system messages from affecting chat requests.
  * Fixed message activity logging so failed sends no longer appear as successful.
  * Clear form errors as soon as users edit affected profile fields.
  * Tightened session seat-limit validation to accept only values from 1 to 1000.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->