### PR TITLE
fix: Prevent Markdown code blocks from overflowing horizontally

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,6 +45,7 @@ const Signup = React.lazy(() => import("./pages/Signup"));
 const Onboarding = React.lazy(() => import("./pages/Onboarding"));
 const Profile = React.lazy(() => import("./pages/Profile"));
 const EditProfile = React.lazy(() => import("./pages/EditProfile"));
+const Settings = React.lazy(() => import("./pages/Settings"));
 const Notifications = React.lazy(() => import("./pages/Notifications"));
 const Leaderboard = React.lazy(() => import("./pages/Leaderboard"));
 const Admin = React.lazy(() => import("./pages/Admin"));

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -16,7 +16,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,
   className = '',
 }) => (
-  <div className={`prose prose-invert max-w-none ${className}`}>
+  <div className={`prose prose-invert max-w-none overflow-x-auto ${className}`}>
     <ReactMarkdown
       remarkPlugins={remarkPlugins}
       rehypePlugins={rehypePlugins}

--- a/src/components/sessions/SessionChat.tsx
+++ b/src/components/sessions/SessionChat.tsx
@@ -204,7 +204,7 @@ export function SessionChat({
                   className={`flex ${isCurrentUser ? "justify-end" : "justify-start"}`}
                 >
                   <div
-                    className={`max-w-[80%] px-4 py-3 rounded-2xl ${
+                    className={`max-w-[80%] px-4 py-3 rounded-2xl overflow-hidden ${
                       isCurrentUser
                         ? "bg-gradient-to-r from-cyan-400 to-purple-500 text-black"
                         : "bg-white/10"

--- a/src/hooks/useSkillEndorsements.test.ts
+++ b/src/hooks/useSkillEndorsements.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: {
     auth: {
       getUser: vi.fn(),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
     },
     from: vi.fn(),
   },

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -35,6 +35,7 @@ export default function Sessions() {
     sendTypingEvent,
     handleLeaveVideo,
     handleJoinVideo,
+    togglePinMessage,
   } = useSessions(user);
 
   return (
@@ -98,6 +99,7 @@ export default function Sessions() {
               studyTime={studyTime}
               isFocusMode={isFocusMode}
               setIsFocusMode={setIsFocusMode}
+              togglePinMessage={togglePinMessage}
               sendMessage={sendMessage}
               sendTypingEvent={sendTypingEvent}
               handleLeaveVideo={handleLeaveVideo}


### PR DESCRIPTION
��### Description

This PR fixes Issue #1822 where long Markdown code blocks (e.g., from the LiveCodeRunner) were overflowing their containers and causing horizontal scrollbars that broke the Chat layout on smaller/mobile screens.

### Changes:
- **MarkdownRenderer**: Added \overflow-x-auto\ directly to the \MarkdownRenderer\'s wrapper container. This enables clean horizontal scrolling of oversized code blocks without letting them leak out.
- **SessionChat Bubbles**: Added \overflow-hidden\ to the parent chat bubble \div\. This ensures the chat bubble strictly respects its \max-w-[80%]\ constraint and forces the MarkdownRenderer to contain itself properly within the bubble.

### Closes
Closes durdana3105/peer-learning#1822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wide Markdown content now scrolls horizontally instead of overflowing the page.
  * Updated chat message styling to restore/maintain pinned-message control behavior on hover.
* **Tests**
  * Improved auth mock behavior in skill endorsement hook tests to support rapid-toggle interaction coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->