### PR TITLE
Fix: Notification bell badge count doesn't update in real-time #1911

### DIFF
--- a/src/features/notifications/useNotifications.ts
+++ b/src/features/notifications/useNotifications.ts
@@ -164,9 +164,10 @@ export function useNotifications(userId?: string) {
             return [incoming, ...current];
           });
 
-          // Re-fetch the authoritative unread count rather than incrementing
-          // locally, since the loaded page may not include every notification.
-          fetchUnreadCount();
+          // Increment locally since Realtime can sometimes beat the read replica
+          if (!incoming.read) {
+            setUnreadCount((current) => current + 1);
+          }
 
           // Check focus mode before showing popup
           supabase.from('profiles').select('is_in_focus_mode').eq('id', userId).single().then(({ data }) => {


### PR DESCRIPTION
Fixes #1911

### Changes
- Updated \useNotifications.ts\ to increment the \unreadCount\ locally immediately upon receiving a Supabase Realtime \INSERT\ event.
- This bypasses the read-replica race condition where calling \etchUnreadCount()\ directly after an event can return stale counts before the WAL is replicated.
- The notification bell badge now updates instantly in real-time.
