### PR TITLE
fix(discover): roll back optimistic connect state and toast on failure

### DIFF
--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -11,6 +11,7 @@ import {
   Zap,
 } from "lucide-react";
 
+import { toast } from "sonner";
 import { supabase } from "@/integrations/supabase/client";
 import { NotificationsDropdown } from "@/components/NotificationsDropdown";
 import { Check } from "lucide-react";
@@ -277,14 +278,18 @@ const Discover = () => {
       status: 'pending'
     });
 
-    if (!error) {
-      await (supabase as any).from("notifications").insert({
-        user_id: peerId,
-        type: 'system',
-        title: 'New Connection Request',
-        body: `${currentUser.name || 'Someone'} wants to connect with you!`,
-      });
+    if (error) {
+      setConnections((prev) => prev.filter((id) => id !== peerId));
+      toast.error("Could not send the connection request. Please try again.");
+      return;
     }
+
+    await (supabase as any).from("notifications").insert({
+      user_id: peerId,
+      type: 'system',
+      title: 'New Connection Request',
+      body: `${currentUser.name || 'Someone'} wants to connect with you!`,
+    });
   }, [connections, currentUser]);
 
   return (


### PR DESCRIPTION
## Summary

On Discover, "Connect" optimistically set the peer as connected (disabling the button to "Pending"), but a failed `peer_connections` insert never rolled that back and showed no error, so the button stayed stuck at "Pending". This rolls back and toasts on failure, matching `Dashboard.handleConnect`.

## Changes

- `Discover.tsx`: on insert error, remove the peer from the optimistic `connections` list and show a `toast.error`, then return; success path is unchanged.

## Verification

- Typecheck: no new type errors versus base.
- Mirrors the rollback already used in `Dashboard.handleConnect`.
- No render test was added: simulating a failing Supabase insert inside the Discover page is disproportionate to a rollback/toast fix.

## Related

Fixes #1672
