### PR TITLE
fix: remove unused catch variables

### DIFF
--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -92,7 +92,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
     }
     try {
       await toggleVote(vote === type ? null : type);
-    } catch (e) {
+    } catch {
       toast.error("Failed to register vote");
     }
   };
@@ -104,7 +104,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
     }
     try {
       await toggleSave(!isSaved);
-    } catch (e) {
+    } catch {
       toast.error("Failed to save resource");
     }
   };

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -114,7 +114,7 @@ export default function Landing() {
         localStorage.setItem(KEY_LAST, todayKey);
         setStreak(1);
       }
-    } catch (e) {
+    } catch {
       setStreak(0);
     }
   }, [preferences?.functional]);


### PR DESCRIPTION
Replace `catch (e)` with `catch` where the error variable is unused.