### PR TITLE
fix(profile): point the edit-profile back button to the dashboard

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -140,10 +140,10 @@ if (profile.bio.length > MAX_BIO_CHARS) {
 
             <h1 className="text-5xl font-bold mb-3">Edit Profile</h1>
             <button
-              onClick={() => navigate('/profile')}
+              onClick={() => navigate('/dashboard')}
               className="inline-flex items-center gap-2 bg-white/5 border border-white/10 text-gray-300 px-4 py-2 rounded-full hover:border-cyan-400/50 hover:text-cyan-300 transition mt-2"
             >
-              ← Back to Profile
+              ← Back to Dashboard
             </button>
             <p className="text-gray-400 text-lg">
               Build your learning identity 🚀


### PR DESCRIPTION
## Summary

The Edit Profile page (route `/profile`) had a "← Back to Profile" button that navigated to `/profile`, the page the user is already on, so it did nothing. This points it to `/dashboard` and relabels it to match.

## Changes

- `Profile.tsx`: back button navigates to `/dashboard` with the label "← Back to Dashboard".

## Verification

- Typecheck: no new type errors versus base.
- `/dashboard` is a valid route in `App.tsx`.

## Related

Fixes #1669


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Profile page’s back navigation to send users to the Dashboard instead of returning to the Profile page.
  * Renamed the button label to better match its destination: “Back to Dashboard.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->