### PR TITLE
fix(db): remove restore_user_streak stub migration that fails to apply

### DIFF
--- a/supabase/migrations/20260611000003_fix_streak_race_condition.sql
+++ b/supabase/migrations/20260611000003_fix_streak_race_condition.sql
@@ -1,1 +1,0 @@
-CREATE OR REPLACE FUNCTION restore_user_streak() RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path = public AS $$ BEGIN PERFORM 1 FROM profiles WHERE id = auth.uid() FOR UPDATE; END; $$;


### PR DESCRIPTION
## Summary

Removes `supabase/migrations/20260611000003_fix_streak_race_condition.sql`. It redefines `restore_user_streak()` with `RETURNS void` while the existing function returns `jsonb`, which PostgreSQL rejects, so it errors on apply and aborts the migration chain. Its body also discards the streak restore logic.

## Changes

- Deleted the migration. The effective `restore_user_streak()` definition remains `20260601000009` (jsonb with the restore logic).

## Verification

Isolated PostgreSQL run: with `restore_user_streak()` present as `jsonb` (its state after `20260601000009`), applying this file raises `ERROR: cannot change return type of existing function`.

## Related

Fixes #1635
