### PR TITLE
fix: retry failed push notifications after claim

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import webpush from "web-push";
 import { sanitizeNotificationActionUrl } from "../utils/notificationActionUrl.js";
+import { collectExpiredSubscriptionIds } from "../utils/pushDeliveryCleanup.js";
 
 const getSupabaseClient = () => {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
@@ -13,31 +14,50 @@ const getSupabaseClient = () => {
   return createClient(supabaseUrl, serviceRoleKey);
 };
 
+// After this long, an unfinished claim is considered abandoned (the process
+// crashed, or every subscription failed for this notification) and becomes
+// eligible to be reclaimed and retried by a future cron run.
+export const PUSH_CLAIM_TTL_MS = 5 * 60 * 1000;
+
+// After this many failed attempts, stop retrying and stamp push_failed_at so
+// the row is permanently excluded from future claim queries.
+export const MAX_PUSH_ATTEMPTS = 5;
+
 /*
  * dispatchPushNotifications
  *
  * Bulk-delivers pending push notifications to subscribed browsers.
  *
- * Batch cap: fetches at most 100 rows per invocation (oldest-first). A
- * notification backlog drains at 100 rows/minute assuming a 1-minute cron
- * schedule. If queue depth grows faster than this, trigger additional manual
- * runs (after the 60-second cooldown) or mark stale rows sent via SQL — see
- * docs/smart-notifications.md → "Manual drain procedure".
+ * Batch cap: fetches at most 100 rows per invocation. A notification backlog
+ * drains at 100 rows/minute assuming a 1-minute cron schedule. If queue depth
+ * grows faster than this, trigger additional manual runs (after the
+ * PUSH_CLAIM_TTL_MS cooldown, if the rows are currently claimed) or mark
+ * stale rows sent via SQL — see docs/smart-notifications.md → "Manual drain
+ * procedure".
+ *
+ * Retry / claim-expiry (fixes #1676): a row is claimable when it has never
+ * been sent, hasn't permanently failed, and is either unclaimed or its claim
+ * is older than PUSH_CLAIM_TTL_MS. Previously a claimed row that failed for
+ * every subscription kept push_claimed_at set forever with no push_sent_at,
+ * so it was claimed exactly once and never retried. Now:
+ *   - a fully-failed attempt increments push_attempts and leaves the row
+ *     claimed; it becomes reclaimable once the claim ages past the TTL.
+ *   - once push_attempts reaches MAX_PUSH_ATTEMPTS, push_failed_at is set and
+ *     the row is permanently excluded from the claim query.
+ *   - a notification with zero subscriptions fails fast (push_failed_at set
+ *     immediately) since retrying can never help.
  *
  * Failure absorption: Promise.allSettled is used intentionally so that a
  * single failing push (network error, expired subscription) does not block
  * delivery to other recipients. The `sent` vs `processed` delta in the
- * response reflects failures. Each notification row is stamped with
- * `push_sent_at` regardless of delivery outcome — there is no automatic retry
- * for failed pushes.
+ * response reflects failures.
  *
  * Subscription expiry (HTTP 410 / 404): the web-push library returns a
  * rejection with `statusCode 410` (subscription expired) or `404` (endpoint
  * not found) when a browser unsubscribes or revokes permission. These
- * subscriptions should be deleted from `push_subscriptions` to avoid
- * accumulating dead endpoints. NOTE: this cleanup is currently implemented in
- * sendPushNotification (notificationController.js) but NOT here. A future
- * improvement should add equivalent cleanup to this handler.
+ * subscriptions are deleted from `push_subscriptions` via the shared
+ * collectExpiredSubscriptionIds helper (also used by sendPushNotification in
+ * notificationController.js) to avoid accumulating dead endpoints.
  *
  * @route   POST /api/cron/dispatch-notifications
  * @access  CRON_SECRET (Authorization: Bearer)
@@ -57,14 +77,20 @@ export const dispatchPushNotifications = async (req, res, next) => {
     webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
     const supabase = getSupabaseClient();
 
-    // Atomically claim a batch of pending notifications so concurrent invocations
-    // cannot double-deliver the same notification (race-condition prevention).
-    const claimedAt = new Date().toISOString();
+    // Atomically claim a batch of pending notifications so concurrent
+    // invocations cannot double-deliver the same notification, while also
+    // allowing rows whose previous claim has expired to be reclaimed.
+    const claimedAt = new Date();
+    const claimExpiryThreshold = new Date(claimedAt.getTime() - PUSH_CLAIM_TTL_MS).toISOString();
+
     const { data: notifications, error: claimError } = await supabase
       .from("notifications")
-      .update({ push_claimed_at: claimedAt })
-      .is("push_claimed_at", null)
-      .select("id,user_id,title,body,action_url");
+      .update({ push_claimed_at: claimedAt.toISOString() })
+      .is("push_sent_at", null)
+      .is("push_failed_at", null)
+      .or(`push_claimed_at.is.null,push_claimed_at.lt.${claimExpiryThreshold}`)
+      .select("id,user_id,title,body,action_url,push_attempts")
+      .limit(100);
 
     if (claimError) {
       return res.status(500).json({ error: claimError.message });
@@ -78,7 +104,7 @@ export const dispatchPushNotifications = async (req, res, next) => {
     const userIds = [...new Set(notifications.map((n) => n.user_id))];
     const { data: allSubscriptions, error: subError } = await supabase
       .from("push_subscriptions")
-      .select("user_id,endpoint,p256dh,auth")
+      .select("id,user_id,endpoint,p256dh,auth")
       .in("user_id", userIds);
 
     if (subError) {
@@ -105,6 +131,7 @@ export const dispatchPushNotifications = async (req, res, next) => {
     }
 
     let sent = 0;
+    const expiredSubscriptionIds = new Set();
 
     for (const notification of notifications) {
       const subscriptions = subsByUser[notification.user_id] || [];
@@ -128,18 +155,45 @@ export const dispatchPushNotifications = async (req, res, next) => {
         )
       );
 
+      for (const id of collectExpiredSubscriptionIds(subscriptions, pushResults)) {
+        expiredSubscriptionIds.add(id);
+      }
+
       const anySucceeded = pushResults.some((r) => r.status === "fulfilled");
       sent += pushResults.filter((r) => r.status === "fulfilled").length;
 
-      // Only stamp push_sent_at when at least one push succeeded so a
-      // fully-failed notification remains retryable — but push_claimed_at
-      // already prevents concurrent re-delivery regardless.
       if (anySucceeded) {
+        // push_sent_at now non-null → excluded from all future claim queries.
         await supabase
           .from("notifications")
           .update({ push_sent_at: new Date().toISOString() })
           .eq("id", notification.id);
+      } else if (subscriptions.length === 0) {
+        // No subscriptions to deliver to at all — retrying can never help,
+        // so give up immediately instead of occupying a claim/retry cycle.
+        await supabase
+          .from("notifications")
+          .update({ push_failed_at: new Date().toISOString() })
+          .eq("id", notification.id);
+      } else {
+        // Every subscription failed for this attempt. Record it; give up
+        // permanently once MAX_PUSH_ATTEMPTS is reached, otherwise leave
+        // push_claimed_at as-is — it becomes reclaimable once it ages past
+        // PUSH_CLAIM_TTL_MS.
+        const attempts = (notification.push_attempts || 0) + 1;
+        const update =
+          attempts >= MAX_PUSH_ATTEMPTS
+            ? { push_attempts: attempts, push_failed_at: new Date().toISOString() }
+            : { push_attempts: attempts };
+        await supabase.from("notifications").update(update).eq("id", notification.id);
       }
+    }
+
+    if (expiredSubscriptionIds.size > 0) {
+      await supabase
+        .from("push_subscriptions")
+        .delete()
+        .in("id", [...expiredSubscriptionIds]);
     }
 
     res.json({ sent, processed: notifications.length });
@@ -264,7 +318,7 @@ export const sendMentorshipCheckinReminders = async (req, res, next) => {
     for (const m of milestones || []) {
       const path = m.mentorship_paths;
       if (!path) continue;
-      
+
       const isOverdue = new Date(m.due_date) < now;
       const title = isOverdue ? "Milestone Overdue" : "Milestone Due Soon";
       const type = isOverdue ? "mentorship_reminder_overdue" : "mentorship_reminder";
@@ -279,7 +333,7 @@ export const sendMentorshipCheckinReminders = async (req, res, next) => {
         entity_id: m.id,
         action_url: "/dashboard", // MentorDashboard
       });
-      
+
       // Notify mentee
       notifications.push({
         user_id: path.mentee_id,

--- a/backend/controllers/notificationController.js
+++ b/backend/controllers/notificationController.js
@@ -1,6 +1,7 @@
 import { createClient } from "@supabase/supabase-js";
 import webpush from "web-push";
 import { sanitizeNotificationActionUrl } from "../utils/notificationActionUrl.js";
+import { collectExpiredSubscriptionIds } from "../utils/pushDeliveryCleanup.js";
 
 const getSupabaseClient = () => {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
@@ -32,7 +33,6 @@ export const sendPushNotification = async (req, res, next) => {
       return res.status(400).json({
         error: "user_id, title, and body are required",
       });
-      
     }
     if (
       typeof user_id !== "string" ||
@@ -93,20 +93,16 @@ export const sendPushNotification = async (req, res, next) => {
         )
       )
     );
-    await Promise.all(
-      results.map(async (result, index) => {
-        if (
-          result.status === "rejected" &&
-          (result.reason?.statusCode === 404 ||
-            result.reason?.statusCode === 410)
-          ) {
-            await supabase
-            .from("push_subscriptions")
-            .delete()
-            .eq("id", subscriptions[index].id);
-          }
-        })
-      );
+
+    // Shared with the cron dispatch path (fixes #1676: cleanup used to only
+    // live here, not in dispatchPushNotifications).
+    const expiredIds = collectExpiredSubscriptionIds(subscriptions, results);
+    if (expiredIds.size > 0) {
+      await supabase
+        .from("push_subscriptions")
+        .delete()
+        .in("id", [...expiredIds]);
+    }
 
     res.json({
       sent: results.filter((result) => result.status === "fulfilled").length,

--- a/backend/controllers/pushDeliveryCleanup.js
+++ b/backend/controllers/pushDeliveryCleanup.js
@@ -1,0 +1,22 @@
+// backend/utils/pushDeliveryCleanup.js
+//
+// Shared between cronController.js (dispatchPushNotifications) and
+// notificationController.js (sendPushNotification) so subscription cleanup
+// logic lives in exactly one place (fixes #1676 — cleanup previously only
+// existed in the single-notification path, not the cron/bulk path).
+
+// Given the subscriptions that were attempted and the Promise.allSettled
+// results in the same order, return the set of subscription ids that are
+// permanently dead (410 Gone / 404 Not Found) and should be deleted.
+export const collectExpiredSubscriptionIds = (subscriptions, pushResults) => {
+  const ids = new Set();
+  pushResults.forEach((result, index) => {
+    if (
+      result.status === "rejected" &&
+      (result.reason?.statusCode === 404 || result.reason?.statusCode === 410)
+    ) {
+      ids.add(subscriptions[index].id);
+    }
+  });
+  return ids;
+};

--- a/backend/tests/dispatchPushNotifications.test.js
+++ b/backend/tests/dispatchPushNotifications.test.js
@@ -2,18 +2,20 @@ import express from "express";
 import request from "supertest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// ─── Shared mutable state shared across both concurrent calls ────────────────
-let claimedIds = new Set();
+const PUSH_CLAIM_TTL_MS = 5 * 60 * 1000;
+const MAX_PUSH_ATTEMPTS = 5;
+
+// ─── Shared mutable state across mock DB calls ───────────────────────────────
 let dbRows = [];
+let subscriptionStore = []; // { id, user_id, endpoint, p256dh, auth }
+let endpointBehavior = {}; // endpoint -> "success" | "fail" | "expired"
 
 const makeSupabaseMock = () => {
-  // Returns a chainable builder that mimics the Supabase JS client.
   const builder = (table) => {
     let _filters = {};
-    let _isFilters = {};
     let _operation = null;
     let _payload = null;
-    let _selectCols = null;
+    let _isOrClaim = false;
 
     const chain = {
       update(payload) {
@@ -21,12 +23,14 @@ const makeSupabaseMock = () => {
         _payload = payload;
         return chain;
       },
-      select(cols) {
-        _selectCols = cols;
+      delete() {
+        _operation = "delete";
         return chain;
       },
-      is(col, val) {
-        _isFilters[col] = val;
+      select() {
+        return chain;
+      },
+      is() {
         return chain;
       },
       eq(col, val) {
@@ -37,45 +41,66 @@ const makeSupabaseMock = () => {
         _filters[`${col}__in`] = vals;
         return chain;
       },
+      or() {
+        _isOrClaim = true;
+        return chain;
+      },
       order() {
         return chain;
       },
       limit() {
         return chain;
       },
-      // Resolve the chain
       then(resolve) {
-        if (table === "notifications" && _operation === "update" && _isFilters["push_claimed_at"] === null) {
-          // Atomic claim: only return rows not yet claimed
-          const unclaimed = dbRows.filter(
-            (r) => r.push_sent_at == null && !claimedIds.has(r.id)
-          );
-          const batch = unclaimed.slice(0, 100);
-          batch.forEach((r) => claimedIds.add(r.id));
-          return resolve({ data: batch.map(r => ({ ...r })), error: null });
+        // Claim query: unsent, not permanently failed, and either unclaimed
+        // or claimed long enough ago that the claim has expired.
+        if (table === "notifications" && _operation === "update" && _isOrClaim) {
+          const now = Date.now();
+          const claimable = dbRows.filter((r) => {
+            if (r.push_sent_at != null) return false;
+            if (r.push_failed_at != null) return false;
+            if (r.push_claimed_at == null) return true;
+            return now - new Date(r.push_claimed_at).getTime() > PUSH_CLAIM_TTL_MS;
+          });
+          const batch = claimable.slice(0, 100);
+          batch.forEach((r) => {
+            r.push_claimed_at = _payload.push_claimed_at;
+          });
+          return resolve({ data: batch.map((r) => ({ ...r })), error: null });
         }
 
-        if (table === "notifications" && _operation === "update" && _filters["id__in"]) {
-          const ids = _filters["id__in"];
-          ids.forEach(id => claimedIds.delete(id));
+        // Rollback: release claim after a subscription-fetch error.
+        if (
+          table === "notifications" &&
+          _operation === "update" &&
+          _filters["id__in"] &&
+          _payload?.push_claimed_at === null
+        ) {
+          _filters["id__in"].forEach((id) => {
+            const row = dbRows.find((r) => r.id === id);
+            if (row) row.push_claimed_at = null;
+          });
           return resolve({ data: null, error: null });
         }
 
+        // Per-notification stamp: success / attempt increment / permanent failure.
         if (table === "notifications" && _operation === "update" && _filters["id"]) {
-          // push_sent_at stamp
           const row = dbRows.find((r) => r.id === _filters["id"]);
-          if (row) row.push_sent_at = _payload.push_sent_at;
+          if (row) Object.assign(row, _payload);
           return resolve({ data: null, error: null });
         }
 
-        if (table === "push_subscriptions") {
+        // Expired-subscription cleanup.
+        if (table === "push_subscriptions" && _operation === "delete" && _filters["id__in"]) {
+          const ids = new Set(_filters["id__in"]);
+          subscriptionStore = subscriptionStore.filter((s) => !ids.has(s.id));
+          return resolve({ data: null, error: null });
+        }
+
+        // Fetch subscriptions for claimed notifications.
+        if (table === "push_subscriptions" && !_operation) {
           const userIds = _filters["user_id__in"] || [];
-          const subs = userIds.map((uid) => ({
-            user_id: uid,
-            endpoint: `https://fcm.example.com/${uid}`,
-            p256dh: "p256dh_key",
-            auth: "auth_key",
-          }));
+          const subs = subscriptionStore.filter((s) => userIds.includes(s.user_id));
           return resolve({ data: subs, error: null });
         }
 
@@ -107,21 +132,25 @@ vi.mock("@supabase/supabase-js", () => ({
   },
 }));
 
-// Slow sendNotification (~150 ms) to widen the race window
 vi.mock("web-push", () => ({
   default: {
     setVapidDetails: vi.fn(),
-    sendNotification: vi.fn(
-      () => new Promise((resolve) => setTimeout(() => resolve({ statusCode: 201 }), 150))
-    ),
+    sendNotification: vi.fn((subscription) => {
+      const behavior = endpointBehavior[subscription.endpoint] || "success";
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          if (behavior === "success") resolve({ statusCode: 201 });
+          else if (behavior === "expired") reject({ statusCode: 410, message: "gone" });
+          else reject({ statusCode: 500, message: "push failed" });
+        }, 20);
+      });
+    }),
   },
 }));
 
 // ─── App fixture ─────────────────────────────────────────────────────────────
 const buildApp = async () => {
-  const { dispatchPushNotifications } = await import(
-    "../controllers/cronController.js"
-  );
+  const { dispatchPushNotifications } = await import("../controllers/cronController.js");
   const app = express();
   app.use(express.json());
   app.post("/dispatch", dispatchPushNotifications);
@@ -129,8 +158,20 @@ const buildApp = async () => {
   return app;
 };
 
-// ─── Tests ───────────────────────────────────────────────────────────────────
-describe("dispatchPushNotifications — race condition", () => {
+const seedRow = (overrides = {}) => ({
+  id: `notif-${Math.random()}`,
+  user_id: "user-1",
+  title: "Title",
+  body: "Body",
+  action_url: "/notifications",
+  push_sent_at: null,
+  push_claimed_at: null,
+  push_failed_at: null,
+  push_attempts: 0,
+  ...overrides,
+});
+
+describe("dispatchPushNotifications", () => {
   let app;
 
   beforeEach(async () => {
@@ -139,19 +180,10 @@ describe("dispatchPushNotifications — race condition", () => {
     vi.stubEnv("VAPID_PUBLIC_KEY", "vapid-public");
     vi.stubEnv("VAPID_PRIVATE_KEY", "vapid-private");
 
-    // Reset shared DB state
     forceSubscriptionError = false;
-    claimedIds = new Set();
-    dbRows = Array.from({ length: 5 }, (_, i) => ({
-      id: `notif-${i}`,
-      user_id: `user-${i}`,
-      title: `Title ${i}`,
-      body: `Body ${i}`,
-      action_url: "/notifications",
-      push_sent_at: null,
-      push_claimed_at: null,
-    }));
-
+    endpointBehavior = {};
+    dbRows = [];
+    subscriptionStore = [];
     app = await buildApp();
   });
 
@@ -161,85 +193,172 @@ describe("dispatchPushNotifications — race condition", () => {
     vi.resetModules();
   });
 
-  it("concurrent calls do not double-deliver: total sent === seeded count", async () => {
-    const [res1, res2] = await Promise.all([
-      request(app).post("/dispatch"),
-      request(app).post("/dispatch"),
-    ]);
+  describe("happy path", () => {
+    it("returns sent=N, processed=N for N seeded rows", async () => {
+      dbRows = [seedRow({ id: "notif-a", user_id: "user-a" })];
+      subscriptionStore = [{ id: "sub-a", user_id: "user-a", endpoint: "ep-a", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-a"] = "success";
 
-    expect(res1.status).toBe(200);
-    expect(res2.status).toBe(200);
+      const res = await request(app).post("/dispatch");
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ sent: 1, processed: 1 });
+      expect(dbRows[0].push_sent_at).not.toBeNull();
+    });
 
-    const totalSent = res1.body.sent + res2.body.sent;
-    const totalProcessed = res1.body.processed + res2.body.processed;
+    it("returns sent=0, processed=0 when no pending notifications exist", async () => {
+      dbRows = [];
+      const res = await request(app).post("/dispatch");
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ sent: 0, processed: 0 });
+    });
 
-    // Each of the 5 notifications should be dispatched exactly once
-    expect(totalProcessed).toBe(5);
-    // 5 notifications × 1 subscription each = 5 successful pushes
-    expect(totalSent).toBe(5);
+    it("sanitizes queued action_url values before sending push payloads", async () => {
+      dbRows = [seedRow({ id: "unsafe-notif", user_id: "user-unsafe", action_url: "https://example.com" })];
+      subscriptionStore = [{ id: "sub-1", user_id: "user-unsafe", endpoint: "ep-1", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-1"] = "success";
+
+      const res = await request(app).post("/dispatch");
+      expect(res.status).toBe(200);
+
+      const webpush = (await import("web-push")).default;
+      const payload = JSON.parse(webpush.sendNotification.mock.calls[0][1]);
+      expect(payload.action_url).toBe("/notifications");
+    });
   });
 
-  it("all rows have push_sent_at set after concurrent invocations", async () => {
-    await Promise.all([
-      request(app).post("/dispatch"),
-      request(app).post("/dispatch"),
-    ]);
+  describe("concurrency (race condition, issue #804)", () => {
+    it("concurrent calls do not double-deliver: total sent === seeded count", async () => {
+      dbRows = Array.from({ length: 5 }, (_, i) => seedRow({ id: `notif-${i}`, user_id: `user-${i}` }));
+      subscriptionStore = dbRows.map((r) => ({
+        id: `sub-${r.user_id}`,
+        user_id: r.user_id,
+        endpoint: `ep-${r.user_id}`,
+        p256dh: "k",
+        auth: "a",
+      }));
+      dbRows.forEach((r) => (endpointBehavior[`ep-${r.user_id}`] = "success"));
 
-    const unsent = dbRows.filter((r) => r.push_sent_at == null);
-    expect(unsent).toHaveLength(0);
+      const [res1, res2] = await Promise.all([
+        request(app).post("/dispatch"),
+        request(app).post("/dispatch"),
+      ]);
+
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+
+      const totalSent = res1.body.sent + res2.body.sent;
+      const totalProcessed = res1.body.processed + res2.body.processed;
+
+      expect(totalProcessed).toBe(5);
+      expect(totalSent).toBe(5);
+    });
   });
 
-  it("single call: returns sent=N, processed=N for N seeded rows", async () => {
-    const res = await request(app).post("/dispatch");
-    expect(res.status).toBe(200);
-    expect(res.body.processed).toBe(5);
-    expect(res.body.sent).toBe(5);
+  describe("failed delivery retry/expiry (issue #1676)", () => {
+    it("keeps a fully-failed notification claimed but does not immediately retry it", async () => {
+      dbRows = [seedRow({ id: "notif-fail", user_id: "user-fail" })];
+      subscriptionStore = [{ id: "sub-1", user_id: "user-fail", endpoint: "ep-fail", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-fail"] = "fail";
+
+      const res1 = await request(app).post("/dispatch");
+      expect(res1.body).toEqual({ sent: 0, processed: 1 });
+
+      const row = dbRows[0];
+      expect(row.push_sent_at).toBeNull();
+      expect(row.push_failed_at).toBeNull();
+      expect(row.push_attempts).toBe(1);
+      expect(row.push_claimed_at).not.toBeNull();
+
+      // Immediately re-running should NOT reclaim it (claim hasn't expired yet).
+      const res2 = await request(app).post("/dispatch");
+      expect(res2.body).toEqual({ sent: 0, processed: 0 });
+      expect(row.push_attempts).toBe(1);
+    });
+
+    it("retries a fully-failed notification once its claim has expired", async () => {
+      dbRows = [
+        seedRow({
+          id: "notif-expired-claim",
+          user_id: "user-fail",
+          push_attempts: 1,
+          push_claimed_at: new Date(Date.now() - PUSH_CLAIM_TTL_MS - 1000).toISOString(),
+        }),
+      ];
+      subscriptionStore = [{ id: "sub-1", user_id: "user-fail", endpoint: "ep-fail", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-fail"] = "fail";
+
+      const res = await request(app).post("/dispatch");
+      expect(res.body).toEqual({ sent: 0, processed: 1 });
+      expect(dbRows[0].push_attempts).toBe(2);
+      expect(dbRows[0].push_failed_at).toBeNull();
+    });
+
+    it("permanently gives up after MAX_PUSH_ATTEMPTS and stops reclaiming the row", async () => {
+      dbRows = [
+        seedRow({
+          id: "notif-give-up",
+          user_id: "user-fail",
+          push_attempts: MAX_PUSH_ATTEMPTS - 1,
+          push_claimed_at: new Date(Date.now() - PUSH_CLAIM_TTL_MS - 1000).toISOString(),
+        }),
+      ];
+      subscriptionStore = [{ id: "sub-1", user_id: "user-fail", endpoint: "ep-fail", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-fail"] = "fail";
+
+      const res1 = await request(app).post("/dispatch");
+      expect(res1.body).toEqual({ sent: 0, processed: 1 });
+      expect(dbRows[0].push_attempts).toBe(MAX_PUSH_ATTEMPTS);
+      expect(dbRows[0].push_failed_at).not.toBeNull();
+
+      // Even after the claim would have expired, it's excluded forever now.
+      dbRows[0].push_claimed_at = new Date(Date.now() - PUSH_CLAIM_TTL_MS - 1000).toISOString();
+      const res2 = await request(app).post("/dispatch");
+      expect(res2.body).toEqual({ sent: 0, processed: 0 });
+    });
+
+    it("marks a notification with no subscriptions as permanently failed immediately", async () => {
+      dbRows = [seedRow({ id: "notif-no-subs", user_id: "user-no-subs" })];
+      subscriptionStore = [];
+
+      const res = await request(app).post("/dispatch");
+      expect(res.body).toEqual({ sent: 0, processed: 1 });
+      expect(dbRows[0].push_failed_at).not.toBeNull();
+      expect(dbRows[0].push_attempts).toBe(0);
+    });
   });
 
-  it("returns sent=0, processed=0 when no pending notifications exist", async () => {
-    dbRows = []; // nothing to dispatch
-    const res = await request(app).post("/dispatch");
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ sent: 0, processed: 0 });
+  describe("subscription cleanup", () => {
+    it("deletes an expired (410) push subscription during dispatch, keeping the working one", async () => {
+      dbRows = [seedRow({ id: "notif-mixed", user_id: "user-mixed" })];
+      subscriptionStore = [
+        { id: "sub-good", user_id: "user-mixed", endpoint: "ep-good", p256dh: "k", auth: "a" },
+        { id: "sub-dead", user_id: "user-mixed", endpoint: "ep-dead", p256dh: "k", auth: "a" },
+      ];
+      endpointBehavior["ep-good"] = "success";
+      endpointBehavior["ep-dead"] = "expired";
+
+      const res = await request(app).post("/dispatch");
+      expect(res.body).toEqual({ sent: 1, processed: 1 });
+      expect(dbRows[0].push_sent_at).not.toBeNull();
+
+      expect(subscriptionStore.map((s) => s.id)).toEqual(["sub-good"]);
+    });
   });
 
-  it("sanitizes queued action_url values before sending push payloads", async () => {
-    dbRows = [
-      {
-        id: "unsafe-notif",
-        user_id: "user-unsafe",
-        title: "Unsafe",
-        body: "Body",
-        action_url: "https://example.com",
-        push_sent_at: null,
-        push_claimed_at: null,
-      },
-    ];
+  describe("subscription fetch failure", () => {
+    it("claimed notifications remain retryable after subscription fetch error", async () => {
+      dbRows = [seedRow({ id: "notif-suberr", user_id: "user-suberr" })];
+      subscriptionStore = [{ id: "sub-1", user_id: "user-suberr", endpoint: "ep-1", p256dh: "k", auth: "a" }];
+      endpointBehavior["ep-1"] = "success";
+      forceSubscriptionError = true;
 
-    const res = await request(app).post("/dispatch");
-    expect(res.status).toBe(200);
+      const res1 = await request(app).post("/dispatch");
+      expect(res1.status).toBe(500);
+      expect(dbRows[0].push_claimed_at).toBeNull();
 
-    const webpush = (await import("web-push")).default;
-    const payload = JSON.parse(webpush.sendNotification.mock.calls[0][1]);
-
-    expect(payload.action_url).toBe("/notifications");
+      const res2 = await request(app).post("/dispatch");
+      expect(res2.status).toBe(200);
+      expect(res2.body).toEqual({ sent: 1, processed: 1 });
+    });
   });
-
-  it("claimed notifications remain retryable after subscription fetch error", async () => {
-  forceSubscriptionError = true;
-
-  // First call: subscription fetch fails → should 500
-  const res1 = await request(app).post("/dispatch");
-  expect(res1.status).toBe(500);
-
-  // Rows should still be pending (push_sent_at not set)
-  const stillPending = dbRows.filter((r) => r.push_sent_at == null);
-  expect(stillPending.length).toBeGreaterThan(0);
-
-  // Second call: mock restored, rollback allows re-claim → should succeed
-  const res2 = await request(app).post("/dispatch");
-  expect(res2.status).toBe(200);
-  expect(res2.body.processed).toBeGreaterThan(0);
-  expect(res2.body.sent).toBeGreaterThan(0);
-});
 });

--- a/backend/utils/pushDeliveryCleanup.js
+++ b/backend/utils/pushDeliveryCleanup.js
@@ -1,0 +1,34 @@
+/**
+ * pushDeliveryCleanup.js
+ *
+ * Shared helper for identifying push subscriptions that should be deleted
+ * after a delivery attempt. A subscription is considered expired when the
+ * web-push library rejects the send with HTTP 410 (Gone) or 404 (Not Found),
+ * which indicates the browser has unsubscribed or revoked permission.
+ */
+
+/**
+ * collectExpiredSubscriptionIds
+ *
+ * Given a list of subscriptions and the corresponding Promise.allSettled
+ * results from webpush.sendNotification calls (one result per subscription,
+ * in the same order), returns an array of subscription IDs whose delivery
+ * was rejected with a 410 or 404 status code.
+ *
+ * @param {Array<{ id: string, endpoint: string }>} subscriptions
+ * @param {Array<PromiseSettledResult>} pushResults  - output of Promise.allSettled(...)
+ * @returns {string[]} IDs of expired/invalid subscriptions to delete
+ */
+export function collectExpiredSubscriptionIds(subscriptions, pushResults) {
+  const expiredIds = [];
+  for (let i = 0; i < subscriptions.length; i++) {
+    const result = pushResults[i];
+    if (
+      result?.status === "rejected" &&
+      (result.reason?.statusCode === 410 || result.reason?.statusCode === 404)
+    ) {
+      expiredIds.push(subscriptions[i].id);
+    }
+  }
+  return expiredIds;
+}

--- a/supabase/migrations/20260610000000_atomic_push_claim.sql
+++ b/supabase/migrations/20260610000000_atomic_push_claim.sql
@@ -1,11 +1,28 @@
--- Atomic claim column to prevent double-delivery race condition (issue #804).
--- An UPDATE … RETURNING on push_claimed_at is atomic in Postgres; only the
--- instance that wins the UPDATE will dispatch and then stamp push_sent_at.
+-- Add retry/expiry support for push notification claims (issue #1676).
+--
+-- Previously a notification that failed delivery for every subscription
+-- kept push_claimed_at set forever with no push_sent_at ever being written:
+-- it was claimed exactly once by dispatchPushNotifications and then skipped
+-- by every subsequent run, since the claim query only checked
+-- "push_claimed_at is null". This migration adds:
+--   - push_attempts: counts failed delivery attempts for a notification.
+--   - push_failed_at: set once retries are exhausted (or there were no
+--     subscriptions to deliver to), permanently excluding the row from the
+--     claim query.
+-- Claim-expiry itself is time-based (compared against push_claimed_at in the
+-- application query), so no new column is needed for that part.
 
 alter table public.notifications
-  add column if not exists push_claimed_at timestamptz;
+  add column if not exists push_attempts integer not null default 0,
+  add column if not exists push_failed_at timestamptz;
 
--- Index used by the atomic claim query below.
+-- Replace the old partial index (from the atomic-claim migration, issue
+-- #804). Claimability now also depends on push_failed_at, and the old
+-- "push_claimed_at is null" predicate is no longer sufficient since expired
+-- claims (checked at query time, not indexable as a static predicate) must
+-- also be claimable.
+drop index if exists notifications_unclaimed_push_idx;
+
 create index if not exists notifications_unclaimed_push_idx
   on public.notifications (created_at)
-  where push_sent_at is null and push_claimed_at is null;
+  where push_sent_at is null and push_failed_at is null;


### PR DESCRIPTION
## Related Issue

Closes #1676

---

## Description

Fixed an issue where failed push notifications could become permanently stuck after being claimed by the cron job.

Previously, when push delivery failed for all user subscriptions, the notification remained claimed (`push_claimed_at` was set) but was never marked as sent (`push_sent_at` remained `NULL`). Since the notification was already claimed, subsequent cron runs skipped it, preventing any future retry.

This fix introduces a retry mechanism for failed notifications, ensures only pending unsent notifications are claimed, and cleans up expired push subscriptions during the dispatch flow.

---

## Changes Made

- Added retry/claim-expiry mechanism for failed push notifications.
- Updated claim logic to process only pending unsent notifications.
- Cleaned up expired or invalid push subscriptions during cron execution.
- Added tests covering failed push delivery, retry behavior, and expired subscription cleanup.

---

## Steps to Test

1. Create a notification for a user with an expired or invalid push subscription.
2. Run the push notification dispatch cron endpoint.
3. Verify the push delivery fails.
4. Confirm the notification is released or becomes eligible for retry instead of remaining permanently claimed.
5. Run the cron endpoint again.
6. Verify the notification is retried.
7. Confirm expired push subscriptions are cleaned up.
8. Verify valid notifications are still delivered successfully.

---

## Expected Result

- Failed push notifications are retried instead of remaining permanently claimed.
- Notifications are not skipped indefinitely after a failed delivery.
- Expired or invalid push subscriptions are cleaned up during the cron flow.
- Existing successful notification delivery behavior remains unchanged.

---

## Files Changed

- `backend/controllers/cronController.js`
- `backend/controllers/notificationController.js`
- `supabase/migrations/20260610000000_atomic_push_claim.sql`
- `backend/tests/dispatchPushNotifications.test.js`

---

## Type of Change

☑️ Bug fix

☐ New feature

☐ Breaking change

☐ Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Push notifications now retry automatically when delivery fails, with expired subscriptions cleaned up in the background.
  * Notifications are now more resilient to concurrent processing, helping prevent duplicate sends.

* **Bug Fixes**
  * Improved handling for permanently failed notifications and cases with no active subscriptions.
  * Stale notification claims can now be reclaimed if a worker stops mid-process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->