### PR TITLE
fix(backend): apply the 50kb AI body limit shadowed by the global parser

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -66,6 +66,8 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization']
 }));
 
+// AI routes use a tighter body limit; mount before the global parser so it applies.
+app.use("/api/ai", express.json({ limit: "50kb" }));
 app.use(express.json({ limit: "100kb" }));
 app.use(cookieParser());
 app.use((req, res, next) => {

--- a/backend/routers/aiRoutes.js
+++ b/backend/routers/aiRoutes.js
@@ -15,13 +15,9 @@ import { aiSchemas } from "../validation/schemas.js";
 
 const router = express.Router();
 
-// SECURITY: Tighter body limit for AI routes (50KB) since these endpoints
-// have well-defined, smaller input requirements than the global 100KB cap.
-const aiBodyLimit = express.json({ limit: "50kb" });
-
-router.post("/ask", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.askAI), asyncHandler(askAI));
-router.post("/generate-summary", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.generateSessionSummary), asyncHandler(generateSessionSummary));
-router.post("/mock-interview/chat", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.mockInterviewChat), asyncHandler(conductMockInterview));
-router.post("/mock-interview/report", aiBodyLimit, requireAuth, rateLimiter, validate(aiSchemas.mockInterviewReport), asyncHandler(generateMockInterviewReport));
+router.post("/ask", requireAuth, rateLimiter, validate(aiSchemas.askAI), asyncHandler(askAI));
+router.post("/generate-summary", requireAuth, rateLimiter, validate(aiSchemas.generateSessionSummary), asyncHandler(generateSessionSummary));
+router.post("/mock-interview/chat", requireAuth, rateLimiter, validate(aiSchemas.mockInterviewChat), asyncHandler(conductMockInterview));
+router.post("/mock-interview/report", requireAuth, rateLimiter, validate(aiSchemas.mockInterviewReport), asyncHandler(generateMockInterviewReport));
 
 export default router;

--- a/backend/tests/aiBodyLimit.test.js
+++ b/backend/tests/aiBodyLimit.test.js
@@ -1,0 +1,25 @@
+import request from "supertest";
+import { describe, it, expect } from "vitest";
+import app from "../app.js";
+
+describe("AI route body limit", () => {
+  it("rejects an AI request body larger than 50KB with 413", async () => {
+    const oversized = { pad: "x".repeat(80 * 1024) };
+    const res = await request(app).post("/api/ai/ask").send(oversized);
+    expect(res.status).toBe(413);
+  });
+
+  it("parses a small AI request body and reaches authentication", async () => {
+    const res = await request(app)
+      .post("/api/ai/ask")
+      .send({ messages: [{ role: "user", content: "hi" }] });
+    expect(res.status).not.toBe(413);
+    expect(res.status).toBe(401);
+  });
+
+  it("still allows non-AI requests up to the global 100KB limit", async () => {
+    const between = { pad: "x".repeat(80 * 1024) };
+    const res = await request(app).post("/api/notifications/send-push").send(between);
+    expect(res.status).not.toBe(413);
+  });
+});


### PR DESCRIPTION
## Summary

The AI routes' 50KB body limit never applied. The global `express.json({ limit: "100kb" })` parses the body first, so the per-route 50KB parser was inert (body-parser's `req._body` short-circuit).

## Changes

- `app.js`: mount a 50KB json parser for `/api/ai` before the global 100KB parser, so it runs first.
- `aiRoutes.js`: remove the now redundant per-route parser.
- Add `tests/aiBodyLimit.test.js`.

## Verification

Against a real Express instance and the actual `app.js`:

- Before: an 80KB body to `/api/ai/ask` returned 200.
- After: 80KB returns 413; a small body returns 401 (parsed, reaches auth); non-AI routes still accept up to 100KB.
- Full backend suite passes (140 tests).

## Related

Fixes #1657
