### PR TITLE
[GSSoC'26] fix: correct Supabase type definitions for resources table

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -373,30 +373,33 @@ export type Database = {
           id: string
           title: string
           description: string | null
-          url: string
+          file_url: string
+          file_size: number | null
           tags: string[] | null
           file_type: string
-          user_id: string
+          uploaded_by: string
           created_at: string
         }
         Insert: {
           id?: string
           title: string
           description?: string | null
-          url: string
+          file_url: string
+          file_size?: number | null
           tags?: string[] | null
           file_type: string
-          user_id: string
+          uploaded_by: string
           created_at?: string
         }
         Update: {
           id?: string
           title?: string
           description?: string | null
-          url?: string
+          file_url?: string
+          file_size?: number | null
           tags?: string[] | null
           file_type?: string
-          user_id?: string
+          uploaded_by?: string
           created_at?: string
         }
         Relationships: []


### PR DESCRIPTION
## Description

- Fixed auto-generated Supabase type definitions for the `resources` table in `src/integrations/supabase/types.ts`
- Corrected three discrepancies between the types and the migration schema (`supabase/migrations/20260518000000_resource_hub.sql`):
  - `url` → `file_url` (migration: `file_url text not null`)
  - `user_id` → `uploaded_by` (migration: `uploaded_by uuid references profiles(id)`)
  - Added missing `file_size: number | null` (migration: `file_size bigint`)
- Prevents developers from using wrong column names in typed Supabase queries

## Files Changed

- `src/integrations/supabase/types.ts`: Fixed `Row`, `Insert`, and `Update` type definitions for `resources` table

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

The change aligns the TypeScript types with the SQL migration. Other files in the codebase correctly use `uploaded_by` and `file_url` (`src/lib/uploadResource.ts:144`, `src/types/resource.ts:9`).

## Known Limitations

- These types should be regenerated via `supabase gen types typescript --linked` against the production database to prevent future drift

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1495
