### PR TITLE
fix(db): remove no-op migration that disabled award_activity_xp

### DIFF
--- a/supabase/migrations/20260611000001_fix_xp_forgery.sql
+++ b/supabase/migrations/20260611000001_fix_xp_forgery.sql
@@ -1,1 +1,0 @@
-CREATE OR REPLACE FUNCTION award_activity_xp(_activity_type TEXT) RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$ BEGIN END; $$;


### PR DESCRIPTION
## Summary

Removes `supabase/migrations/20260611000001_fix_xp_forgery.sql`, a stub migration that replaced `award_activity_xp(text)` with an empty body and silently disabled all activity XP.

## Changes

- Deleted the stub migration. The effective definition reverts to `20260531000008_fix_award_activity_xp_rate_limit.sql`, the correct rate limited implementation.

## Verification

Isolated PostgreSQL run:

- With `20260531000008` loaded, `award_activity_xp('session_join')` awarded 50 XP and logged one activity row.
- After loading the stub, a further call awarded nothing.

## Related

Fixes #1633
