### PR TITLE
fix(whiteboard): isolate strokes per id so concurrent drawing does not corrupt the canvas

### DIFF
--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -3,9 +3,11 @@ import { useEffect, useRef, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/useAuth";
 import {
+  Point,
   ToolType,
   WhiteboardEvent,
 } from "./types";
+import { nextSegment } from "./strokePath";
 
 type Props = {
   roomId: string;
@@ -22,6 +24,8 @@ export default function Canvas({ roomId }: Props) {
   const strokesRef = useRef<WhiteboardEvent[]>([]);
 
   const currentStrokeId = useRef<string | null>(null);
+
+  const lastPointRef = useRef<Map<string, Point>>(new Map());
 
   const { user } = useAuth();
 
@@ -72,37 +76,26 @@ export default function Canvas({ roomId }: Props) {
   ) => {
     if (event.type === "clear") {
       ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+      lastPointRef.current.clear();
       return;
     }
 
-    const point = event.payload.point;
+    // Draw isolated per-stroke segments so interleaved events never cross strokes.
+    const segment = nextSegment(event, lastPointRef.current);
 
-    if (!point) return;
+    if (!segment) return;
 
-    const drawColor =
+    ctx.strokeStyle =
       event.payload.tool === "eraser"
         ? "#020617"
         : event.payload.color || "#ffffff";
 
-    ctx.strokeStyle = drawColor;
-
     ctx.lineWidth = event.payload.lineWidth || 3;
 
-    if (event.type === "draw-start") {
-      ctx.beginPath();
-
-      ctx.moveTo(point.x, point.y);
-    }
-
-    if (event.type === "draw-move") {
-      ctx.lineTo(point.x, point.y);
-
-      ctx.stroke();
-    }
-
-    if (event.type === "draw-end") {
-      ctx.closePath();
-    }
+    ctx.beginPath();
+    ctx.moveTo(segment.from.x, segment.from.y);
+    ctx.lineTo(segment.to.x, segment.to.y);
+    ctx.stroke();
   };
 
   const replayCanvas = () => {
@@ -111,6 +104,7 @@ export default function Canvas({ roomId }: Props) {
     if (!ctx) return;
 
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+    lastPointRef.current.clear();
 
     for (const event of strokesRef.current) {
       drawEvent(ctx, event);
@@ -348,6 +342,8 @@ export default function Canvas({ roomId }: Props) {
     ctx.canvas.width,
     ctx.canvas.height
   );
+
+  lastPointRef.current.clear();
 
   strokesRef.current = [];
 

--- a/src/components/Whiteboard/strokePath.test.ts
+++ b/src/components/Whiteboard/strokePath.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { nextSegment } from "./strokePath";
+import { Point, WhiteboardEvent } from "./types";
+
+const ev = (type: WhiteboardEvent["type"], strokeId?: string, point?: Point): WhiteboardEvent => ({
+  type,
+  payload: { strokeId, point },
+});
+
+describe("nextSegment concurrent stroke isolation", () => {
+  it("connects each move to its own stroke, not to an interleaved stroke", () => {
+    const last = new Map<string, Point>();
+
+    // Stroke A starts and moves.
+    expect(nextSegment(ev("draw-start", "A", { x: 10, y: 10 }), last)).toBeNull();
+    expect(nextSegment(ev("draw-move", "A", { x: 20, y: 20 }), last)).toEqual({
+      from: { x: 10, y: 10 },
+      to: { x: 20, y: 20 },
+    });
+
+    // Stroke B starts in the middle (the interleaving that corrupted the shared path).
+    expect(nextSegment(ev("draw-start", "B", { x: 200, y: 200 }), last)).toBeNull();
+
+    // Stroke A's next move must connect from A's own last point (20,20), not B's start.
+    expect(nextSegment(ev("draw-move", "A", { x: 30, y: 30 }), last)).toEqual({
+      from: { x: 20, y: 20 },
+      to: { x: 30, y: 30 },
+    });
+
+    // Stroke B's move connects from B's own start.
+    expect(nextSegment(ev("draw-move", "B", { x: 210, y: 210 }), last)).toEqual({
+      from: { x: 200, y: 200 },
+      to: { x: 210, y: 210 },
+    });
+  });
+
+  it("a move with no prior start draws a zero-length segment (a dot)", () => {
+    const last = new Map<string, Point>();
+    expect(nextSegment(ev("draw-move", "C", { x: 5, y: 5 }), last)).toEqual({
+      from: { x: 5, y: 5 },
+      to: { x: 5, y: 5 },
+    });
+  });
+
+  it("draw-end clears the stroke so a later reuse does not connect to stale points", () => {
+    const last = new Map<string, Point>();
+    nextSegment(ev("draw-start", "A", { x: 1, y: 1 }), last);
+    nextSegment(ev("draw-move", "A", { x: 2, y: 2 }), last);
+    expect(nextSegment(ev("draw-end", "A"), last)).toBeNull();
+    expect(last.has("A")).toBe(false);
+  });
+});

--- a/src/components/Whiteboard/strokePath.ts
+++ b/src/components/Whiteboard/strokePath.ts
@@ -1,0 +1,31 @@
+import { Point, WhiteboardEvent } from "./types";
+
+export type StrokeSegment = { from: Point; to: Point };
+
+// Compute the line segment to draw for a whiteboard event, tracking the last
+// point per strokeId so interleaved events from concurrent authors never
+// connect across different strokes.
+export const nextSegment = (
+  event: WhiteboardEvent,
+  lastPoints: Map<string, Point>
+): StrokeSegment | null => {
+  const strokeId = event.payload.strokeId;
+
+  if (event.type === "draw-end") {
+    if (strokeId) lastPoints.delete(strokeId);
+    return null;
+  }
+
+  const point = event.payload.point;
+  if (!point) return null;
+
+  if (event.type === "draw-start") {
+    if (strokeId) lastPoints.set(strokeId, point);
+    return null;
+  }
+
+  // draw-move
+  const prev = strokeId ? lastPoints.get(strokeId) : undefined;
+  if (strokeId) lastPoints.set(strokeId, point);
+  return { from: prev ?? point, to: point };
+};


### PR DESCRIPTION
## Summary

`drawEvent` relied on the single shared canvas path, so a remote `draw-start` arriving mid-stroke reset the path and the next local `draw-move` drew a stray line from the other stroke's point. This isolates strokes per `strokeId` and draws discrete segments.

## Changes

- `strokePath.ts`: pure `nextSegment` helper that tracks the last point per `strokeId` and returns the segment to draw.
- `Canvas.tsx`: `drawEvent` draws isolated per-stroke segments; reset the per-stroke state on replay and clear.
- `strokePath.test.ts`: unit tests for interleaved strokes.

Round line caps keep the discrete segments visually identical to a continuous stroke.

## Verification

- Unit test: with strokes A and B interleaved, A's move after B's `draw-start` connects from A's own last point (20,20), not B's start (200,200). A first move with no start draws a dot; `draw-end` clears the stroke.
- Typecheck: no new type errors versus base.
- The visual multi-client rendering is not covered by an automated test (jsdom does not render canvas); the segment logic and wiring are covered by the unit test and typecheck.

## Note

This touches the same `drawEvent` function as the coordinate-normalization fix (#1663 / branch `fix/whiteboard-coordinate-normalization`). If both are merged, a small rebase is needed; the two changes compose cleanly (normalize the point, then feed it through `nextSegment`).

## Related

Fixes #1664
