### PR TITLE
fix: hide contributor dashboard for unauthenticated users (#1778)

### DIFF
--- a/src/components/Navbar/navLinks.ts
+++ b/src/components/Navbar/navLinks.ts
@@ -55,6 +55,11 @@ export const getNavLinks = (user: User | null, isAdmin: boolean) => {
           label: "Peer Review",
           icon: FileCheck,
         },
+        {
+          to: "/contributor-dashboard",
+          label: "Contributor Dashboard",
+          icon: LayoutDashboard,
+        },
         ...(isAdmin
           ? [
               {
@@ -81,11 +86,6 @@ export const getNavLinks = (user: User | null, isAdmin: boolean) => {
           to: "/#community",
           label: "Communities",
           icon: Users,
-        },
-        {
-          to: "/contributor-dashboard",
-          label: "Contributor Dashboard",
-          icon: LayoutDashboard,
         },
         {
           to: "/#faq",


### PR DESCRIPTION
## Description

Fixes #1778

### Changes Made
- Removed the Contributor Dashboard navigation item from the guest navigation.
- Ensured only authenticated users can access contributor-specific navigation.
- Kept the existing route protection unchanged.

### Testing
- [x] Verified the Contributor Dashboard is not visible before login.
- [x] Verified protected routes still redirect unauthenticated users to the login page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted access to the Contributor Dashboard navigation link to signed-in users.
  * Updated navigation ordering so the dashboard appears after Peer Review and before Admin options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->