### PR TITLE
fix(resources): guard vote button against stale-state double counting

### DIFF
--- a/src/components/resources/ResourceCard.tsx
+++ b/src/components/resources/ResourceCard.tsx
@@ -35,6 +35,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
   const [isDeleting, setIsDeleting] = useState(false);
   const [localUpvotes, setLocalUpvotes] = useState(resource.upvotes_count || 0);
   const [localDownvotes, setLocalDownvotes] = useState(resource.downvotes_count || 0);
+  const [pendingVote, setPendingVote] = useState<1 | -1 | null | undefined>(undefined);
 
   const isOwner = currentUser?.id === resource.uploaded_by;
 
@@ -42,6 +43,8 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
     resource.id,
     currentUser?.id
   );
+
+  const displayedVote = pendingVote !== undefined ? pendingVote : vote;
 
   useEffect(() => {
     setLocalUpvotes(resource.upvotes_count || 0);
@@ -98,6 +101,8 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
       return;
     }
 
+    if (pendingVote !== undefined) return;
+
     const previousVote = vote;
     const newVote = previousVote === type ? null : type;
 
@@ -108,6 +113,7 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
     if (newVote === 1) upvoteDelta += 1;
     if (newVote === -1) downvoteDelta += 1;
 
+    setPendingVote(newVote);
     setLocalUpvotes((prev) => prev + upvoteDelta);
     setLocalDownvotes((prev) => prev + downvoteDelta);
 
@@ -117,6 +123,8 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
       setLocalUpvotes((prev) => prev - upvoteDelta);
       setLocalDownvotes((prev) => prev - downvoteDelta);
       toast.error("Failed to register vote");
+    } finally {
+      setPendingVote(undefined);
     }
   };
 
@@ -188,19 +196,21 @@ const ResourceCard = ({ resource, onDelete }: ResourceCardProps) => {
           <Button 
             variant="ghost" 
             size="sm" 
-            className={cn("gap-1.5", vote === 1 && "text-green-600 bg-green-50")}
+            className={cn("gap-1.5", displayedVote === 1 && "text-green-600 bg-green-50")}
             onClick={() => handleVote(1)}
+            disabled={pendingVote !== undefined}
           >
-            <ThumbsUp className="h-4 w-4" fill={vote === 1 ? "currentColor" : "none"} />
+            <ThumbsUp className="h-4 w-4" fill={displayedVote === 1 ? "currentColor" : "none"} />
             <span className="text-xs font-medium">{localUpvotes}</span>
           </Button>
           <Button 
             variant="ghost" 
             size="sm" 
-            className={cn("gap-1.5", vote === -1 && "text-red-600 bg-red-50")}
+            className={cn("gap-1.5", displayedVote === -1 && "text-red-600 bg-red-50")}
             onClick={() => handleVote(-1)}
+            disabled={pendingVote !== undefined}
           >
-            <ThumbsDown className="h-4 w-4" fill={vote === -1 ? "currentColor" : "none"} />
+            <ThumbsDown className="h-4 w-4" fill={displayedVote === -1 ? "currentColor" : "none"} />
             <span className="text-xs font-medium">{localDownvotes}</span>
           </Button>
         </div>


### PR DESCRIPTION
## Summary

Fixes vote counters on resource cards inflating when a user clicks the upvote/downvote button more than once before the previous vote request finishes.

## What was wrong

`handleVote` in `ResourceCard.tsx` computed the optimistic delta from `vote`, which comes from `useResourceInteractions` and only updates after `toggleVote`'s mutation resolves and `invalidateQueries` refetches. Clicking again before that round trip completes meant `previousVote` was still stale, so the same delta got applied a second time, third time, etc. Server-side counts were fine (the vote table has a composite PK and the trigger only reacts to real transitions), but the UI kept climbing.

## Fix

Added a `pendingVote` state that holds the optimistic vote while a mutation is in flight. `handleVote` now bails out early if a vote is already pending, and both buttons get `disabled` while pending so a rapid click can't queue up a second request against stale state. Display reads from `pendingVote` when set, falling back to the confirmed `vote` otherwise.

## Testing

- `npm run lint` and `npx tsc --noEmit` clean
- `npm test` — all 260 tests pass
- Manually reasoned through rapid-click sequence: first click sets pending + optimistic delta, subsequent clicks are no-ops until the mutation settles

Fixes #1816


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Vote selections now appear immediately while the action is processing.
  * Vote buttons are temporarily disabled during submission to prevent overlapping actions.
  * Vote controls now return to an interactive state even if the vote attempt fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->