### PR TITLE
fix: remove unused eslint-disable directives and fix hook dependencies

### DIFF
--- a/src/components/FloatingAI.tsx
+++ b/src/components/FloatingAI.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from "react";
 import { Bot, Send, X, User } from "lucide-react";
 import { API_BASE_URL } from "@/config/api";

--- a/src/components/GroupPomodoro.tsx
+++ b/src/components/GroupPomodoro.tsx
@@ -105,7 +105,7 @@ export default memo(function GroupPomodoro({ roomId, creatorId }: GroupPomodoroP
       active = false;
       supabase.removeChannel(channel);
     };
-  }, [roomId]);
+  }, [roomId, toast]);
 
   const clampDurations = useCallback(() => ({
     work: Math.min(WORK_MAX, Math.max(WORK_MIN, Math.floor(workDuration))),

--- a/src/components/NotificationsDropdown.tsx
+++ b/src/components/NotificationsDropdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect, useRef } from "react";
 import { Bell } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";

--- a/src/components/Room/ChatBox.tsx
+++ b/src/components/Room/ChatBox.tsx
@@ -9,7 +9,6 @@ const MarkdownRenderer = React.lazy(() =>
 );
 
 interface ChatBoxProps {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   messages: any[];
   user: User | null;
   onSendMessage: (msg: string) => Promise<void>;

--- a/src/components/Room/InviteMenu.tsx
+++ b/src/components/Room/InviteMenu.tsx
@@ -14,7 +14,6 @@ export const InviteMenu = React.memo(function InviteMenu({ roomId }: InviteMenuP
   const handleInvite = async () => {
     if (!inviteEmail.trim()) return;
     setIsInviting(true);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await (supabase.rpc as any)("invite_to_study_room", {
       p_room_id: roomId,
       p_user_email: inviteEmail,

--- a/src/components/Sparkles.tsx
+++ b/src/components/Sparkles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useRef } from 'react';
 
 const Sparkles: React.FC = () => {

--- a/src/components/StudyRooms.tsx
+++ b/src/components/StudyRooms.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { supabase } from '@/integrations/supabase/client';

--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useEffect, useRef, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/useAuth";
@@ -209,6 +208,7 @@ export default function Canvas({ roomId }: Props) {
     return () => {
       supabase.removeChannel(channel);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [roomId]);
 
   const getCoordinates = (

--- a/src/components/mentor/MentorForm.tsx
+++ b/src/components/mentor/MentorForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect } from "react";
 import { motion } from "framer-motion";
 import { CheckCircle2, Loader2, Plus, X } from "lucide-react";
@@ -41,6 +40,7 @@ export default function MentorForm() {
       (step === 2 && validateExperience()) ||
       (step === 3 && validateMentorship());
     if (isValid) setError("");
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formData, step]);
 
   useEffect(() => {

--- a/src/components/mentorship/MentorshipMilestones.tsx
+++ b/src/components/mentorship/MentorshipMilestones.tsx
@@ -39,7 +39,7 @@ export function MentorshipMilestones({ userId, isMentor }: MentorshipMilestonesP
 
   useEffect(() => {
     fetchPaths();
-  }, [userId]);
+  }, [userId, fetchPaths]);
 
   const createPath = async () => {
     if (!newGoal || !newMenteeId) {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type, no-unsafe-finally, @typescript-eslint/no-unused-expressions, @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/src/features/notifications/pushNotifications.ts
+++ b/src/features/notifications/pushNotifications.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { supabase } from "@/integrations/supabase/client";
 import { env } from "@/env";
 import { sanitizeNotificationActionUrl } from "./actionUrl";

--- a/src/features/notifications/useNotifications.ts
+++ b/src/features/notifications/useNotifications.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import type { Notification } from "./types";

--- a/src/hooks/useAwardXP.ts
+++ b/src/hooks/useAwardXP.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { getXPForActivity } from "@/lib/gamification";

--- a/src/hooks/useResources.ts
+++ b/src/hooks/useResources.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-empty-object-type, no-unsafe-finally, @typescript-eslint/no-unused-expressions, @typescript-eslint/ban-ts-comment, @typescript-eslint/no-require-imports */
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { toast } from "@/hooks/use-toast";
@@ -128,8 +127,7 @@ export const useResources = (filters?: ResourceFilters) => {
         description: normalized.message,
         variant: "destructive",
       });
-    } // eslint-disable-next-line no-unsafe-finally
-    finally {
+    } finally {
       if (!isMountedRef.current || requestId !== requestIdRef.current || controller.signal.aborted) {
         return;
       }

--- a/src/hooks/useRoomChat.ts
+++ b/src/hooks/useRoomChat.ts
@@ -4,13 +4,11 @@ import { supabase } from "@/integrations/supabase/client";
 import { User } from "@supabase/supabase-js";
 
 export function useRoomChat(id: string | undefined, user: User | null, setActivities: React.Dispatch<React.SetStateAction<string[]>>) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [messages, setMessages] = useState<any[]>([]);
 
   const fetchMessages = useCallback(async () => {
     if (!id) return;
     const { data, error } = await supabase
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .from('study_room_messages' as any)
       .select('*, profiles(name, avatar_url)')
       .eq('room_id', id)
@@ -35,7 +33,6 @@ export function useRoomChat(id: string | undefined, user: User | null, setActivi
       ...prev,
     ]);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const { error } = await supabase.from('study_room_messages' as any).insert([
       { room_id: id, profile_id: user.id, content: newMessage }
     ]);

--- a/src/hooks/useRoomDetails.ts
+++ b/src/hooks/useRoomDetails.ts
@@ -5,7 +5,6 @@ import { supabase } from "@/integrations/supabase/client";
 import { User } from "@supabase/supabase-js";
 
 export function useRoomDetails(id: string | undefined, user: User | null) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [room, setRoom] = useState<any>(null);
   const navigate = useNavigate();
 
@@ -13,7 +12,6 @@ export function useRoomDetails(id: string | undefined, user: User | null) {
     if (!id) return;
 
     const fetchRoomDetails = async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data, error } = await supabase.from('study_rooms' as any).select('*').eq('id', id).single();
       if (error) {
         console.error("Error fetching room:", error);

--- a/src/hooks/useRoomPresence.ts
+++ b/src/hooks/useRoomPresence.ts
@@ -3,17 +3,14 @@ import { supabase } from "@/integrations/supabase/client";
 import { User } from "@supabase/supabase-js";
 
 export function useRoomPresence(id: string | undefined, user: User | null, fetchMessages: () => void, setActivities: React.Dispatch<React.SetStateAction<string[]>>) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [participants, setParticipants] = useState<any[]>([]);
 
   useEffect(() => {
     if (!id || !user) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let roomChannel: any;
 
     const initializeChat = async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const { data } = await supabase.from('profiles' as any).select('name').eq('id', user.id).single() as any;
       const displayName = data?.name || user.email?.split('@')[0] || 'Student';
 
@@ -24,7 +21,6 @@ export function useRoomPresence(id: string | undefined, user: User | null, fetch
       roomChannel
         .on('presence', { event: 'sync' }, () => {
           const newState = roomChannel.presenceState();
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const onlineUsers = Object.values(newState).map((p: any) => p[0]);
 
           setParticipants(onlineUsers);
@@ -67,7 +63,7 @@ export function useRoomPresence(id: string | undefined, user: User | null, fetch
 
       if (roomChannel) supabase.removeChannel(roomChannel);
     };
-  }, [id, user, fetchMessages]);
+  }, [id, user, fetchMessages, setActivities]);
 
   return { participants };
 }

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { toast } from "sonner";
 
 type UnknownRecord = Record<string, unknown>;

--- a/src/lib/rewardXP.ts
+++ b/src/lib/rewardXP.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { supabase } from "@/integrations/supabase/client";
 
 export const rewardXP = async (

--- a/src/lib/streakSystem.ts
+++ b/src/lib/streakSystem.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 /**
  * streakSystem.ts
  *

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import React, { memo, Suspense, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowLeft, MessageCircle, Search, Send } from "lucide-react";
 import { useVirtualizer } from "@tanstack/react-virtual";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { Suspense, lazy, useEffect, useState } from "react";
 import { motion } from "framer-motion";
 import { useNavigate } from "react-router-dom";

--- a/src/pages/Discover.tsx
+++ b/src/pages/Discover.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import {

--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { memo, useEffect, useRef, useState, useCallback } from "react";
 import { motion } from "framer-motion";
 import {

--- a/src/pages/MentorDashboard.tsx
+++ b/src/pages/MentorDashboard.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { useEffect, useState } from "react";
 import { useRole } from "@/contexts/RoleContext";
 import { useAuth } from "@/contexts/useAuth";

--- a/src/pages/Notifications.tsx
+++ b/src/pages/Notifications.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 

--- a/src/pages/aipage.tsx
+++ b/src/pages/aipage.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
+ 
 import { useState } from "react";
 import { Bot, Send, User } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary

Clean up ESLint warnings across the codebase:

### Removed unused eslint-disable directives
- Removed `@typescript-eslint/no-explicit-any` disable comments from 15+ files where they were no longer needed
- Removed unused `no-unsafe-finally` disable comment from useResources.ts
- Removed unused multi-rule disable comment from textarea.tsx

### Fixed React hooks dependencies
- **GroupPomodoro.tsx**: Added missing `toast` dependency
- **MentorshipMilestones.tsx**: Added missing `fetchPaths` dependency
- **useRoomPresence.ts**: Added missing `setActivities` dependency

### Suppressed safe warnings
- Added targeted eslint-disable for complex exhaustive-deps cases in Canvas.tsx and MentorForm.tsx where adding deps would cause re-render issues

No functionality changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing and reliability of live updates in group rooms and presence, ensuring updates re-run appropriately when related values change.
  * Ensured mentorship progress loads/reloads when the underlying fetch function changes, preventing stale paths.

* **Chores / Refactor**
  * Removed unused ESLint suppression directives across multiple components, hooks, pages, and utilities.
  * Updated a couple of hook lint/dependency suppressions to better align with expected rerun behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->