### PR TITLE
fix(sessions): clear messages when switching sessions

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -96,9 +96,12 @@ export function useSessions(user: any) {
   // - sessionSummary: without this, a summary generated for a previous
   //   video session can keep showing after switching to a different
   //   session, making it look like it belongs to the new one.
+  // - messages: without this, the previous session's thread stays rendered
+  //   for the whole fetch round-trip after switching.
   useEffect(() => {
     setParticipantCount(1);
     setSessionSummary(null);
+    setMessages([]);
   }, [selectedSession]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Switching the selected session kept the previous session's messages rendered until the new fetch resolved, because the per-session reset effect cleared `participantCount` and `sessionSummary` but not `messages`. This clears `messages` in the same effect.

## Changes

- `useSessions.ts`: add `setMessages([])` to the per-session reset effect.

## Verification

- Typecheck: no new type errors versus base.
- The fix mirrors the sibling resets already in this effect for participant count and AI summary.

## Related

Fixes #1666
