### PR TITLE
Fix: Make session chat message sending reliable and prevent silent failures

### DIFF
--- a/src/components/sessions/SessionChat.tsx
+++ b/src/components/sessions/SessionChat.tsx
@@ -16,7 +16,7 @@ type SessionChatProps = {
   studyTime: number;
   isFocusMode: boolean;
   setIsFocusMode: (val: boolean) => void;
-  sendMessage: (msg: string) => void;
+  sendMessage: (msg: string) => Promise<boolean>;
   togglePinMessage: (msgId: string, currentPinStatus: boolean) => void;
   sendTypingEvent: () => void;
   handleLeaveVideo: () => void;
@@ -317,12 +317,12 @@ export function SessionChat({
           {/* INPUT */}
           <div className="pt-4 border-t border-white/10 flex gap-3">
             <LiveCodeRunner 
-              onShare={(code, lang, output) => {
+              onShare={async (code, lang, output) => {
                 let formattedMessage = `\`\`\`${lang}\n${code}\n\`\`\``;
                 if (output) {
                   formattedMessage += `\n**Output:**\n\`\`\`text\n${output}\n\`\`\``;
                 }
-                sendMessage(formattedMessage);
+                await sendMessage(formattedMessage);
               }}
             />
             <input
@@ -333,19 +333,27 @@ export function SessionChat({
                 setMessage(e.target.value);
                 sendTypingEvent();
               }}
-              onKeyDown={(e) => {
+              onKeyDown={async (e) => {
                 if (e.key === "Enter") {
-                  sendMessage(message);
-                  setMessage("");
+                  if (message.trim()) {
+                    const success = await sendMessage(message);
+                    if (success) {
+                      setMessage("");
+                    }
+                  }
                 }
               }}
               className="flex-1 bg-white/10 border border-white/10 rounded-2xl px-4 py-3 outline-none focus:border-cyan-400 text-white"
             />
 
             <button
-              onClick={() => {
-                sendMessage(message);
-                setMessage("");
+              onClick={async () => {
+                if (message.trim()) {
+                  const success = await sendMessage(message);
+                  if (success) {
+                    setMessage("");
+                  }
+                }
               }}
               className="bg-gradient-to-r from-cyan-400 to-purple-500 text-black p-4 rounded-2xl hover:opacity-90 transition"
             >

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -303,7 +303,7 @@ export function useSessions(user: any) {
   }, [user, awardXP, toast]);
 
   const sendMessage = useCallback(async (msgText: string) => {
-    if (!msgText.trim() || !selectedSession) return;
+    if (!msgText.trim() || !selectedSession) return false;
 
     const activity = {
       id: Date.now(),
@@ -330,8 +330,10 @@ export function useSessions(user: any) {
         });
 
       if (error) throw error;
+      return true;
     } catch (err: any) {
       toast({ title: "Failed to send message", description: err.message || "An unexpected error occurred.", variant: "destructive" });
+      return false;
     }
   }, [selectedSession, user, toast]);
 


### PR DESCRIPTION
## Closes #1374 

**Problem:**
Previously, when a user sent a message in the session chat, the input field was cleared immediately without waiting for the backend to confirm the message was successfully saved. If an error occurred (e.g., database insertion failure), the user would lose the message they just typed, leading to a frustrating and silent failure. 

**Solution:**
Improved the message send flow to ensure the UI accurately reflects the success or failure of the message insertion:
- **`useSessions.ts`**: Updated the `sendMessage` hook to return a `Promise<boolean>` which resolves to `true` on successful insert and `false` if an error occurs.
- **`SessionChat.tsx`**: Updated the input handlers (Enter key, Send button, and LiveCodeRunner) to `await` the result of `sendMessage`. The input field is now only cleared if the message is confirmed to be successfully sent. If a failure occurs, the user's typed text remains safely in the input field.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented empty messages from being submitted.
  * Text and shared code now clear from the input only after successful delivery.
  * Preserved entered content when sending fails, making it easier to retry.
  * Improved message delivery feedback and handling when no session is selected or a send operation encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->