### PR TITLE
fix: include user object in Portfolio useEffect deps

### DIFF
--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -218,7 +218,7 @@ const Portfolio = () => {
       isMounted = false;
       clearTimeout(timeout);
     };
-  }, [user?.id, user?.email, toast]);
+  }, [user, toast]);
 
   const updateAchievement = (index: number, achievement: Achievement) => {
     setForm((current) => ({


### PR DESCRIPTION
Replace `user?.id` and `user?.email` with `user` to resolve react-hooks/exhaustive-deps warning.