### PR TITLE
fix(#1443): escape calendar export text fields

### DIFF
--- a/src/utils/calendar.test.ts
+++ b/src/utils/calendar.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { escapeICalText, generateICS } from "./calendar";
+
+describe("calendar exports", () => {
+  let createdBlob: Blob | undefined;
+
+  beforeEach(() => {
+    createdBlob = undefined;
+    vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      createdBlob = blob as Blob;
+      return "blob:calendar";
+    });
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const generateCalendarText = async (title: string, description: string) => {
+    generateICS(title, description, new Date("2026-07-05T10:00:00Z"), 60);
+
+    expect(createdBlob).toBeDefined();
+    return createdBlob!.text();
+  };
+
+  it("escapes title newlines without creating a new ICS property", async () => {
+    const text = await generateCalendarText(
+      "React Review\nLOCATION:Injected Room",
+      "Session details"
+    );
+
+    expect(text).toContain("SUMMARY:React Review\\nLOCATION:Injected Room");
+    expect(text).not.toContain("\r\nLOCATION:Injected Room");
+  });
+
+  it("escapes commas, semicolons, and backslashes in descriptions", () => {
+    expect(escapeICalText("Discuss hooks, state; and effects \\ notes")).toBe(
+      "Discuss hooks\\, state\\; and effects \\\\ notes"
+    );
+  });
+
+  it("keeps normal title and description values unchanged", async () => {
+    const text = await generateCalendarText("React Review", "Discuss hooks");
+
+    expect(text).toContain("SUMMARY:React Review");
+    expect(text).toContain("DESCRIPTION:Discuss hooks");
+  });
+});

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -6,6 +6,13 @@
  * @param startDate      Session start time (Date object)
  * @param durationMinutes Session duration in minutes (default 60)
  */
+export const escapeICalText = (text: string) =>
+  text
+    .replace(/\\/g, "\\\\")
+    .replace(/\r\n|\n|\r/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;");
+
 export const generateICS = (
   title: string,
   description: string,
@@ -29,8 +36,8 @@ export const generateICS = (
     `DTSTAMP:${formatDate(new Date())}`,
     `DTSTART:${formatDate(startDate)}`,
     `DTEND:${formatDate(endDate)}`,
-    `SUMMARY:${title}`,
-    `DESCRIPTION:${description.replace(/\n/g, "\\n")}`,
+    `SUMMARY:${escapeICalText(title)}`,
+    `DESCRIPTION:${escapeICalText(description)}`,
     "END:VEVENT",
     "END:VCALENDAR",
   ].join("\r\n");


### PR DESCRIPTION
## Summary
- Added iCalendar text escaping for calendar export `SUMMARY` and `DESCRIPTION` fields.
- Escapes backslashes, newline variants, commas, and semicolons.
- Added tests for escaped calendar text output.

## Related Issue
Fixes #1443

## Validation
- `npm.cmd run test -- src/utils/calendar.test.ts` passed
- `npm.cmd run lint` passed with existing warnings
- `npm.cmd run typecheck` failed due unrelated existing errors in:
  - `src/hooks/useResources.ts`
  - `src/hooks/useSkillEndorsements.ts`

## Notes
Existing untracked `uploads/` directory was not touched.