### PR TITLE
fix: Fix Avatar Upload silent failure and file size check

### DIFF
--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -37,7 +37,6 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
       return;
     }
 
-    // Client-side pre-check for 5MB
     if (file.size > 5 * 1024 * 1024) {
       onUploadError(
         "Image is too large. Please upload an image smaller than 5MB."

--- a/src/components/AvatarUpload.tsx
+++ b/src/components/AvatarUpload.tsx
@@ -37,10 +37,10 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
       return;
     }
 
-    // Client-side pre-check for 50MB (though backend enforces it as well)
-    if (file.size > 50 * 1024 * 1024) {
+    // Client-side pre-check for 5MB
+    if (file.size > 5 * 1024 * 1024) {
       onUploadError(
-        "Image is too large. Please upload an image smaller than 50MB."
+        "Image is too large. Please upload an image smaller than 5MB."
       );
       return;
     }
@@ -84,7 +84,7 @@ export const AvatarUpload: React.FC<AvatarUploadProps> = ({
 
         if (res.status === 413) {
           throw new Error(
-            "Image is too large. Please upload an image smaller than 50MB."
+            "Image is too large. Please upload an image smaller than 5MB."
           );
         }
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -168,7 +168,7 @@ if (profile.bio.length > MAX_BIO_CHARS) {
               <AvatarUpload
                 currentAvatarUrl={profile.avatar_url}
                 onUploadSuccess={(url) => setProfile({ ...profile, avatar_url: url })}
-                onUploadError={(error) => alert(error)}
+                onUploadError={(error) => toast.error(error)}
               />
             </div>
 


### PR DESCRIPTION
��### Description

This PR fixes Issue #1821 where the Avatar Upload component would silently fail for large images.

### Changes:
- **Fixed Undefined Error**: Imported \API_BASE_URL\ inside \AvatarUpload.tsx\. Previously, the missing import was causing a \ReferenceError\ that was being silently swallowed by the catch block during the fetch call.
- **Client-side Size Enforcement**: Adjusted the client-side pre-upload file size check from 50MB down to 5MB to properly match backend expectations.
- **Improved UX**: Replaced the ugly, native \lert(error)\ in \Profile.tsx\ with a clean \	oast.error(error)\ for better user feedback when an upload fails.

### Closes
Closes durdana3105/peer-learning#1821
