### PR TITLE
fix: wrap fetchPaths in useCallback in MentorshipMilestones

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useState } from "react";
 import { Camera, Loader2 } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
-import { API_BASE_URL } from "@/config/api";
 
 type AvatarUploadProps = {
   currentAvatarUrl: string;
@@ -69,8 +68,6 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
       });
 
       if (!res.ok) {
-        const text = await res.text();
-
         if (res.status === 401) {
           throw new Error(
             "Your session has expired. Please sign in again and retry the upload."

--- a/src/components/mentorship/MentorshipMilestones.tsx
+++ b/src/components/mentorship/MentorshipMilestones.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { CheckCircle2, Circle, Plus, Trophy, Calendar, Map } from "lucide-react";
@@ -16,7 +16,7 @@ export function MentorshipMilestones({ userId, isMentor }: MentorshipMilestonesP
   const [newMenteeId, setNewMenteeId] = useState("");
   const [isCreatingPath, setIsCreatingPath] = useState(false);
 
-  const fetchPaths = async () => {
+  const fetchPaths = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from("mentorship_paths")
@@ -35,11 +35,11 @@ export function MentorshipMilestones({ userId, isMentor }: MentorshipMilestonesP
     } finally {
       setLoading(false);
     }
-  };
+  }, [userId]);
 
   useEffect(() => {
     fetchPaths();
-  }, [userId]);
+  }, [userId, fetchPaths]);
 
   const createPath = async () => {
     if (!newGoal || !newMenteeId) {


### PR DESCRIPTION
Wrap `fetchPaths` in `useCallback` with `[userId]` dependency to prevent identity change on every render, satisfying `react-hooks/exhaustive-deps`.