### PR TITLE
fix: Prevent inconsistent skill endorsement state under rapid interactions

### DIFF
--- a/src/hooks/useSkillEndorsements.test.ts
+++ b/src/hooks/useSkillEndorsements.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSkillEndorsements } from "./useSkillEndorsements";
+import { supabase } from "@/integrations/supabase/client";
+import { useToast } from "@/hooks/use-toast";
+
+// Mock supabase
+vi.mock("@/integrations/supabase/client", () => ({
+  supabase: {
+    auth: {
+      getUser: vi.fn(),
+    },
+    from: vi.fn(),
+  },
+}));
+
+// Mock useToast
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: vi.fn(),
+}));
+
+describe("useSkillEndorsements rapid interactions", () => {
+  const mockToast = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useToast as any).mockReturnValue({ toast: mockToast });
+    
+    // Default auth mock
+    (supabase.auth.getUser as any).mockResolvedValue({
+      data: { user: { id: "current-user-123" } },
+    });
+  });
+
+  it("prevents rapid toggling state desync", async () => {
+    let resolveInsert: (val: any) => void;
+    const insertPromise = new Promise((res) => {
+      resolveInsert = res;
+    });
+
+    const mockInsert = vi.fn().mockReturnValue(insertPromise);
+    const mockDelete = vi.fn().mockReturnThis();
+    const mockMatch = vi.fn().mockResolvedValue({ error: null });
+
+    (supabase.from as any).mockImplementation((table: string) => {
+      if (table === "skill_endorsements") {
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          insert: mockInsert,
+          delete: mockDelete,
+          match: mockMatch,
+        };
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useSkillEndorsements({ profileUserId: "profile-123", skills: ["React"] })
+    );
+
+    await waitFor(() => {
+      expect(result.current.currentUserId).toBe("current-user-123");
+    });
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    act(() => {
+      result.current.toggleEndorsement("React");
+      result.current.toggleEndorsement("React"); 
+    });
+
+    expect(result.current.endorsements["React"].count).toBe(1);
+    expect(result.current.endorsements["React"].hasEndorsed).toBe(true);
+
+    await act(async () => {
+      resolveInsert!({ error: null });
+    });
+
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSkillEndorsements.ts
+++ b/src/hooks/useSkillEndorsements.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 
@@ -31,7 +31,7 @@ export function useSkillEndorsements({
   const [loading, setLoading] = useState(true);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [authReady, setAuthReady] = useState(false);
-  const [pendingSkills, setPendingSkills] = useState<Set<string>>(new Set());
+  const pendingSkillsRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
@@ -99,12 +99,13 @@ export function useSkillEndorsements({
         return;
       }
 
-      if (pendingSkills.has(skill)) return;
-      setPendingSkills((prev) => new Set(prev).add(skill));
+      if (pendingSkillsRef.current.has(skill)) return;
+      pendingSkillsRef.current.add(skill);
 
       const current = endorsements[skill];
       const isRemoving = current?.hasEndorsed ?? false;
 
+      // Optimistically update UI using functional update to preserve other skill updates
       setEndorsements((prev) => ({
         ...prev,
         [skill]: {
@@ -136,6 +137,7 @@ export function useSkillEndorsements({
         }
       } catch (err) {
         console.error("[useSkillEndorsements] toggle error:", err);
+        // Revert the optimistic update on error
         setEndorsements((prev) => ({
           ...prev,
           [skill]: {
@@ -149,14 +151,10 @@ export function useSkillEndorsements({
           variant: "destructive",
         });
       } finally {
-        setPendingSkills((prev) => {
-          const next = new Set(prev);
-          next.delete(skill);
-          return next;
-        });
+        pendingSkillsRef.current.delete(skill);
       }
     },
-    [currentUserId, profileUserId, endorsements, toast, pendingSkills]
+    [currentUserId, profileUserId, endorsements, toast]
   );
 
   return { endorsements, loading, toggleEndorsement, currentUserId };


### PR DESCRIPTION
## Fixes #1373

### Description
This PR addresses an issue where rapid interactions with the skill endorsement toggle resulted in an inconsistent UI state and potential duplicate requests to the backend. Because React batches state updates (especially in event handlers), multiple rapid clicks caused subsequent event handlers to run before the `pendingSkills` state was updated. 

### Changes Made
- **Refactored `pendingSkills` to use a `useRef`:** Replaced the `pendingSkills` state array with `pendingSkillsRef`. Refs update synchronously and do not trigger re-renders, creating an immediate lock for a skill as soon as a toggle begins. Any duplicate clicks on the same skill are rejected immediately.
- **Preserved concurrent updates:** The state setter for `endorsements` was kept as a functional update (`setEndorsements(prev => ...)`). This ensures that if a user rapidly clicks on *different* skills simultaneously, both optimistic updates are merged perfectly without one overriding the other due to stale closures.
- **Added regression coverage:** Added a new Vitest test suite (`src/hooks/useSkillEndorsements.test.ts`) that mocks Supabase and verifies that rapid double-clicks on the same skill only result in a single optimistic state change and a single backend API request.

### Testing Instructions
1. Run the test suite using Vitest (`npm run test`) and verify the new regression tests pass.
2. In the UI, navigate to a user's portfolio and rapidly double-click or multi-click on a skill endorsement badge.
3. Observe that only one API request is dispatched per distinct interaction, and the endorsement count/status updates correctly without desyncing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate skill endorsements when users rapidly toggle the same skill.
  * Improved consistency of endorsement counts and status during quick interactions.

* **Tests**
  * Added coverage for rapid endorsement toggling and verified that only one endorsement request is submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->