### PR TITLE
[GSSoC'26] fix: centralize AI model allowlist to prevent drift

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -1,10 +1,11 @@
 import { z } from "zod";
 
 import { HttpError } from "../utils/httpError.js";
+import { ALLOWED_AI_MODELS } from "../utils/constants.js";
 
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions";
 const OPENROUTER_MODEL = "openai/gpt-4o-mini";
-const ALLOWED_MODELS = ["openai/gpt-4o-mini", "openai/gpt-4o", "openai/gpt-4"];
+const ALLOWED_MODELS = ALLOWED_AI_MODELS;
 
 const ASK_AI_MAX_TOKENS = 512;
 const SUMMARY_MAX_TOKENS = 400;

--- a/backend/utils/constants.js
+++ b/backend/utils/constants.js
@@ -1,0 +1,5 @@
+export const ALLOWED_AI_MODELS = [
+  "openai/gpt-4o-mini",
+  "openai/gpt-4o",
+  "openai/gpt-4",
+];

--- a/backend/validation/schemas.js
+++ b/backend/validation/schemas.js
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
-const allowedChatModels = ["openai/gpt-3.5-turbo", "openai/gpt-4o-mini"];
+import { ALLOWED_AI_MODELS } from "../utils/constants.js";
+
+const allowedChatModels = ALLOWED_AI_MODELS;
 const MAX_ASK_MESSAGES = 10;
 const MAX_SUMMARY_MESSAGES = 50;
 
@@ -47,7 +49,7 @@ export const chatSchemas = {
     body: z
       .object({
         messages: z.array(chatMessageSchema).min(1).max(50),
-        model: z.enum(allowedChatModels).default("openai/gpt-3.5-turbo"),
+        model: z.enum(allowedChatModels).default("openai/gpt-4o-mini"),
         max_tokens: z.number().int().positive().max(512).optional(),
         temperature: z.number().min(0).max(2).default(0.7),
       })


### PR DESCRIPTION
## Description

- Created shared `ALLOWED_AI_MODELS` constant in `backend/utils/constants.js` as a single source of truth
- Imported and used the shared list in both `backend/validation/schemas.js` and `backend/controllers/aiController.js`
- Previously, two separate lists existed: schema allowed `["openai/gpt-3.5-turbo", "openai/gpt-4o-mini"]` while controller allowed `["openai/gpt-4o-mini", "openai/gpt-4o", "openai/gpt-4"]`
  - `gpt-3.5-turbo` passed validation but got rejected by controller
  - `gpt-4o` and `gpt-4` were rejected by validation but supported by controller
- Updated default model in schema from `openai/gpt-3.5-turbo` to `openai/gpt-4o-mini` to match the shared allowlist

## Files Changed

- `backend/utils/constants.js`: **New file** — shared AI model allowlist (single source of truth)
- `backend/validation/schemas.js`: Use shared allowlist, update default model
- `backend/controllers/aiController.js`: Use shared allowlist

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Difficulty & Label Request

Assessed difficulty: `level1`

Please apply the matching difficulty label for GSSoC '26 scoring.
If applicable, please also apply `gssoc:approved` after review.

## Testing & Verification

- Schema enum now accepts the same models the controller allows
- Default model `gpt-4o-mini` exists in the shared allowlist
- No functional behavior change beyond consistency

## Known Limitations

- `backend/utils/constants.js` currently only contains AI model allowlist; other shared AI config could be added in future

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

New file added: `backend/utils/constants.js` — required by issue #1491.

Closes #1491
