### PR TITLE
fix(db): remove get_badge stub migration that fails to apply

### DIFF
--- a/supabase/migrations/20260611000002_fix_search_paths.sql
+++ b/supabase/migrations/20260611000002_fix_search_paths.sql
@@ -1,1 +1,0 @@
-CREATE OR REPLACE FUNCTION get_badge(xp INT) RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$ BEGIN RETURN 'beginner'; END; $$;


### PR DESCRIPTION
## Summary

Removes `supabase/migrations/20260611000002_fix_search_paths.sql`. The file tries to `CREATE OR REPLACE` `get_badge` while renaming its input parameter from `_xp` to `xp`, which PostgreSQL rejects, so it errors on apply and aborts the migration chain. It also fixes no search path (get_badge already has `search_path = public` from `20260601000009`).

## Changes

- Deleted the migration. The effective `get_badge` definition remains `20260601000009`, which has the correct tiered logic and `search_path = public`.

## Verification

Isolated PostgreSQL run:

- Real `get_badge` (param `_xp`): `get_badge(5000)` returns `Legend`.
- Applying the file: `ERROR: cannot change name of input parameter "_xp"`.
- After the failed apply, `get_badge(5000)` still returns `Legend`.

## Related

Fixes #1634
