### PR TITLE
fix: prevent FOUC on theme load by setting theme class in head script

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,16 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <script>
+      (function() {
+        try {
+          var theme = localStorage.getItem('app-theme') || 'default';
+          document.documentElement.classList.add('theme-' + theme);
+        } catch (e) {
+          document.documentElement.classList.add('theme-default');
+        }
+      })();
+    </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/placeholder.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
Fixes #1219

## Problem
The user's selected theme (`app-theme` from localStorage) was only being applied inside a `useEffect` in `ThemeProvider`. Since effects run after the initial render/paint, the app would briefly render with the default theme before switching to the user's saved theme — causing a visible flash on every page load/refresh.

## Fix
Added a small synchronous script directly in `index.html`'s `<head>`, before any stylesheets or app scripts load. It reads `app-theme` from localStorage and applies the matching `theme-*` class to the `<html>` element immediately, before the browser paints anything.

```js
(function() {
  try {
    var theme = localStorage.getItem('app-theme') || 'default';
    document.documentElement.classList.add('theme-' + theme);
  } catch (e) {
    document.documentElement.classList.add('theme-default');
  }
})();
```

This mirrors the existing logic in `ThemeProvider`'s `useEffect`, just moved earlier so it runs before first paint instead of after.

## Testing
- Set each theme (`purple`, `blue`, `green`, `orange`, `black-white`) via localStorage and hard-refreshed the page
- Confirmed no flash of the default theme before the correct theme renders
- Verified default/no-consent case still falls back correctly to `theme-default`

## Notes
- No changes made to `ThemeProvider` itself — existing logic still works as-is for runtime theme switching
- No changes to consent handling; script only reads an existing value if present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The app now automatically applies the saved theme when the page loads.
  * If theme settings can’t be read, the default theme is used instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->