### PR TITLE
fix(match): order discover query by id before applying the row limit

### DIFF
--- a/backend/controllers/matchController.js
+++ b/backend/controllers/matchController.js
@@ -171,10 +171,16 @@ export const getSupabaseDiscover = async (req, res) => {
       return res.status(404).json({ success: false, message: "User profile not found" });
     }
 
+    // Postgres gives no ordering guarantee without ORDER BY, so an unordered
+    // LIMIT can return a different set of rows on every call once the table
+    // has more candidates than the limit - silently hiding some profiles and
+    // making pagination unstable between requests. Order by id so the 1000-row
+    // window is deterministic and consistent across page requests.
     let query = supabaseAdmin
       .from("profiles")
       .select("id, name, skills, interests, learning_goals, teach_subjects, learn_subjects, learning_style, preferred_language, timezone")
       .neq("id", userId)
+      .order("id", { ascending: true })
       .limit(1000);
 
     if (search.trim()) {

--- a/backend/tests/supabaseDiscover.test.js
+++ b/backend/tests/supabaseDiscover.test.js
@@ -17,6 +17,7 @@ const makeFromChain = () => ({
   eq: mockEq,
   neq: mockNeq,
   single: mockSingle,
+  order: vi.fn().mockReturnThis(),
   range: vi.fn().mockImplementation(() => ({
     or: mockOr,
     ilike: mockIlike,
@@ -158,6 +159,7 @@ describe("GET /api/match/supabase-discover — page validation", () => {
         data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
         error: null,
         }),
+        order: vi.fn().mockReturnThis(),
         limit: vi.fn().mockResolvedValue({ data: PEER_PROFILES, error: null }),
     }));
 
@@ -174,6 +176,7 @@ describe("GET /api/match/supabase-discover — page validation", () => {
         data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
         error: null,
         }),
+        order: vi.fn().mockReturnThis(),
         limit: vi.fn().mockResolvedValue({ data: PEER_PROFILES, error: null }),
     }));
 
@@ -204,6 +207,7 @@ describe("getSupabaseDiscover — pagination offset calculation", () => {
           data: { skills: ["Python"], learning_goals: ["Python"], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
           error: null,
         }),
+        order: vi.fn().mockReturnThis(),
         limit: vi.fn().mockImplementation((lim) => {
           if (table === "profiles") capturedLimit = lim;
           return {
@@ -231,6 +235,37 @@ describe("getSupabaseDiscover — pagination offset calculation", () => {
     expect(responsePayload.recommendations).toHaveLength(10);
   });
 
+  it("orders the profiles query by id before applying the 1000-row limit", async () => {
+    let capturedOrderArgs;
+
+    mockSupabase.from.mockImplementation((table) => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      neq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
+        error: null,
+      }),
+      order: vi.fn().mockImplementation((...args) => {
+        if (table === "profiles") capturedOrderArgs = args;
+        return { limit: vi.fn().mockResolvedValue({ data: [], error: null }) };
+      }),
+    }));
+
+    const req = {
+      user: { id: CURRENT_USER_ID },
+      query: {},
+    };
+    const res = createRes();
+
+    await getSupabaseDiscover(req, res);
+
+    // Without ORDER BY, Postgres gives no guarantee on which rows a LIMIT
+    // returns, so pagination and candidate visibility would be unstable
+    // once the table has more rows than the limit.
+    expect(capturedOrderArgs).toEqual(["id", { ascending: true }]);
+  });
+
   it("clamps page=99999 to 1000 at the controller level (defence-in-depth)", async () => {
     let capturedLimit;
 
@@ -242,6 +277,7 @@ describe("getSupabaseDiscover — pagination offset calculation", () => {
         data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
         error: null,
       }),
+      order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockImplementation((lim) => {
         if (table === "profiles") capturedLimit = lim;
         return { then: (resolve) => resolve({ data: [], error: null }), or: vi.fn().mockReturnThis() };
@@ -279,6 +315,7 @@ describe("getSupabaseDiscover — skill array search (regression for #1227)", ()
         data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
         error: null,
       }),
+      order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockImplementation(() => ({
         or: vi.fn().mockImplementation((arg) => {
           capturedOrArg = arg;
@@ -314,6 +351,7 @@ describe("getSupabaseDiscover — skill array search (regression for #1227)", ()
         data: { skills: [], learning_goals: [], interests: [], learn_subjects: [], teach_subjects: [], learning_style: null, preferred_language: null, timezone: null },
         error: null,
       }),
+      order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockImplementation(() => ({
         contains: vi.fn().mockImplementation((col, val) => {
           containsArgs = [col, val];


### PR DESCRIPTION
## Summary

Fixes unstable Discover pagination and hidden matches caused by an unordered `LIMIT 1000`.

## What was wrong

`getSupabaseDiscover` builds the profiles query with `.limit(1000)` and no `.order()` anywhere in the chain. Postgres doesn't guarantee row order without `ORDER BY` - the planner can return a different 1000 rows on different executions of the same query (after writes, autovacuum, or a plan change). That breaks two things once the platform has more than 1000 candidate profiles:

- the 1000-row window a user's best matches get scored from isn't stable, so a compatible profile can be scored on one request and silently missing on the next
- paginating through `page=1`, `page=2`, etc. isn't guaranteed to walk the same underlying set, so results can repeat or skip entirely

## Fix

Added `.order("id", { ascending: true })` before `.limit(1000)`, so the fetched window is deterministic and consistent across requests for the same user. This is the same style already used for the `.order().limit()` chain in `cronController.js`.

Left the 1000-row cap and JS-side scoring as-is for now - moving Discover onto a Postgres RPC like the existing `match_users` used in `getRecommendedPartners` would remove the cap entirely, but that's a bigger change than this fix needs to make.

## Testing

- Updated the `supabaseDiscover.test.js` mocks to include `order` in the chain (they only had `select/eq/neq/single/limit` before, which would have thrown once the real code called `.order()`)
- Added a test asserting `.order("id", { ascending: true })` is called on the profiles query before `.limit()`
- `npm run lint` clean, `npm test` - all 261 tests pass

Fixes #1815
