### PR TITLE
feat: add redo support for collaborative whiteboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,7 @@ const Onboarding = React.lazy(() => import("./pages/Onboarding"));
 const Profile = React.lazy(() => import("./pages/Profile"));
 const EditProfile = React.lazy(() => import("./pages/EditProfile"));
 const Notifications = React.lazy(() => import("./pages/Notifications"));
+const Settings = React.lazy(() => import("./pages/Settings"));
 const Leaderboard = React.lazy(() => import("./pages/Leaderboard"));
 const Admin = React.lazy(() => import("./pages/Admin"));
 const ForgotPassword = React.lazy(() => import("./pages/ForgotPassword"));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,8 +104,8 @@ function AppContent() {
     <>
       <MouseSparkles />
       <CookieConsentBanner />
-
-      <Routes>
+      <Suspense fallback={<SplashScreen />}></Suspense>
+        <Routes>
           <Route
             path="/"
             element={user ? <Navigate to="/dashboard" replace /> : <WithNav><Index /></WithNav>}

--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -39,6 +39,10 @@ export default function Canvas({ roomId }: Props) {
 
   const [color, setColor] = useState("#ffffff");
 
+  const [canUndo, setCanUndo] = useState(false);
+
+  const [canRedo, setCanRedo] = useState(false);
+
   const [lineWidth] = useState(3);
 
   const resizeCanvas = () => {
@@ -156,6 +160,9 @@ export default function Canvas({ roomId }: Props) {
     };
 
     strokesRef.current.push(ownedEvent);
+
+    setCanUndo(true);
+    setCanRedo(false);
 
     const ctx = getContext();
 
@@ -373,6 +380,9 @@ const updated = events.filter(
 
 strokesRef.current = updated;
 
+setCanUndo(updated.length > 0);
+setCanRedo(true);
+
 replayCanvas();
 
     const { error: undoError } = await supabase
@@ -404,6 +414,9 @@ replayCanvas();
   strokesRef.current.push(...stroke);
 
   replayCanvas();
+  
+  setCanRedo(redoStackRef.current.length > 0);
+  setCanUndo(true);
 
   // Save and broadcast again
   for (const event of stroke) {
@@ -429,6 +442,7 @@ replayCanvas();
     lastPointRef.current.clear();
 
     strokesRef.current = [];
+    redoStackRef.current = [];
 
     const { error: clearError } = await supabase
       .from("whiteboard_events" as any)
@@ -483,13 +497,23 @@ replayCanvas();
         <div className="ml-auto flex items-center gap-2">
           <button
             onClick={undoLastStroke}
-            className="px-3 py-1 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700"
-          >
+            disabled={!canUndo}
+            className={`px-3 py-1 rounded text-sm ${
+              canUndo
+                ? "bg-slate-800 text-slate-300 hover:bg-slate-700"
+                : "bg-slate-700 text-slate-500 cursor-not-allowed"
+            }`}
+            >
             Undo
           </button>
           <button
             onClick={redoLastStroke}
-            className="px-3 py-1 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700"
+            disabled={!canRedo}
+            className={`px-3 py-1 rounded text-sm ${
+              canRedo
+                ? "bg-slate-800 text-slate-300 hover:bg-slate-700"
+                : "bg-slate-700 text-slate-500 cursor-not-allowed"
+            }`}
             >
             Redo
             </button>

--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -348,79 +348,99 @@ export default function Canvas({ roomId }: Props) {
     currentStrokeId.current = null;
   };
   const undoLastStroke = async () => {
-    const events = [...strokesRef.current];
+  const events = [...strokesRef.current];
 
-    let lastStrokeId: string | undefined;
+  let lastStrokeId: string | undefined;
 
-    for (let i = events.length - 1; i >= 0; i--) {
-      if (events[i].user_id !== user?.id) continue;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i].user_id !== user?.id) continue;
 
-      const strokeId =
-        events[i].payload?.strokeId;
+    const strokeId = events[i].payload?.strokeId;
 
-      if (strokeId) {
-        lastStrokeId = strokeId;
-        break;
-      }
+    if (strokeId) {
+      lastStrokeId = strokeId;
+      break;
     }
+  }
 
-    if (!lastStrokeId) return;
+  if (!lastStrokeId) return;
 
-    // Save the removed stroke for redo
-const removedStroke = events.filter(
-  (event) => event.payload?.strokeId === lastStrokeId
-);
+  const removedStroke = events.filter(
+    (event) => event.payload?.strokeId === lastStrokeId
+  );
 
-redoStackRef.current.push(removedStroke);
+  // First delete from database
+  const { error: undoError } = await supabase
+    .from("whiteboard_events" as any)
+    .delete()
+    .eq("room_id", roomId)
+    .eq("user_id", user?.id)
+    .eq("payload->>strokeId", lastStrokeId);
 
-// Remove it from the canvas
-const updated = events.filter(
-  (event) => event.payload?.strokeId !== lastStrokeId
-);
+  if (undoError) {
+    console.error("Undo failed to sync:", undoError);
+    toast.error("Undo could not be saved. Please check your connection.");
+    return;
+  }
 
-strokesRef.current = updated;
+  // Update local history only after database success
+  redoStackRef.current.push(removedStroke);
 
-setCanUndo(updated.length > 0);
-setCanRedo(true);
+  const updated = events.filter(
+    (event) => event.payload?.strokeId !== lastStrokeId
+  );
 
-replayCanvas();
+  strokesRef.current = updated;
 
-    const { error: undoError } = await supabase
-      .from("whiteboard_events" as any)
-      .delete()
-      .eq("room_id", roomId)
-      .eq("user_id", user?.id)
-      .eq("payload->>strokeId", lastStrokeId);
+  setCanUndo(updated.length > 0);
+  setCanRedo(true);
 
-    if (undoError) {
-      console.error("Undo failed to sync:", undoError);
-      toast.error("Undo could not be saved. Please check your connection.");
-    }
+  replayCanvas();
 
-    broadcastEvent({
-      type: "undo",
-      payload: {
-        strokeId: lastStrokeId,
-      },
-    });
-  };
+  broadcastEvent({
+    type: "undo",
+    payload: {
+      strokeId: lastStrokeId,
+    },
+  });
+};
 
   const redoLastStroke = async () => {
-  const stroke = redoStackRef.current.pop();
+  const stroke = redoStackRef.current[
+    redoStackRef.current.length - 1
+  ];
 
   if (!stroke) return;
 
-  // Add the stroke back
+  // Persist first
+  for (const event of stroke) {
+    const { error } = await supabase
+      .from("whiteboard_events" as any)
+      .insert({
+        room_id: roomId,
+        user_id: user?.id,
+        type: event.type,
+        payload: event.payload,
+      });
+
+    if (error) {
+      console.error("Redo failed to sync:", error);
+      toast.error("Redo could not be saved. Please check your connection.");
+      return;
+    }
+  }
+
+  // Only remove from redo stack after success
+  redoStackRef.current.pop();
+
   strokesRef.current.push(...stroke);
 
   replayCanvas();
-  
+
   setCanRedo(redoStackRef.current.length > 0);
   setCanUndo(true);
 
-  // Save and broadcast again
   for (const event of stroke) {
-    await persistEvent(event);
     broadcastEvent(event);
   }
 };

--- a/src/components/Whiteboard/Canvas.tsx
+++ b/src/components/Whiteboard/Canvas.tsx
@@ -25,6 +25,8 @@ export default function Canvas({ roomId }: Props) {
 
   const strokesRef = useRef<WhiteboardEvent[]>([]);
 
+  const redoStackRef = useRef<WhiteboardEvent[][]>([]);
+
   const currentStrokeId = useRef<string | null>(null);
 
   const lastPointRef = useRef<Map<string, Point>>(new Map());
@@ -281,6 +283,9 @@ export default function Canvas({ roomId }: Props) {
 
     currentStrokeId.current = strokeId;
 
+// New drawing clears redo history
+    redoStackRef.current = [];
+
     pushEvent({
       type: "draw-start",
       payload: {
@@ -354,15 +359,21 @@ export default function Canvas({ roomId }: Props) {
 
     if (!lastStrokeId) return;
 
-    const updated = events.filter(
-      (event) =>
-        event.payload?.strokeId !==
-        lastStrokeId
-    );
+    // Save the removed stroke for redo
+const removedStroke = events.filter(
+  (event) => event.payload?.strokeId === lastStrokeId
+);
 
-    strokesRef.current = updated;
+redoStackRef.current.push(removedStroke);
 
-    replayCanvas();
+// Remove it from the canvas
+const updated = events.filter(
+  (event) => event.payload?.strokeId !== lastStrokeId
+);
+
+strokesRef.current = updated;
+
+replayCanvas();
 
     const { error: undoError } = await supabase
       .from("whiteboard_events" as any)
@@ -383,6 +394,23 @@ export default function Canvas({ roomId }: Props) {
       },
     });
   };
+
+  const redoLastStroke = async () => {
+  const stroke = redoStackRef.current.pop();
+
+  if (!stroke) return;
+
+  // Add the stroke back
+  strokesRef.current.push(...stroke);
+
+  replayCanvas();
+
+  // Save and broadcast again
+  for (const event of stroke) {
+    await persistEvent(event);
+    broadcastEvent(event);
+  }
+};
 
   const clearBoard = async () => {
     if (user?.id !== hostId) return;
@@ -459,7 +487,12 @@ export default function Canvas({ roomId }: Props) {
           >
             Undo
           </button>
-
+          <button
+            onClick={redoLastStroke}
+            className="px-3 py-1 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700"
+            >
+            Redo
+            </button>
           {user?.id === hostId && (
             <button
               onClick={clearBoard}

--- a/src/components/Whiteboard/types.ts
+++ b/src/components/Whiteboard/types.ts
@@ -7,7 +7,8 @@ export type WhiteboardEventType =
   | "draw-move"
   | "draw-end"
   | "clear"
-  | "undo";
+  | "undo"
+  | "redo";
 
 export type Point = {
   x: number;


### PR DESCRIPTION
## Summary
This PR adds redo functionality to the collaborative whiteboard.

### Changes
- Added a Redo button to the whiteboard toolbar.
- Implemented redo functionality to restore the last undone stroke.
- Cleared redo history when a new stroke is drawn.
- Preserved existing Undo and Clear functionality.

Fixes #1726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the Settings page through the existing settings route.
  - Added Redo functionality to the whiteboard, allowing users to restore recently undone strokes.
  - Whiteboard undo and redo actions now synchronize across connected sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->