### PR TITLE
[GSSoC'26] fix: remove unused Router import in App.tsx

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, Suspense, useState, useRef } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate, Router } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";


### PR DESCRIPTION
## Description

- Removed unused `Router` import from `react-router-dom` in `src/App.tsx`
- `Router` was never used in the file — only `BrowserRouter`, `Routes`, `Route`, and `Navigate` are used
- Eliminates dead code and lint warnings

## Files Changed

- `src/App.tsx`: Removed `Router` from the named import on line 3

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

Commands run:

```bash
npm run lint
```

Result: No lint errors related to unused imports.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up an unused navigation import for a slightly tidier codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->