### PR TITLE
fix(whiteboard): normalize stroke coordinates so drawings align across canvas sizes

### DIFF
--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -9,6 +9,7 @@ import {
   WhiteboardEvent,
 } from "./types";
 import { nextSegment } from "./strokePath";
+import { normalizePoint, denormalizePoint } from "./coords";
 
 type Props = {
   roomId: string;
@@ -88,6 +89,14 @@ export default function Canvas({ roomId }: Props) {
 
     if (!segment) return;
 
+    // New events store normalized fractions; denormalize to the local canvas size.
+    const from = event.payload.normalized
+      ? denormalizePoint(segment.from, ctx.canvas.width, ctx.canvas.height)
+      : segment.from;
+    const to = event.payload.normalized
+      ? denormalizePoint(segment.to, ctx.canvas.width, ctx.canvas.height)
+      : segment.to;
+
     ctx.strokeStyle =
       event.payload.tool === "eraser"
         ? "#020617"
@@ -96,8 +105,8 @@ export default function Canvas({ roomId }: Props) {
     ctx.lineWidth = event.payload.lineWidth || 3;
 
     ctx.beginPath();
-    ctx.moveTo(segment.from.x, segment.from.y);
-    ctx.lineTo(segment.to.x, segment.to.y);
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
     ctx.stroke();
   };
 
@@ -251,10 +260,12 @@ export default function Canvas({ roomId }: Props) {
 
     const rect = canvas.getBoundingClientRect();
 
-    return {
-      x: e.clientX - rect.left,
-      y: e.clientY - rect.top,
-    };
+    return normalizePoint(
+      e.clientX - rect.left,
+      e.clientY - rect.top,
+      rect.width,
+      rect.height
+    );
   };
 
   const startDrawing = (
@@ -278,6 +289,7 @@ export default function Canvas({ roomId }: Props) {
         lineWidth,
         tool,
         strokeId,
+        normalized: true,
       },
     });
   };
@@ -300,6 +312,7 @@ export default function Canvas({ roomId }: Props) {
         tool,
         strokeId:
           currentStrokeId.current || undefined,
+        normalized: true,
       },
     });
   };

--- a/src/components/Whiteboard/coords.test.ts
+++ b/src/components/Whiteboard/coords.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { normalizePoint, denormalizePoint } from "./coords";
+
+describe("whiteboard coordinate normalization", () => {
+  it("round-trips to the same pixel on the same canvas size", () => {
+    const n = normalizePoint(800, 250, 900, 500);
+    const p = denormalizePoint(n, 900, 500);
+    expect(p.x).toBeCloseTo(800);
+    expect(p.y).toBeCloseTo(250);
+  });
+
+  it("keeps the same relative position across different canvas sizes", () => {
+    // Captured near the right edge of a 900x500 canvas (90% across, 50% down).
+    const n = normalizePoint(810, 250, 900, 500);
+    expect(n.x).toBeCloseTo(0.9);
+    expect(n.y).toBeCloseTo(0.5);
+
+    // Rendered on a smaller 500x300 canvas: still 90% across, 50% down.
+    const p = denormalizePoint(n, 500, 300);
+    expect(p.x).toBeCloseTo(450);
+    expect(p.y).toBeCloseTo(150);
+  });
+
+  it("guards against a zero-sized canvas", () => {
+    expect(normalizePoint(100, 100, 0, 0)).toEqual({ x: 0, y: 0 });
+  });
+});

--- a/src/components/Whiteboard/coords.ts
+++ b/src/components/Whiteboard/coords.ts
@@ -1,0 +1,23 @@
+import { Point } from "./types";
+
+// Convert a canvas-pixel point to a resolution-independent fraction (0..1),
+// so strokes land in the same relative position on canvases of any size.
+export const normalizePoint = (
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): Point => ({
+  x: width > 0 ? x / width : 0,
+  y: height > 0 ? y / height : 0,
+});
+
+// Convert a normalized fraction back to pixels for the current canvas size.
+export const denormalizePoint = (
+  point: Point,
+  width: number,
+  height: number
+): Point => ({
+  x: point.x * width,
+  y: point.y * height,
+});

--- a/src/components/Whiteboard/types.ts
+++ b/src/components/Whiteboard/types.ts
@@ -31,6 +31,8 @@ export type WhiteboardEvent = {
     tool?: ToolType;
 
     strokeId?: string;
+
+    normalized?: boolean;
   };
 
   created_at?: string;


### PR DESCRIPTION
## Summary

The whiteboard captured, broadcast, and persisted stroke points as raw pixels relative to each client's own canvas, so participants with different canvas sizes saw strokes at different positions. This normalizes points to fractions of the canvas size and denormalizes on draw.

## Changes

- `coords.ts`: pure `normalizePoint` / `denormalizePoint` helpers.
- `Canvas.tsx`: capture normalized fractions in `getCoordinates`; denormalize in `drawEvent` using the local canvas size; tag emitted draw events with `normalized: true`.
- `types.ts`: add a `normalized` flag to the event payload.
- `coords.test.ts`: unit tests for the transform.

Backward compatible: already-persisted raw-pixel events have no `normalized` flag and keep drawing verbatim.

## Verification

- Unit test: a point at 90% across a 900px canvas denormalizes to 90% across a 500px canvas (450px); a same-size round trip returns the original pixel.
- Typecheck: no new type errors versus base.
- The visual multi-client rendering is not covered by an automated test (jsdom does not render canvas); the transform and wiring are covered by the unit test and typecheck.

## Related

Fixes #1663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Whiteboard strokes now use resolution-independent (normalized) coordinates for consistent playback.
  * Strokes preserve relative positioning across different canvas sizes and after resizing.

* **Bug Fixes**
  * Fixed misaligned replayed strokes when canvas dimensions differ between sessions.

* **Tests**
  * Added unit tests for coordinate normalization/denormalization, including canvas resize behavior and zero-dimension safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->