### PR TITLE
fix: add missing ensureUserExists and fetchLeaderboard deps in Leaderboard

### DIFF
--- a/src/pages/Leaderboard.tsx
+++ b/src/pages/Leaderboard.tsx
@@ -239,7 +239,7 @@ const Leaderboard = () => {
 
     init();
 
-  }, [user, filter]);
+  }, [user, filter, ensureUserExists, fetchLeaderboard]);
 
   // REALTIME
   // We use a ref so the realtime listener always calls the latest fetchLeaderboard, 


### PR DESCRIPTION
Add `ensureUserExists` and `fetchLeaderboard` to the useEffect dependency array to satisfy `react-hooks/exhaustive-deps`.