### PR TITLE
fix(deploy): exclude /api from the SPA rewrite so it does not shadow API routes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "rewrites": [
-    { "source": "/(.*)", "destination": "/" }
+    { "source": "/((?!api/).*)", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary

The SPA rewrite in `vercel.json` used a catch-all `"/(.*)"` that also matched `/api/*`, so API paths on the deployment origin were served the SPA HTML instead of reaching a backend (or returning 404). This excludes `/api` from the SPA rewrite with a negative lookahead.

## Changes

- `vercel.json`: change the rewrite source to `"/((?!api/).*)"`.

## Verification

- Regex check: the new pattern rewrites app routes and assets (`/`, `/dashboard`, `/assets/index.js`) to the SPA but does not match `/api/chat`, `/api/ai/ask`, `/api/match/recommendations`. The old pattern matched all of them.
- `vercel.json` remains valid JSON.
- A full end-to-end check requires a Vercel deployment, which is controlled by the maintainer.

## Note

Fully restoring the backend-dependent features on the deployment also requires deploying the Express backend and pointing `VITE_API_URL` at it (or co-deploying it as Vercel functions). That is a deployment step outside this repo change.

## Related

Fixes #1662
