### PR TITLE
fix: bound askAI systemPrompt and count it toward content/token caps

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -185,12 +185,21 @@ export const askAI = async (req, res, next) => {
       totalContentLength += m.content.length;
     }
 
+    // systemPrompt is forwarded to the model too, so it must count toward the
+    // total-content cap and the response-token budget — otherwise a large
+    // systemPrompt bypasses both and inflates upstream token cost.
+    const systemPromptText = typeof systemPrompt === "string" ? systemPrompt : "";
+    totalContentLength += systemPromptText.length;
+
     if (totalContentLength > MAX_TOTAL_CONTENT_LENGTH) {
       return res.status(400).json({ error: "Total message content exceeds maximum allowed length." });
     }
 
     const latestMessage = messages[messages.length - 1].content;
-    const maxTokens = budgetResponseTokens(latestMessage, ASK_AI_MAX_TOKENS);
+    const maxTokens = budgetResponseTokens(
+      systemPromptText ? `${systemPromptText}\n${latestMessage}` : latestMessage,
+      ASK_AI_MAX_TOKENS
+    );
 
     const model = ALLOWED_MODELS.includes(requestedModel) ? requestedModel : OPENROUTER_MODEL;
     

--- a/backend/validation/schemas.js
+++ b/backend/validation/schemas.js
@@ -94,7 +94,7 @@ export const aiSchemas = {
           content: z.string().trim().min(1).max(4000),
         })
       ).min(1).max(MAX_ASK_MESSAGES),
-      systemPrompt: z.string().optional(),
+      systemPrompt: z.string().max(2000).optional(),
       model: z.string().optional()
     }),
   },


### PR DESCRIPTION
### What & why
`aiSchemas.askAI` declared `systemPrompt: z.string().optional()` with **no `.max()`**, and `askAI()` (`backend/controllers/aiController.js`):
- summed only `messages` for the `MAX_TOTAL_CONTENT_LENGTH` (20,000) check, and
- measured only the latest message for `budgetResponseTokens`.

`systemPrompt` is forwarded verbatim to OpenRouter, so a client could send a multi-megabyte `systemPrompt` that passes every guard, defeating the per-message/total caps and inflating upstream token cost. (Distinct from the separate `/chat` route in #1598.)

### Fix
- **schemas.js** — cap `systemPrompt` at `.max(2000)` (hard reject at validation).
- **aiController.js** — add `systemPrompt.length` to `totalContentLength` so the 20k total cap includes it, and fold `systemPrompt` into the `budgetResponseTokens` input so the response-token budget reflects the real input size.

Defense in depth: the schema rejects oversized prompts up front; the controller counting protects the cap even if the prompt reaches it by any other path.

Closes #1886