### PR TITLE
[GSSoC'26] fix(#1481): change Connect with Peer notification type from 'connection_request' to 'system'

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -220,7 +220,7 @@ const Dashboard = () => {
     }
     const { error: notifError } = await (supabase as any).from("notifications").insert({
       user_id: peerId,
-      type: "connection_request",
+      type: "system",
       body: `${profile?.name || "Someone"} wants to connect with you!`,
     });
     if (notifError) {


### PR DESCRIPTION
## Description

- Changed `Dashboard.tsx` handleConnect function: `type: "connection_request"` → `type: "system"`
- The `notification_type` PostgreSQL enum only allows `message`, `session_reminder`, `announcement`, and `system` — `connection_request` was never in the enum
- The Discover.tsx page already uses `type: "system"` for the same operation, making this consistent

## Files Changed

- `src/pages/Dashboard.tsx`: Fixed notification type in handleConnect

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

## GSSoC 2026 Compliance

This contribution was prepared with AI assistance and manually reviewed before submission.

Closes #1481