### PR TITLE
feat: Pin Important Messages and Resources in Session Chat

### DIFF
--- a/src/components/sessions/SessionChat.tsx
+++ b/src/components/sessions/SessionChat.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from "react";
-import { Send, Video, Sparkles, BellOff, Bell, Download } from "lucide-react";
+import { Send, Video, Sparkles, BellOff, Bell, Download, Pin, PinOff } from "lucide-react";
 import { LiveCodeRunner } from "@/components/studyroom/LiveCodeRunner";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
 
@@ -17,6 +17,7 @@ type SessionChatProps = {
   isFocusMode: boolean;
   setIsFocusMode: (val: boolean) => void;
   sendMessage: (msg: string) => void;
+  togglePinMessage: (msgId: string, currentPinStatus: boolean) => void;
   sendTypingEvent: () => void;
   handleLeaveVideo: () => void;
   handleJoinVideo: () => void;
@@ -37,6 +38,7 @@ export function SessionChat({
   isFocusMode,
   setIsFocusMode,
   sendMessage,
+  togglePinMessage,
   sendTypingEvent,
   handleLeaveVideo,
   handleJoinVideo,
@@ -44,6 +46,8 @@ export function SessionChat({
 }: SessionChatProps) {
   const [message, setMessage] = useState("");
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  
+  const pinnedMessages = messages.filter((msg) => msg.is_pinned);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -193,6 +197,33 @@ export function SessionChat({
             </button>
           )}
 
+          {/* PINNED MESSAGES HEADER */}
+          {pinnedMessages.length > 0 && (
+            <div className="mt-4 bg-white/5 border border-cyan-500/20 rounded-2xl p-4 shadow-lg shadow-cyan-500/5">
+              <div className="flex items-center gap-2 mb-3 border-b border-white/5 pb-2">
+                <Pin className="text-cyan-400" size={16} />
+                <h3 className="font-semibold text-cyan-300 text-sm">Pinned Resources</h3>
+              </div>
+              <div className="space-y-3 max-h-40 overflow-y-auto pr-2">
+                {pinnedMessages.map((msg) => (
+                  <div key={`pinned-${msg.id}`} className="bg-black/20 rounded-xl p-3 border border-white/5 relative group">
+                    <p className="text-xs text-cyan-500 font-medium mb-1">{msg.username}</p>
+                    <div className="text-sm">
+                      <MarkdownRenderer content={msg.message} />
+                    </div>
+                    <button
+                      onClick={() => togglePinMessage(msg.id, true)}
+                      className="absolute top-2 right-2 p-1.5 bg-white/5 rounded-lg opacity-0 group-hover:opacity-100 hover:bg-white/10 text-gray-400 hover:text-red-400 transition"
+                      title="Unpin message"
+                    >
+                      <PinOff size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
           {/* MESSAGES */}
           <div className="flex-1 overflow-y-auto py-5 space-y-4">
             {messages.map((msg) => {
@@ -204,15 +235,33 @@ export function SessionChat({
                   className={`flex ${isCurrentUser ? "justify-end" : "justify-start"}`}
                 >
                   <div
-                    className={`max-w-[80%] px-4 py-3 rounded-2xl ${
+                    className={`max-w-[80%] px-4 py-3 rounded-2xl overflow-hidden relative group ${
                       isCurrentUser
                         ? "bg-gradient-to-r from-cyan-400 to-purple-500 text-black"
                         : "bg-white/10"
                     }`}
                   >
-                    {!isCurrentUser && (
-                      <p className="text-xs text-cyan-300 mb-1">{msg.username}</p>
-                    )}
+                    <div className="flex items-center justify-between mb-1">
+                      {!isCurrentUser && (
+                        <p className="text-xs text-cyan-300">{msg.username}</p>
+                      )}
+                      {msg.is_pinned && isCurrentUser && (
+                        <p className="text-xs text-black/60 font-bold ml-auto flex items-center gap-1"><Pin size={10} /> Pinned</p>
+                      )}
+                      {msg.is_pinned && !isCurrentUser && (
+                        <p className="text-xs text-cyan-300/60 font-bold ml-auto flex items-center gap-1"><Pin size={10} /> Pinned</p>
+                      )}
+                    </div>
+                    
+                    <button
+                      onClick={() => togglePinMessage(msg.id, !!msg.is_pinned)}
+                      className={`absolute top-2 right-2 p-1.5 rounded-lg opacity-0 group-hover:opacity-100 transition ${
+                        isCurrentUser ? "hover:bg-black/10 text-black/70" : "hover:bg-white/10 text-white/70"
+                      }`}
+                      title={msg.is_pinned ? "Unpin message" : "Pin message"}
+                    >
+                      {msg.is_pinned ? <PinOff size={14} /> : <Pin size={14} />}
+                    </button>
 
                     <MarkdownRenderer content={msg.message} />
 

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -156,6 +156,11 @@ export function useSessions(user: any) {
           setMessages((prev) => [...prev, payload.new]);
         }
       })
+      .on("postgres_changes", { event: "UPDATE", schema: "public", table: "messages", filter: `session_id=eq.${selectedSession.id}` }, (payload: any) => {
+        if (payload.new.session_id === selectedSession.id) {
+          setMessages((prev) => prev.map(msg => msg.id === payload.new.id ? payload.new : msg));
+        }
+      })
       .on("presence", { event: "sync" }, () => {
         const state = roomChannel.presenceState();
         setParticipantCount(Math.max(1, Object.keys(state).length));
@@ -307,6 +312,28 @@ export function useSessions(user: any) {
     }
   }, [selectedSession, user, toast]);
 
+  const togglePinMessage = useCallback(async (messageId: string, currentPinnedState: boolean) => {
+    if (!selectedSession) return;
+    try {
+      const { error } = await (supabase as any)
+        .from("messages")
+        .update({ is_pinned: !currentPinnedState })
+        .eq("id", messageId)
+        .eq("session_id", selectedSession.id);
+        
+      if (error) throw error;
+      
+      // Optimistic UI update
+      setMessages((prev) => prev.map(msg => msg.id === messageId ? { ...msg, is_pinned: !currentPinnedState } : msg));
+      
+      if (!currentPinnedState) {
+        toast({ title: "Message Pinned", description: "This message is now pinned to the top of the chat." });
+      }
+    } catch (err: any) {
+      toast({ title: "Failed to update pin status", description: err.message || "An unexpected error occurred.", variant: "destructive" });
+    }
+  }, [selectedSession, toast]);
+
   const sendTypingEvent = useCallback(() => {
     if (channelRef.current) {
       channelRef.current.send({
@@ -389,6 +416,7 @@ export function useSessions(user: any) {
     setIsFocusMode,
     handleJoinSession,
     sendMessage,
+    togglePinMessage,
     sendTypingEvent,
     handleLeaveVideo,
     handleJoinVideo,

--- a/supabase/migrations/20260722000000_add_is_pinned_to_messages.sql
+++ b/supabase/migrations/20260722000000_add_is_pinned_to_messages.sql
@@ -1,0 +1,2 @@
+-- Add is_pinned column to messages table for pinning important resources in Session Chat
+alter table public.messages add column if not exists is_pinned boolean default false;


### PR DESCRIPTION
## Description

This PR implements the highly requested \
Pin
Message\ feature (Issue #1823), allowing users to permanently highlight important resources and code snippets in the Session Chat.

### Changes:
- **Database Migration**: Added a new Supabase SQL migration script (\20260722000000_add_is_pinned_to_messages.sql\) which safely adds an \is_pinned\ boolean column to the \messages\ table.
- **Realtime Sync**: Updated the Supabase realtime channel listener in \useSessions.ts\ to capture \UPDATE\ events, ensuring that when someone pins or unpins a message, it visually toggles instantly for everyone in the room.
- **UI/UX Updates**: Added hover-enabled Pin/Unpin buttons on individual messages. Pinned messages are grouped into a dedicated, visually distinct \
Pinned
Resources\ header section at the top of the chat area for easy access.

### Closes
Closes durdana3105/peer-learning#1823
