### PR TITLE
fix(mentor): enforce mentorship-type selection before submitting the application

### DIFF
--- a/src/components/mentor/MentorForm.tsx
+++ b/src/components/mentor/MentorForm.tsx
@@ -103,6 +103,10 @@ export default function MentorForm() {
     return formData.mentorship_types.length > 0;
   };
   const handleSubmit = async () => {
+    if (!validateMentorship()) {
+      setError("Please select at least one mentorship type");
+      return;
+    }
     setLoading(true);
     setError("");
     let isTimeout = false;
@@ -402,10 +406,6 @@ export default function MentorForm() {
                 }
                 if (step === 2 && !validateExperience()) {
                   setError("Please fill GitHub and LinkedIn profiles");
-                  return;
-                }
-                if (step === 3 && !validateMentorship()) {
-                  setError("Please select at least one mentorship type");
                   return;
                 }
                 setError("");


### PR DESCRIPTION
## Summary

The mentor application form never enforced the mentorship-type selection: the `validateMentorship()` check lived in an unreachable branch of the Continue button (only rendered when `step < 3`), while the Submit button on the last step called `handleSubmit` directly. This enforces the check in `handleSubmit` and removes the dead branch.

## Changes

- `MentorForm.tsx`: early-return in `handleSubmit` when no mentorship type is selected (reusing the existing error message); remove the unreachable `step === 3` branch from the Continue button.

## Verification

- Typecheck: no new type errors versus base.
- The fix matches the per-step validation pattern used for the other steps.
- No component test was added: the form has no existing tests and a behavioral test would require driving all four steps and mocking the Supabase auth, skills, and mentors calls, which is disproportionate to a validation-guard fix.

## Related

Fixes #1667
