### PR TITLE
fix(ai): abort stalled upstream requests

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -19,6 +19,7 @@ const MAX_SUMMARY_MESSAGE_LENGTH = 1000;
 const MAX_SUMMARY_MESSAGES = 50;
 const MAX_ASK_MESSAGES = 10;
 const MAX_TOTAL_CONTENT_LENGTH = 20000;
+const AI_UPSTREAM_TIMEOUT_MS = 15_000;
 
 const escapeForPrompt = (str) =>
   str
@@ -120,7 +121,10 @@ const callOpenRouter = async ({ messages, maxTokens, temperature = 0.7, response
     body.response_format = responseFormat;
   }
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), AI_UPSTREAM_TIMEOUT_MS);
   let response;
+
   try {
     response = await fetch(OPENROUTER_URL, {
       method: "POST",
@@ -129,15 +133,18 @@ const callOpenRouter = async ({ messages, maxTokens, temperature = 0.7, response
         Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
       },
       body: JSON.stringify(body),
+      signal: controller.signal,
     });
   } catch (error) {
-    if (error.name === "AbortError") {
+    if (error?.name === "AbortError") {
       throw new HttpError(503, "AI request timed out. Please try again.", {
         retryable: true,
         reason: "timeout",
       });
     }
     throw error;
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   if (!response.ok) {

--- a/backend/tests/aiController.test.js
+++ b/backend/tests/aiController.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { askAI, generateSessionSummary } from "../controllers/aiController.js";
 
@@ -13,6 +13,10 @@ describe("aiController", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     process.env.OPENROUTER_API_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("sends max_tokens when handling askAI", async () => {
@@ -36,6 +40,42 @@ describe("aiController", () => {
     expect(payload.max_tokens).toBeGreaterThanOrEqual(64);
     expect(payload.max_tokens).toBeLessThanOrEqual(512);
     expect(res.json).toHaveBeenCalledWith({ answer: "hello" });
+  });
+
+  it("times out a stalled upstream request", async () => {
+    vi.useFakeTimers();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_url, requestInit) =>
+        new Promise((_, reject) => {
+          requestInit.signal.addEventListener(
+            "abort",
+            () => {
+              const error = new Error("Request aborted");
+              error.name = "AbortError";
+              reject(error);
+            },
+            { once: true }
+          );
+        })
+    );
+    const req = { body: { messages: [{ role: "user", content: "How do I start with DSA?" }] } };
+    const res = createRes();
+    const next = vi.fn();
+
+    const requestPromise = askAI(req, res, next);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    await requestPromise;
+
+    expect(fetchSpy.mock.calls[0][1].signal.aborted).toBe(true);
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "HttpError",
+        statusCode: 503,
+        details: { retryable: true, reason: "timeout" },
+      })
+    );
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it("returns strict summary JSON when model output is valid", async () => {


### PR DESCRIPTION
## Summary
- add an abortable deadline to the shared upstream request helper
- clear request timers after completion or failure
- cover stalled requests with a fake-timer regression test

## Testing
- `npm test`
- `npm run lint` (passes with existing warnings)
- `npm run build` (blocked by existing declaration-order errors in `src/pages/Chat.tsx`)

Fixes #1833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI requests that exceed 15 seconds now time out instead of hanging indefinitely.
  * Timed-out requests return a retryable service-unavailable error, allowing clients to try again.

* **Tests**
  * Added coverage to verify timeout handling and ensure timer behavior is properly reset between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->