### PR TITLE
fix: add missing deps and wrap replayCanvas in useCallback

### DIFF
--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/contexts/useAuth";
 import {
@@ -105,7 +105,7 @@ export default function Canvas({ roomId }: Props) {
     }
   };
 
-  const replayCanvas = () => {
+  const replayCanvas = useCallback(() => {
     const ctx = getContext();
 
     if (!ctx) return;
@@ -115,7 +115,7 @@ export default function Canvas({ roomId }: Props) {
     for (const event of strokesRef.current) {
       drawEvent(ctx, event);
     }
-  };
+  }, []);
 
   const persistEvent = async (event: WhiteboardEvent) => {
     await supabase.from("whiteboard_events" as any).insert({
@@ -209,7 +209,7 @@ export default function Canvas({ roomId }: Props) {
     return () => {
       supabase.removeChannel(channel);
     };
-  }, [roomId]);
+  }, [roomId, replayCanvas, user?.id]);
 
   const getCoordinates = (
     e: React.MouseEvent<HTMLCanvasElement>


### PR DESCRIPTION
Wrap `replayCanvas` in `useCallback` and add `replayCanvas` and `user?.id` to useEffect dependency array to satisfy `react-hooks/exhaustive-deps`.