### PR TITLE
Fix: Video Room layout overflows and breaks in mobile portrait view #1910

### DIFF
--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -10,7 +10,7 @@ interface VideoRoomProps {
 
 const VideoRoom: React.FC<VideoRoomProps> = ({ roomName, userName, onLeave }) => {
   return (
-    <div className="w-full h-[750px] bg-white/5 border border-white/10 backdrop-blur-2xl rounded-3xl overflow-hidden relative">
+    <div className="w-full h-[60vh] md:h-[750px] bg-white/5 border border-white/10 backdrop-blur-2xl rounded-3xl overflow-hidden relative flex flex-col">
       <JitsiMeeting
         domain="meet.jit.si"
         roomName={`PeerLearning_${roomName}`}

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -60,7 +60,7 @@ export default function Sessions() {
         />
 
         {/* CONTENT */}
-        <div className="grid lg:grid-cols-3 gap-6">
+        <div className="flex flex-col lg:grid lg:grid-cols-3 gap-6">
           {/* LEFT SIDE */}
           <div className="lg:col-span-2">
             <div className="flex items-center gap-2 mb-6">


### PR DESCRIPTION
Fixes #1910

### Changes
- Updated the \VideoRoom\ container height to use \60vh\ on mobile devices and \750px\ on desktop/tablet to prevent vertical stretching.
- Converted the main layout grid in \Sessions.tsx\ to use \lex-col\ on mobile, ensuring the chat sidebar stacks cleanly below the video container rather than overflowing or getting squeezed.
- The UI is now responsive and scrollable in mobile portrait view.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layouts for video rooms and sessions.
  * Video room content now adapts its height and stacks vertically on smaller screens.
  * Sessions content now displays in a single column on smaller screens and a three-column grid on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->