### PR TITLE
[GSSoC'26] fix(#1486): add mentor_id filter and fix status filter in MentorDashboard

### DIFF
--- a/src/pages/MentorDashboard.tsx
+++ b/src/pages/MentorDashboard.tsx
@@ -73,7 +73,8 @@ const MentorDashboard = () => {
         const { data: sessionData } = await supabase
           .from("sessions")
           .select("id,title,scheduled_at,duration_minutes,status")
-          .in("status", ["upcoming", "scheduled", "live"])
+          .eq("status", "scheduled")
+          .eq("mentor_id", user.id)
           .limit(4);
 
         if (sessionData) {


### PR DESCRIPTION
## Description

- Added `.eq("mentor_id", user.id)` filter to sessions query in MentorDashboard
- Changed status filter from `.in("status", ["upcoming", "scheduled", "live"])` to `.eq("status", "scheduled")`
- Previously the query showed sessions from ALL mentors (privacy issue) and used a broader status filter

## Files Changed

- `src/pages/MentorDashboard.tsx`: Fixed session query filters

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## Testing & Verification

- MentorDashboard now shows only the current mentor's scheduled sessions
- No privacy leak to other mentors' sessions

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1486