### PR TITLE
fix(cron): cap push-notification dispatch to the oldest 100 per invocation

### DIFF
--- a/backend/controllers/cronController.js
+++ b/backend/controllers/cronController.js
@@ -57,12 +57,29 @@ export const dispatchPushNotifications = async (req, res, next) => {
     webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
     const supabase = getSupabaseClient();
 
-    // Atomically claim a batch of pending notifications so concurrent invocations
-    // cannot double-deliver the same notification (race-condition prevention).
+    // Select the oldest pending notifications in a bounded batch (max 100 per run).
+    const { data: pending, error: selectError } = await supabase
+      .from("notifications")
+      .select("id")
+      .is("push_claimed_at", null)
+      .is("push_sent_at", null)
+      .order("created_at", { ascending: true })
+      .limit(100);
+
+    if (selectError) {
+      return res.status(500).json({ error: selectError.message });
+    }
+
+    if (!pending || pending.length === 0) {
+      return res.json({ sent: 0, processed: 0 });
+    }
+
+    // Atomically claim only that batch; the push_claimed_at guard prevents double-delivery.
     const claimedAt = new Date().toISOString();
     const { data: notifications, error: claimError } = await supabase
       .from("notifications")
       .update({ push_claimed_at: claimedAt })
+      .in("id", pending.map((n) => n.id))
       .is("push_claimed_at", null)
       .select("id,user_id,title,body,action_url");
 

--- a/backend/tests/dispatchPushNotifications.test.js
+++ b/backend/tests/dispatchPushNotifications.test.js
@@ -14,6 +14,7 @@ const makeSupabaseMock = () => {
     let _operation = null;
     let _payload = null;
     let _selectCols = null;
+    let _limit = null;
 
     const chain = {
       update(payload) {
@@ -40,19 +41,29 @@ const makeSupabaseMock = () => {
       order() {
         return chain;
       },
-      limit() {
+      limit(n) {
+        _limit = n;
         return chain;
       },
       // Resolve the chain
       then(resolve) {
-        if (table === "notifications" && _operation === "update" && _isFilters["push_claimed_at"] === null) {
-          // Atomic claim: only return rows not yet claimed
+        if (table === "notifications" && _operation === null && _isFilters["push_claimed_at"] === null) {
+          // Step 1: select the oldest unclaimed ids, bounded by the batch limit
           const unclaimed = dbRows.filter(
             (r) => r.push_sent_at == null && !claimedIds.has(r.id)
           );
-          const batch = unclaimed.slice(0, 100);
+          const batch = unclaimed.slice(0, _limit ?? unclaimed.length);
+          return resolve({ data: batch.map((r) => ({ id: r.id })), error: null });
+        }
+
+        if (table === "notifications" && _operation === "update" && _isFilters["push_claimed_at"] === null) {
+          // Step 2: atomic claim of only the selected ids not yet claimed
+          const ids = _filters["id__in"] || [];
+          const batch = dbRows.filter(
+            (r) => ids.includes(r.id) && r.push_sent_at == null && !claimedIds.has(r.id)
+          );
           batch.forEach((r) => claimedIds.add(r.id));
-          return resolve({ data: batch.map(r => ({ ...r })), error: null });
+          return resolve({ data: batch.map((r) => ({ ...r })), error: null });
         }
 
         if (table === "notifications" && _operation === "update" && _filters["id__in"]) {
@@ -194,6 +205,29 @@ describe("dispatchPushNotifications — race condition", () => {
     expect(res.status).toBe(200);
     expect(res.body.processed).toBe(5);
     expect(res.body.sent).toBe(5);
+  });
+
+  it("processes at most 100 notifications per invocation and drains the rest next run", async () => {
+    const webpush = (await import("web-push")).default;
+    webpush.sendNotification.mockImplementation(() => Promise.resolve({ statusCode: 201 }));
+
+    dbRows = Array.from({ length: 150 }, (_, i) => ({
+      id: `notif-${i}`,
+      user_id: `user-${i}`,
+      title: `Title ${i}`,
+      body: `Body ${i}`,
+      action_url: "/notifications",
+      push_sent_at: null,
+      push_claimed_at: null,
+    }));
+
+    const res1 = await request(app).post("/dispatch");
+    expect(res1.status).toBe(200);
+    expect(res1.body.processed).toBe(100);
+
+    const res2 = await request(app).post("/dispatch");
+    expect(res2.status).toBe(200);
+    expect(res2.body.processed).toBe(50);
   });
 
   it("returns sent=0, processed=0 when no pending notifications exist", async () => {


### PR DESCRIPTION
## Summary

The push-dispatch cron claimed every unclaimed notification in one run, ignoring the documented 100-row oldest-first cap. This bounds each invocation to the oldest 100 while preserving the atomic claim guard.

## Changes

- `cronController.js`: select the oldest 100 unclaimed ids, then claim exactly those with the existing `push_claimed_at IS NULL` guard.
- `dispatchPushNotifications.test.js`: add a cap test and update the mock to reflect the two-step claim.

## Verification

- Isolated PostgreSQL: 150 rows -> run 1 claims the oldest 100, run 2 drains the remaining 50, total 150 with no double-claim; re-running the guarded claim on already-claimed rows claims 0.
- Backend suite green, including the existing concurrent-invocation no-double-delivery test.

## Related

Fixes #1658


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push notification delivery so pending items are processed in smaller batches and handled more reliably under load.
  * Notifications are now picked up in order, with only unprocessed items claimed for each run, reducing the chance of duplicate sends.
  * The system now returns a clear no-work result when there are no pending notifications, and surfaces selection errors more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->