### PR TITLE
[GSSoC'26] fix: use correct column name uploaded_by in Dashboard activity feed

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -118,7 +118,7 @@ const Dashboard = () => {
           supabase
             .from("resources")
             .select("title, created_at")
-            .eq("user_id", user.id)
+            .eq("uploaded_by", user.id)
             .order("created_at", { ascending: false })
             .limit(3),
           supabase


### PR DESCRIPTION
## Description

- Fixed Dashboard activity feed query in `src/pages/Dashboard.tsx` to use correct column name
- Changed `.eq("user_id", user.id)` to `.eq("uploaded_by", user.id)` — `uploaded_by` is the actual column in the `resources` table per the migration schema
- Previously the query used `user_id` which doesn't exist, causing Supabase to return a 400 error and the activity feed to silently show "No recent activity yet."

## Files Changed

- `src/pages/Dashboard.tsx`: Fixed column name in resources query (line 121)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

The change is a single identifier rename verifiable by inspection. Other parts of the codebase (`src/lib/uploadResource.ts:144`, `src/lib/deleteResource.ts:28`, `src/types/resource.ts:9`) already use `uploaded_by` correctly.

## Known Limitations

- None

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1494
