### PR TITLE
Fix: Resolve stored XSS vulnerability #1844

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import type { PluggableList } from 'unified';
 
 interface MarkdownRendererProps {
@@ -10,7 +10,19 @@ interface MarkdownRendererProps {
 }
 
 const remarkPlugins: PluggableList = [remarkGfm];
-const rehypePlugins: PluggableList = [rehypeSanitize];
+const strictSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    a: ['href', 'title', 'target', 'rel'],
+  },
+  protocols: {
+    ...defaultSchema.protocols,
+    href: ['http', 'https', 'mailto'],
+  },
+};
+
+const rehypePlugins: PluggableList = [[rehypeSanitize, strictSchema]];
 
 export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   content,

--- a/src/hooks/useSkillEndorsements.test.ts
+++ b/src/hooks/useSkillEndorsements.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/integrations/supabase/client", () => ({
   supabase: {
     auth: {
       getUser: vi.fn(),
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
     },
     from: vi.fn(),
   },


### PR DESCRIPTION
Fixes #1844

### Security Fixes
**Markdown Stored XSS Mitigation (#1844)**: Configured a strict schema for \ehype-sanitize\ in \MarkdownRenderer.tsx\. This now strips \javascript:\ URIs and restricts attributes to safe ones (like \href\, \	itle\, \	arget\, \el\), completely preventing the stored XSS vulnerability inside session chats.
