### PR TITLE
feat: Add Focus Mode during Study Sessions

### DIFF
--- a/src/components/sessions/SessionChat.tsx
+++ b/src/components/sessions/SessionChat.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from "react";
-import { Send, Video, Sparkles } from "lucide-react";
+import { Send, Video, Sparkles, BellOff, Bell } from "lucide-react";
 import { LiveCodeRunner } from "@/components/studyroom/LiveCodeRunner";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
@@ -14,6 +14,8 @@ type SessionChatProps = {
   sessionSummary: any;
   summaryLoading: boolean;
   studyTime: number;
+  isFocusMode: boolean;
+  setIsFocusMode: (val: boolean) => void;
   sendMessage: (msg: string) => void;
   sendTypingEvent: () => void;
   handleLeaveVideo: () => void;
@@ -32,6 +34,8 @@ export function SessionChat({
   sessionSummary,
   summaryLoading,
   studyTime,
+  isFocusMode,
+  setIsFocusMode,
   sendMessage,
   sendTypingEvent,
   handleLeaveVideo,
@@ -73,12 +77,27 @@ export function SessionChat({
                     className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm border w-fit ${
                       userStatus === "Active"
                         ? "bg-cyan-500/10 border-cyan-400/20 text-cyan-300"
+                        : userStatus === "Busy"
+                        ? "bg-red-500/10 border-red-400/20 text-red-300"
                         : "bg-yellow-500/10 border-yellow-400/20 text-yellow-300"
                     }`}
                   >
-                    {userStatus === "Active" ? "⚡" : "🌙"}
+                    {userStatus === "Active" ? "⚡ " : userStatus === "Busy" ? "⛔ " : "🌙 "}
                     {userStatus}
                   </div>
+
+                  <button
+                    onClick={() => setIsFocusMode(!isFocusMode)}
+                    className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm border w-fit transition-colors ${
+                      isFocusMode
+                        ? "bg-red-500/10 border-red-400/20 text-red-300"
+                        : "bg-white/5 border-white/10 text-gray-300 hover:bg-white/10"
+                    }`}
+                    title={isFocusMode ? "Disable Focus Mode" : "Enable Focus Mode (Sets status to Busy and silences notifications)"}
+                  >
+                    {isFocusMode ? <BellOff size={14} /> : <Bell size={14} />}
+                    Focus Mode
+                  </button>
                 </div>
 
                 <div className="bg-white/5 border border-white/10 rounded-2xl p-4">

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -23,6 +23,18 @@ export function useSessions(user: any) {
 
   const [activities, setActivities] = useState<any[]>([]);
   const [userStatus, setUserStatus] = useState("Active");
+  const [isFocusMode, setIsFocusMode] = useState(false);
+  const isFocusModeRef = useRef(isFocusMode);
+
+  useEffect(() => {
+    isFocusModeRef.current = isFocusMode;
+    if (isFocusMode) {
+      setUserStatus("Busy");
+    } else {
+      setUserStatus("Active");
+    }
+  }, [isFocusMode]);
+
   const [typingUser, setTypingUser] = useState<string | null>(null);
   const [participantCount, setParticipantCount] = useState(1);
   const [isVideoActive, setIsVideoActive] = useState(false);
@@ -197,10 +209,13 @@ export function useSessions(user: any) {
 
   useEffect(() => {
     const handleActivity = () => {
+      if (isFocusModeRef.current) return;
       setUserStatus("Active");
       clearTimeout(idleTimerRef.current);
       idleTimerRef.current = setTimeout(() => {
-        setUserStatus("Idle");
+        if (!isFocusModeRef.current) {
+          setUserStatus("Idle");
+        }
       }, 15000);
     };
 
@@ -370,6 +385,8 @@ export function useSessions(user: any) {
     sessionSummary,
     summaryLoading,
     studyTime,
+    isFocusMode,
+    setIsFocusMode,
     handleJoinSession,
     sendMessage,
     sendTypingEvent,

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -28,6 +28,8 @@ export default function Sessions() {
     sessionSummary,
     summaryLoading,
     studyTime,
+    isFocusMode,
+    setIsFocusMode,
     handleJoinSession,
     sendMessage,
     sendTypingEvent,
@@ -94,6 +96,8 @@ export default function Sessions() {
               sessionSummary={sessionSummary}
               summaryLoading={summaryLoading}
               studyTime={studyTime}
+              isFocusMode={isFocusMode}
+              setIsFocusMode={setIsFocusMode}
               sendMessage={sendMessage}
               sendTypingEvent={sendTypingEvent}
               handleLeaveVideo={handleLeaveVideo}


### PR DESCRIPTION
��### Description

This PR implements the requested Focus Mode feature (Issue #1808).

### Changes:
- Added a Focus Mode toggle in \SessionChat.tsx\.
- Added \isFocusMode\ state to \useSessions.ts\.
- Automatically sets the user's status to \
Busy\ when Focus Mode is activated, overriding the idle timeout.
- Ensured UI properly reflects the \
Busy\ status and the toggle button.

### Closes
Closes durdana3105/peer-learning#1808


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Focus Mode to session chats, allowing users to temporarily prevent their status from switching to Idle.
  * Added a chat-header toggle with visual indicators for Focus Mode.
  * Improved status indicators to distinguish Active, Busy, and other states with unique icons and colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->