### PR TITLE
fix: /api/match/recommendations 500 — role guard selects nonexistent is_admin column

### DIFF
--- a/backend/middlewares/requireAuth.js
+++ b/backend/middlewares/requireAuth.js
@@ -202,7 +202,11 @@ export const requireProfileRole = (...allowedRoles) => async (req, res, next) =>
 
     const { data: profile, error } = await supabaseAdmin
       .from("profiles")
-      .select("id, is_mentor, is_learner, is_admin")
+      // is_admin is intentionally not selected: no migration creates that column,
+      // and selecting it makes PostgREST reject the query (500). deriveActiveRoles
+      // reads profile?.is_admin defensively, so admin derivation resumes with no
+      // code change if a future migration adds the column back to this select.
+      .select("id, is_mentor, is_learner")
       .eq("id", req.user.id)
       .maybeSingle();
 


### PR DESCRIPTION
### What & why
`requireProfileRole` (`backend/middlewares/requireAuth.js`) selected `"id, is_mentor, is_learner, is_admin"` from `profiles`, but **no migration ever creates an `is_admin` column** (only `is_mentor`/`is_learner` exist). PostgREST rejects the unknown column, the guard hits its `if (error)` branch, and throws `HttpError(500)`.

That guard protects `/api/match/recommendations` (`requireProfileRole("mentor","learner")`), so **that endpoint 500s on every request**.

### Fix
Drop `is_admin` from the select (one line). `deriveActiveRoles` already reads `profile?.is_admin` defensively via optional chaining, so:
- No admin role is derived — which is the de-facto current behaviour, since the column never existed and any attempt to read it crashed.
- If a future migration adds the column and re-adds it to this select, admin derivation resumes with **zero** further code change.

I deliberately did **not** add an `is_admin` column: the repo carefully restricts self-updates to profile columns (`restrict_profiles_rls`, `profiles_update_column_restriction`), so introducing a self-settable admin flag would need matching RLS hardening — out of scope for a 500 fix.

A clarifying comment is added at the select so the intent is obvious.

Closes #1883

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile authorization handling while preserving existing role-based access behavior.
  * Reduced unnecessary profile data retrieved during authorization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->