### PR TITLE
[GSSoC'26] fix(#1485): fix inconsistent session status values in frontend + drop old DB constraint

### DIFF
--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -10,7 +10,7 @@ const Notifications = () => {
       const { data, error } = await (supabase as any)
         .from("sessions")
         .select("*")
-        .eq("status", "upcoming")
+        .eq("status", "scheduled")
         .limit(50);
 
       if (!error) setAlerts(data);

--- a/supabase/migrations/20260706000000_drop_old_status_check.sql
+++ b/supabase/migrations/20260706000000_drop_old_status_check.sql
@@ -1,0 +1,15 @@
+DO $$
+BEGIN
+  -- Drop the auto-generated CHECK constraint from the original bootstrap migration
+  -- which allowed only ('upcoming', 'joined', 'completed'). The session scheduling
+  -- migration (20260527120000_session_scheduling.sql) added a new constraint allowing
+  -- ('scheduled', 'live', 'ended'), but never dropped the original. Both constraints
+  -- on the same column make INSERT/UPDATE impossible since no single value satisfies both.
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'sessions_status_check1'
+      AND conrelid = 'sessions'::regclass
+  ) THEN
+    ALTER TABLE sessions DROP CONSTRAINT sessions_status_check1;
+  END IF;
+END $$;


### PR DESCRIPTION
## Description

- Fixed `Notifications.tsx` line 13: changed `status = "upcoming"` to `status = "scheduled"`
- Added migration `20260706000000_drop_old_status_check.sql` to drop the original CHECK constraint that allowed only `('upcoming', 'joined', 'completed')`, which conflicted with the newer constraint allowing `('scheduled', 'live', 'ended')`

## Files Changed

- `src/pages/Notifications.tsx`: Fixed status filter from "upcoming" to "scheduled"
- `supabase/migrations/20260706000000_drop_old_status_check.sql`: New migration to drop old CHECK constraint

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1485