### PR TITLE
fix(backend): stop logging intentional HttpErrors as unhandled errors

### DIFF
--- a/backend/middlewares/errorHandler.js
+++ b/backend/middlewares/errorHandler.js
@@ -61,11 +61,11 @@ export const errorHandler = (err, req, res, next) => {
     return res.status(400).json({ error: err.message });
   }
 
-  console.error("Unhandled error:", err);
   // --- Known HttpError (intentionally thrown by our code) ---
   if (err instanceof HttpError) {
     const status = err.statusCode || 500;
-    console.error(`[${requestId}] HttpError ${status}:`, err.message);
+    const log = status >= 500 ? console.error : console.warn;
+    log(`[${requestId}] HttpError ${status}:`, err.message);
 
     const payload = { error: err.message };
 

--- a/backend/tests/errorHandler.test.js
+++ b/backend/tests/errorHandler.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { errorHandler } from "../middlewares/errorHandler.js";
+import { HttpError } from "../utils/httpError.js";
+
+const makeRes = () => ({
+  headersSent: false,
+  statusCode: null,
+  body: null,
+  status(code) { this.statusCode = code; return this; },
+  json(payload) { this.body = payload; return this; },
+  setHeader() {},
+});
+
+describe("errorHandler logging", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does not log an intentional 4xx HttpError as an unhandled error", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const res = makeRes();
+
+    errorHandler(new HttpError(401, "Authentication required"), { requestId: "req-1" }, res, () => {});
+
+    expect(res.statusCode).toBe(401);
+    const loggedUnhandled = errorSpy.mock.calls.some((args) => String(args[0]).includes("Unhandled error"));
+    expect(loggedUnhandled).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it("logs a genuinely unknown error exactly once as unhandled", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes();
+
+    errorHandler(new Error("boom"), { requestId: "req-2" }, res, () => {});
+
+    expect(res.statusCode).toBe(500);
+    const unhandledLogs = errorSpy.mock.calls.filter((args) => String(args[0]).includes("Unhandled error"));
+    expect(unhandledLogs).toHaveLength(1);
+  });
+
+  it("logs a 5xx HttpError at error level", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = makeRes();
+
+    errorHandler(new HttpError(500, "boom"), { requestId: "req-3" }, res, () => {});
+
+    expect(res.statusCode).toBe(500);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The global error handler had an unconditional `console.error("Unhandled error:", err)` before it classified the error, so every intentional `HttpError` was logged twice, and expected 4xx client errors were recorded as unhandled server errors. This removes the stray line and logs 4xx at warn, 5xx at error.

## Changes

- `errorHandler.js`: remove the unconditional log; log HttpError at warn (status < 500) or error (>= 500).
- Add `tests/errorHandler.test.js`.

## Verification

- New test: a 401 HttpError is not logged as "Unhandled error" and is logged at warn; an unknown error is logged exactly once as unhandled; a 5xx HttpError logs at error. The test fails on the old code and passes on the fix.
- Full backend suite passes.

## Related

Fixes #1661
