### PR TITLE
Fix navbar active section update on scroll

### DIFF
--- a/src/components/Navbar/DesktopNav.tsx
+++ b/src/components/Navbar/DesktopNav.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { User } from "@supabase/supabase-js";
 import { getNavLinks } from "./navLinks";
+import { useScrollSpy } from "@/hooks/useScrollSpy";
 
 interface DesktopNavProps {
   user: User | null;
@@ -12,17 +13,24 @@ export const DesktopNav = React.memo(function DesktopNav({ user, isAdmin }: Desk
   const location = useLocation();
   const navLinks = getNavLinks(user, isAdmin);
 
+  const sectionIds = user
+    ? []
+    : navLinks
+        .filter((l) => l.to.startsWith("/#"))
+        .map((l) => l.to.replace("/#", "")); // -> ["features", "community", "faq"]
+
+  const activeSection = useScrollSpy({ sectionIds, offset: 80 });
+
   return (
     <div className="hidden items-center gap-3 md:flex">
       {navLinks.map((link) => {
         const Icon = link.icon;
 
-        const active =
-          link.to === "/"
-            ? location.pathname === "/" && !location.hash
-            : link.to.startsWith("/#")
-            ? location.hash === link.to.replace("/", "")
-            : location.pathname === link.to;
+        const active = link.to.startsWith("/#")
+          ? location.pathname === "/" && activeSection === link.to.replace("/#", "")
+          : link.to === "/"
+          ? location.pathname === "/" && activeSection === null
+          : location.pathname === link.to;
 
         const className = `flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-all duration-300
           ${
@@ -36,11 +44,17 @@ export const DesktopNav = React.memo(function DesktopNav({ user, isAdmin }: Desk
           link.to === "/#community" ||
           link.to === "/#faq"
         ) {
+          const id = link.to.replace("/#", "");
           return (
             <a
               key={link.to}
               href={link.to.replace("/", "")}
               className={className}
+              onClick={(e) => {
+                e.preventDefault();
+                document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+                window.history.replaceState(null, "", link.to.replace("/", ""));
+              }}
             >
               <Icon size={16} />
               {link.label}

--- a/src/hooks/useScrollSpy.ts
+++ b/src/hooks/useScrollSpy.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+interface UseScrollSpyOptions {
+  sectionIds: string[];
+  offset?: number;
+}
+
+export function useScrollSpy({
+  sectionIds,
+  offset = 80,
+}: UseScrollSpyOptions) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sectionIdsKey = sectionIds.join(",");
+
+  useEffect(() => {
+    if (sectionIds.length === 0) return;
+
+    const updateActiveSection = () => {
+      const sections = sectionIds
+        .map((id) => document.getElementById(id))
+        .filter((el): el is HTMLElement => el !== null);
+
+      if (sections.length === 0) return;
+
+      const scrollPos = window.scrollY + offset + 1;
+
+      let current: string | null = null;
+
+      for (const section of sections) {
+        if (section.offsetTop <= scrollPos) {
+          current = section.id;
+        }
+      }
+
+      // Above first section = Home
+      if (window.scrollY < offset) {
+        setActiveId(null);
+      } else {
+        setActiveId(current);
+      }
+    };
+
+    updateActiveSection();
+
+    window.addEventListener("scroll", updateActiveSection, {
+      passive: true,
+    });
+
+    window.addEventListener("resize", updateActiveSection);
+
+    return () => {
+      window.removeEventListener("scroll", updateActiveSection);
+      window.removeEventListener("resize", updateActiveSection);
+    };
+  }, [sectionIdsKey, offset]);
+
+  return activeId;
+}


### PR DESCRIPTION
## Description

This PR fixes the navbar active state so that it updates dynamically while scrolling through the landing page.

### Changes
- Added a reusable `useScrollSpy` hook.
- Updated DesktopNav to use the current visible section instead of relying only on `location.hash`.
- Ensures the active navigation item changes automatically while scrolling.
- Preserves smooth scrolling behavior for navigation links.



Fixes #1722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation now highlights the section currently in view as you scroll.
  * Section links smoothly scroll to the target area and update the URL without a full page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->