### PR TITLE
test: add Playwright E2E tests for signup, login, dashboard, and chat (#1217)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 dist/
 .env
+playwright-report/
+test-results/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,10 +1,23 @@
-import { createLovableConfig } from "lovable-agent-playwright-config/config";
+import { defineConfig, devices } from '@playwright/test';
 
-export default createLovableConfig({
-  // Add your custom playwright configuration overrides here
-  // Example:
-  // timeout: 60000,
-  // use: {
-  //   baseURL: 'http://localhost:3000',
-  // },
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  retries: 0,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:8080',
+    reuseExistingServer: true,
+  },
 });

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('redirects unauthenticated user to login', async ({ page }) => {
+  await page.goto('/chat');
+  await expect(page).toHaveURL(/\/login/);
+});

--- a/tests/e2e/dashboard.spec.ts
+++ b/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('redirects unauthenticated user to login', async ({ page }) => {
+  await page.goto('/dashboard');
+  await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
+});

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test('shows validation errors on empty submit', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'Log In' }).click();
+
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Password is required')).toBeVisible();
+});
+
+test('shows error on invalid credentials', async ({ page }) => {
+  await page.goto('/login');
+
+  await page.getByPlaceholder('Email Address').fill('nonexistent@example.com');
+  await page.getByPlaceholder('Password').fill('wrongpassword');
+  await page.getByRole('button', { name: 'Log In' }).click();
+
+  await expect(page.getByRole('alert')).toBeVisible({ timeout: 10000 });
+});

--- a/tests/e2e/signup.spec.ts
+++ b/tests/e2e/signup.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('shows validation errors on empty submit', async ({ page }) => {
+  await page.goto('/signup');
+  await page.getByRole('button', { name: 'Sign Up' }).click();
+
+  await expect(page.getByText('Name is required')).toBeVisible();
+  await expect(page.getByText('Email is required')).toBeVisible();
+  await expect(page.getByText('Password is required')).toBeVisible();
+});
+
+test('submits form and shows confirmation toast', async ({ page }) => {
+  await page.goto('/signup');
+
+  await page.getByPlaceholder('Full Name').fill('Test User');
+  await page.getByPlaceholder('Email').fill(`test${Date.now()}@example.com`);
+  await page.getByPlaceholder('Password', { exact: true }).fill('Test1234!');
+  await page.getByPlaceholder('Confirm Password').fill('Test1234!');
+
+  await page.getByRole('button', { name: 'Sign Up' }).click();
+
+  await expect(page.getByText('Account created!')).toBeVisible({ timeout: 10000 });
+});


### PR DESCRIPTION
Fixes #1217

## Summary
Added Playwright E2E test coverage for the four critical user flows requested in the issue: signup, login, dashboard access, and chat access.

## What's covered
- **Signup**: validation errors on empty submit, and confirmation toast on valid submission
- **Login**: validation errors on empty submit, and error message on invalid credentials
- **Dashboard**: unauthenticated users are redirected to `/login`
- **Chat**: unauthenticated users are redirected to `/login`

## Notes
- Dashboard and Chat tests cover the unauthenticated redirect path, since testing the full authenticated flow would require seeded Supabase test accounts that aren't available to me as an outside contributor. Happy to extend these once a test Supabase project/test credentials are available.
- Added `playwright-report/` and `test-results/` to `.gitignore` since these are local test output, not source files.

## Testing
Ran locally via `npx playwright test` with a real `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` set — all 6 tests pass.