### PR TITLE
fix: add missing useCallback deps in Chat sendTypingStatus

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -398,7 +398,7 @@ const Chat = () => {
         isTyping,
       },
     });
-  }, []);
+  }, [currentUser?.id, selectedUser?.id]);
 
   const handleMessageChange = useCallback((value: string) => {
     setMessageText(value);


### PR DESCRIPTION
Add `currentUser?.id` and `selectedUser?.id` to the `sendTypingStatus` useCallback dependency array to satisfy `react-hooks/exhaustive-deps`.