### PR TITLE
fix(security): drop User-Agent from rate-limit key to prevent bucket rotation

### DIFF
--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -20,11 +20,12 @@ const CLEANUP_INTERVAL_MS = 60 * 1000;
  * Derives a rate-limit key for the current request.
  *
  * Priority:
- *   1. Authenticated user ID (most reliable - cannot be spoofed).
- *   2. Composite fingerprint combining req.ip, the raw socket remote address,
- *      and the User-Agent header. This ensures that even if an attacker spoofs
- *      X-Forwarded-For (when trust proxy is misconfigured), the raw socket IP
- *      still anchors them to their real origin.
+ *   1. Authenticated user ID (cannot be spoofed).
+ *   2. Client IP: req.ip plus the raw socket remote address, so a spoofed
+ *      X-Forwarded-For still resolves to the real socket origin.
+ *
+ * Client-controlled headers such as User-Agent are excluded, since an attacker
+ * could rotate them to obtain fresh buckets and bypass the limit.
  */
 const deriveRateLimitKey = (req) => {
   if (req.user?.id) {
@@ -33,9 +34,8 @@ const deriveRateLimitKey = (req) => {
 
   const expressIp = req.ip || "unknown";
   const socketIp = req.socket?.remoteAddress || "unknown";
-  const ua = req.headers["user-agent"] || "no-ua";
 
-  return `ip:${expressIp}|${socketIp}|${ua}`;
+  return `ip:${expressIp}|${socketIp}`;
 };
 
 export const createRateLimiter = (options = {}) => {

--- a/backend/tests/rateLimiterKey.test.js
+++ b/backend/tests/rateLimiterKey.test.js
@@ -1,0 +1,24 @@
+import express from "express";
+import request from "supertest";
+import { describe, it, expect } from "vitest";
+import { createRateLimiter } from "../middlewares/rateLimiter.js";
+
+const buildApp = (maxRequests) => {
+  const app = express();
+  app.get("/ping", createRateLimiter({ maxRequests }), (_req, res) => res.json({ ok: true }));
+  return app;
+};
+
+describe("rate limiter key derivation", () => {
+  it("does not create a fresh bucket when the User-Agent rotates on the same IP", async () => {
+    const app = buildApp(3);
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).get("/ping").set("User-Agent", `agent-${i}`);
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).get("/ping").set("User-Agent", "agent-rotated");
+    expect(blocked.status).toBe(429);
+  });
+});


### PR DESCRIPTION
## Summary

The unauthenticated rate-limit key included the User-Agent header, so rotating that header produced a fresh bucket on every request and bypassed the per-IP limit. This keys unauthenticated traffic on the client IP only.

## Changes

- `rateLimiter.js`: drop the User-Agent from `deriveRateLimitKey`; key on `req.ip` plus the raw socket remote address. Corrected the stale comment.
- Add `tests/rateLimiterKey.test.js`.

## Verification

- New test: three requests then a fourth, all from the same IP with different User-Agent values. The fourth returns 429 with the fix and returns 200 (bypass) without it.
- Full backend suite passes.

## Related

Fixes #1659
