### PR TITLE
fix: clear validation error reactively when user corrects input (#1614)

### DIFF
--- a/src/components/mentor/MentorForm.tsx
+++ b/src/components/mentor/MentorForm.tsx
@@ -31,6 +31,18 @@ export default function MentorForm() {
     skills: [] as string[],
     mentorship_types: [] as string[],
   });
+
+  // Clear validation error reactively when user fixes input (#1614)
+  useEffect(() => {
+    if (!error) return;
+    const isValid =
+      (step === 0 && validateBasicInfo()) ||
+      (step === 1 && validateSkills()) ||
+      (step === 2 && validateExperience()) ||
+      (step === 3 && validateMentorship());
+    if (isValid) setError("");
+  }, [formData, step]);
+
   useEffect(() => {
     const fetchSkills = async () => {
       const { data } = await (supabase as any).from("skills_taxonomy").select("name").order("name");
@@ -440,4 +452,3 @@ export default function MentorForm() {
     </div>
   );
 }
-// Fix for #1167: Refined zod schema validation


### PR DESCRIPTION
## Bug\nValidation error messages persist on screen even after the user fixes the input, only disappearing after clicking Continue again.\n\n## Fix\nAdded a useEffect that clears the error whenever formData changes and the current step's validation passes.\n\nFixes #1614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now clear automatically as soon as users correct invalid input in the mentor form.
  * Validation feedback updates more smoothly across the form’s steps, including basic info, skills, experience, and mentorship.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->