### PR TITLE
Fix: Harden file upload validation 

### DIFF
--- a/backend/controllers/uploadController.js
+++ b/backend/controllers/uploadController.js
@@ -4,6 +4,7 @@ import fs from "fs";
 import crypto from "crypto";
 import { getSupabaseAdmin } from "../utils/supabase.js";
 import { HttpError } from "../utils/httpError.js";
+import { fileTypeFromFile } from "file-type";
 
 // Ensure files do not exceed 50MB
 const MAX_FILE_SIZE = 50 * 1024 * 1024;
@@ -102,6 +103,61 @@ export const handleUpload = async (req, res, next) => {
     if (!preset || !preset.mimetypes.has(file.mimetype)) {
       fs.unlinkSync(file.path);
       throw new HttpError(400, "Invalid destination folder or file type.");
+    }
+
+    // Additional Server-Side Content Validation
+    const detectedType = await fileTypeFromFile(file.path);
+
+    if (detectedType) {
+      // The file has a recognized binary signature.
+      // If the detected type is in our preset, it's safe.
+      // Exception: docx files are zip archives and might be detected as such. 
+      // If the client claims docx and it's a zip, we keep docx to maintain the extension.
+      let isAllowed = preset.mimetypes.has(detectedType.mime);
+      let finalMime = detectedType.mime;
+
+      if (detectedType.mime === "application/zip" && file.mimetype === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+        isAllowed = true;
+        finalMime = file.mimetype;
+      }
+
+      if (!isAllowed) {
+        fs.unlinkSync(file.path);
+        throw new HttpError(400, `File content (${detectedType.mime}) is not allowed for this folder.`);
+      }
+
+      file.mimetype = finalMime;
+    } else {
+      // The file-type library could not recognize the signature (common for plain text).
+      // Verify that the client-provided mimetype is indeed a text type we allow.
+      const allowedTextTypes = new Set([
+        "text/plain",
+        "text/markdown",
+        "text/javascript",
+        "text/x-python",
+        "application/x-python-code",
+        "application/typescript",
+      ]);
+
+      if (!allowedTextTypes.has(file.mimetype)) {
+        fs.unlinkSync(file.path);
+        throw new HttpError(400, "Unrecognized file signature for binary format, or invalid text type.");
+      }
+
+      // To prevent masquerading binary files as text, check for null bytes in the first 4KB
+      const fd = fs.openSync(file.path, 'r');
+      const buffer = Buffer.alloc(4096);
+      let bytesRead = 0;
+      try {
+        bytesRead = fs.readSync(fd, buffer, 0, 4096, 0);
+      } finally {
+        fs.closeSync(fd);
+      }
+      
+      if (buffer.subarray(0, bytesRead).includes(0x00)) {
+        fs.unlinkSync(file.path);
+        throw new HttpError(400, "File claims to be text but contains binary data.");
+      }
     }
 
     const userId = req.user?.id;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1145,6 +1145,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2327,6 +2328,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Resolves #1375 

The file upload endpoint previously relied on the client-provided MIME type (`req.file.mimetype`), leaving it vulnerable to MIME spoofing where a user could disguise malicious or unsupported files. 

This PR hardens server-side validation by introducing strict content inspection using the `file-type` package and adding text-file byte validation. 

## Changes Made
- **Implemented Server-Side MIME Validation**: Added the `file-type` library in `uploadController.js` to inspect the underlying binary signatures (magic numbers) of uploaded files instead of trusting the client header.
- **Added Text File Sanitization**: Since text and code files (`.txt`, `.js`, `.py`, `.md`) do not have binary signatures, the controller now inspects the first 4KB chunk of text uploads for null bytes (`0x00`) to prevent disguised executables from bypassing filters.
- **Enhanced Error Handling**: Suspicious or mismatched files are now immediately deleted from the temporary storage and rejected with clear HTTP 400 error messages.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security update (improves validation and prevents potential upload attacks)

## Testing Performed
- Verified that binary files (Images, PDFs, ZIPs) are correctly identified by their magic numbers and allowed only if they match the preset constraints.
- Verified that files containing mismatched extensions and signatures are properly rejected.
- Verified that files uploaded as text formats containing null bytes are rejected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload validation by checking a file’s actual content rather than relying solely on its declared type.
  * Rejected files with mismatched, unsupported, or disguised binary content.
  * Added support for valid DOCX uploads detected as ZIP files.
  * Invalid uploads are now removed automatically and return a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->