### PR TITLE
fix(backend): correct unintended character range in email validation regex

### DIFF
--- a/backend/tests/emailValidation.test.js
+++ b/backend/tests/emailValidation.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { isValidEmail } from "../utils/sendEmail.js";
+
+describe("isValidEmail", () => {
+  it("accepts valid addresses, including a hyphen in the local part", () => {
+    for (const email of [
+      "user@example.com",
+      "user.name@example.com",
+      "user+tag@example.com",
+      "user_name@example.com",
+      "a-b@example.com",
+      "first%last@example.com",
+    ]) {
+      expect(isValidEmail(email)).toBe(true);
+    }
+  });
+
+  it("rejects characters outside the intended local-part set", () => {
+    for (const email of [
+      "a'()*@example.com",
+      "a b@example.com",
+      "a<b@example.com",
+    ]) {
+      expect(isValidEmail(email)).toBe(false);
+    }
+  });
+
+  it("rejects addresses without a valid TLD", () => {
+    expect(isValidEmail("a@b")).toBe(false);
+    expect(isValidEmail("user@example")).toBe(false);
+  });
+});

--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -3,7 +3,7 @@ import { env } from "../config.js";
 
 // Stricter email validation following RFC 5321/5322 simplified rules
 // Prevents accepting invalid formats like 'a@b' (no TLD) or single-character components
-const isValidEmail = (value) => {
+export const isValidEmail = (value) => {
   const email = String(value).trim().toLowerCase();
 
   // RFC 5321/5322 simplified pattern with stricter requirements:
@@ -12,7 +12,7 @@ const isValidEmail = (value) => {
   // - TLD: at least 2 characters (required for valid domain)
   // The email is already normalised to lowercase above so the /i flag
   // is redundant and is intentionally omitted here.
-  const emailRegex = /^[a-z0-9._%-+]+@[a-z0-9.-]+\.[a-z]{2,}$/;
+  const emailRegex = /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$/;
 
   if (!emailRegex.test(email)) {
     return false;


### PR DESCRIPTION
## Summary

The email validation regex used the character class `[a-z0-9._%-+]`, where `%-+` is an unintended range (`%` to `+`). It accepted `& ' ( ) *` and rejected a literal hyphen in the local part. Reordering the hyphen to the end makes `%`, `+`, and `-` literals.

## Changes

- `sendEmail.js`: change the class to `[a-z0-9._%+-]`; export `isValidEmail` for testing.
- Add `tests/emailValidation.test.js`.

## Verification

- New test covers valid addresses (including a hyphen local part), rejected junk characters, and missing-TLD cases. It fails on the old regex and passes on the fix.
- Full backend suite passes.

## Related

Fixes #1660
