### PR TITLE
fix(security): stop storing author identity on anonymous peer submissions

### DIFF
--- a/src/pages/PeerReviewDashboard.tsx
+++ b/src/pages/PeerReviewDashboard.tsx
@@ -24,7 +24,7 @@ export default function PeerReviewDashboard() {
       const { data: pending } = await supabase
         .from('peer_submissions')
         .select('*, profiles(name, avatar_url)')
-        .neq('user_id', user.id)
+        .or(`user_id.is.null,user_id.neq.${user.id}`)
         .eq('status', 'pending')
         .order('created_at', { ascending: false });
 

--- a/src/pages/SubmitForReview.tsx
+++ b/src/pages/SubmitForReview.tsx
@@ -54,7 +54,7 @@ export default function SubmitForReview() {
     const { error } = await supabase
       .from('peer_submissions')
       .insert({
-        user_id: user.id,
+        user_id: formData.is_anonymous ? null : user.id,
         title: formData.title,
         description: formData.description,
         content_url: safeContentUrl,

--- a/supabase/migrations/20260705000000_anonymize_peer_submissions.sql
+++ b/supabase/migrations/20260705000000_anonymize_peer_submissions.sql
@@ -1,0 +1,15 @@
+-- Anonymous peer submissions must not store or expose the author identity.
+
+UPDATE public.peer_submissions SET user_id = NULL WHERE is_anonymous = true;
+
+DROP POLICY IF EXISTS "Enable insert for authenticated users" ON public.peer_submissions;
+
+CREATE POLICY "Enable insert for authenticated users"
+    ON public.peer_submissions FOR INSERT
+    WITH CHECK (
+        auth.uid() IS NOT NULL
+        AND (
+            (is_anonymous = true AND user_id IS NULL)
+            OR (is_anonymous = false AND user_id = auth.uid())
+        )
+    );


### PR DESCRIPTION
## Summary

Anonymous peer submissions previously stored and exposed the author `user_id` and joined profile, so any authenticated user could de-anonymize them. This follows the project's `doubts` model: anonymous rows carry no `user_id`.

## Changes

- New migration `20260705000000_anonymize_peer_submissions.sql`: scrubs existing anonymous rows to `user_id = NULL` and enforces `user_id IS NULL` for anonymous inserts (non-anonymous inserts still require `user_id = auth.uid()`).
- `SubmitForReview.tsx`: inserts `user_id: null` when anonymous.
- `PeerReviewDashboard.tsx`: the pending query includes null-user_id rows so anonymous submissions stay reviewable.
- `types.ts`: `peer_submissions.user_id` marked nullable to match the column.

## Verification

- RLS on an isolated PostgreSQL instance: an anonymous insert carrying a real user_id is rejected; an anonymous insert with null succeeds; a non-anonymous insert requires self; a pre-existing anonymous row is scrubbed; reading anonymous rows returns no user_id.
- Typecheck: no new type errors versus the base branch.

## Trade-off

Like `doubts`, anonymous submissions are no longer linked to their author, so they do not appear under "My Submissions". A view or RPC that preserves author linkage is a possible follow-up.

## Related

Fixes #1636
