### PR TITLE
fix(db): remove markdown fences from messages created_at migration

### DIFF
--- a/supabase/migrations/20260601000012_fix_message_created_at_spoofing.sql
+++ b/supabase/migrations/20260601000012_fix_message_created_at_spoofing.sql
@@ -1,4 +1,3 @@
-```sql
 -- Ensure message timestamps are assigned by the database, not trusted from clients.
 
 ALTER TABLE public.messages
@@ -28,4 +27,3 @@ CREATE TRIGGER a_enforce_messages_created_at
 BEFORE INSERT ON public.messages
 FOR EACH ROW
 EXECUTE FUNCTION public.enforce_messages_created_at();
-```


### PR DESCRIPTION
## Summary

Removes the Markdown code fences that wrapped `supabase/migrations/20260601000012_fix_message_created_at_spoofing.sql`. The fence lines are not valid SQL, so the file failed to parse and the migration chain broke on a fresh `supabase db reset`.

## Changes

- Deleted the opening fence line and the closing fence line from the migration. No SQL content changed.

## Verification

- Parsed both versions with the PostgreSQL parser (libpg_query). The original fenced file fails with `syntax error at or near "```"`. The fixed file parses cleanly into 6 statements (default, backfill update, NOT NULL, function, drop trigger, create trigger).

## Related

Fixes #1632
