### PR TITLE
[GSSoC'26] fix(#1484): add upper bound validation for session custom duration

### DIFF
--- a/src/hooks/useCreateSession.ts
+++ b/src/hooks/useCreateSession.ts
@@ -17,7 +17,10 @@ export const formSchema = z
     date: z.date({ required_error: "A date is required." }),
     time: z.string().min(1, "Time is required."),
     durationPreset: z.number().optional(),
-    durationCustom: z.string().optional(),
+    durationCustom: z.string().optional().refine(
+      (val) => !val || (parseInt(val) >= 15 && parseInt(val) <= 480),
+      "Duration must be between 15 and 480 minutes"
+    ),
     seatLimit: z.string().optional(),
   })
   .refine(
@@ -62,7 +65,9 @@ export function useCreateSession({ onSuccess, setOpen }: UseCreateSessionProps) 
   const resolveDurationMinutes = useCallback((values: FormValues): number => {
     if (useCustom) {
       const c = parseInt(values.durationCustom ?? "", 10);
-      return isNaN(c) || c < 15 ? 60 : c;
+      if (isNaN(c) || c < 15) return 60;
+      if (c > 480) return 480;
+      return c;
     }
     return selectedPreset;
   }, [useCustom, selectedPreset]);


### PR DESCRIPTION
## Description

- Added upper bound check (480 minutes max) to `resolveDurationMinutes` in `useCreateSession.ts`
- Added zod validation rule for `durationCustom` field to validate range client-side
- Previously, users could enter arbitrary large values (e.g., 100000) that would be rejected by the DB constraint with an opaque error

## Files Changed

- `src/hooks/useCreateSession.ts`: Added upper bound clamping and zod validation

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1484