### PR TITLE
perf(chat): remove duplicate profiles query on the chat user list

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -18,22 +18,6 @@ type Profile = {
   avatar_url?: string | null;
 };
 
-type UserRow = Profile;
-
-const mergeUsers = (profiles: Profile[], users: UserRow[]) => {
-  const map = new Map<string, Profile>();
-
-  for (const user of users) {
-    map.set(user.id, user);
-  }
-
-  for (const profile of profiles) {
-    map.set(profile.id, profile);
-  }
-
-  return Array.from(map.values());
-};
-
 type ChatMessage = {
   id: string;
   sender_id: string | null;
@@ -179,28 +163,17 @@ const Chat = () => {
     const loadUsers = async () => {
       setLoadingUsers(true);
 
-      const [{ data: profileData }, { data: userData }] = await Promise.all([
-        supabase
-          .from("profiles")
-          .select("*")
-          .neq("id", currentUser.id)
-          .order("name", { ascending: true })
-          .limit(100),
-        supabase
-          .from("profiles")
-          .select("*")
-          .neq("id", currentUser.id)
-          .order("name", { ascending: true })
-          .limit(100),
-      ]);
+      const { data: profileData } = await supabase
+        .from("profiles")
+        .select("*")
+        .neq("id", currentUser.id)
+        .order("name", { ascending: true })
+        .limit(100);
 
-      const mergedUsers = mergeUsers(
-        (profileData ?? []) as Profile[],
-        (userData ?? []) as UserRow[]
-      );
+      const nextUsers = (profileData ?? []) as Profile[];
 
-      setUsers(mergedUsers);
-      setSelectedUser((current) => current ?? mergedUsers[0] ?? null);
+      setUsers(nextUsers);
+      setSelectedUser((current) => current ?? nextUsers[0] ?? null);
 
       setLoadingUsers(false);
     };


### PR DESCRIPTION
## Summary

The `/chat` page fetched its user list with two byte-identical `profiles` queries via `Promise.all`, then merged and deduped them. This queries `profiles` once and removes the now-unnecessary merge, matching how the same pattern was fixed for the Messages hook (#1180 / PR #1194).

## Changes

- `Chat.tsx`: single `profiles` query for the user list; remove the redundant `mergeUsers` helper and the `UserRow` alias.

## Verification

- Typecheck: no new type errors versus base.
- Behavior is unchanged: the merge only deduplicated by id, which a single primary-key-keyed query already guarantees.

## Related

Fixes #1665
