### PR TITLE
fix: stop exposing every user's email address through profiles RLS (#1924)

### DIFF
--- a/src/components/messages/Sidebar.tsx
+++ b/src/components/messages/Sidebar.tsx
@@ -97,7 +97,6 @@ export function Sidebar({
     return conversationSummaries.filter(({ profile, lastMessage }) => {
       const haystack = [
         getDisplayName(profile),
-        profile.email ?? "",
         getRoleLabel(profile),
         lastMessage ? getMessageBody(lastMessage) : "",
       ]
@@ -114,7 +113,7 @@ export function Sidebar({
       if (profile.id === currentUserId) return false;
       if (!query) return true;
 
-      const haystack = [getDisplayName(profile), profile.email ?? "", getRoleLabel(profile)]
+      const haystack = [getDisplayName(profile), getRoleLabel(profile)]
         .join(" ")
         .toLowerCase();
       return haystack.includes(query);

--- a/src/components/messages/utils.ts
+++ b/src/components/messages/utils.ts
@@ -1,9 +1,9 @@
 import { ProfileSummary, MessageRow } from "@/hooks/useMessages";
 
-export const getDisplayName = (profile?: Pick<ProfileSummary, "name" | "email"> | null) =>
-  profile?.name?.trim() || profile?.email?.split("@")[0] || "Learner";
+export const getDisplayName = (profile?: Pick<ProfileSummary, "name"> | null) =>
+  profile?.name?.trim() || "Learner";
 
-export const getInitial = (profile?: Pick<ProfileSummary, "name" | "email"> | null) =>
+export const getInitial = (profile?: Pick<ProfileSummary, "name"> | null) =>
   getDisplayName(profile).charAt(0).toUpperCase();
 
 export const getMessageBody = (message: MessageRow) =>

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -8,7 +8,6 @@ import { sanitizeMessageContent } from "@/utils/sanitize";
 export type ProfileSummary = {
   id: string;
   name: string | null;
-  email: string | null;
   avatar_url: string | null;
   is_mentor: boolean;
   is_learner: boolean;
@@ -82,7 +81,6 @@ const THREAD_PAGE_SIZE = 50;
 const normalizeProfile = (row: ProfileRow | UserRow): ProfileSummary => ({
   id: row.id,
   name: row.name,
-  email: row.email,
   avatar_url: row.avatar_url ?? null,
   is_mentor: "is_mentor" in row ? row.is_mentor : false,
   is_learner: "is_learner" in row ? row.is_learner : false,
@@ -232,7 +230,9 @@ export function useMessages(
       try {
         const { data: profileData, error: profileError } = await supabase
           .from("profiles")
-          .select("*")
+          // SECURITY (#1924): never select email — only the non-sensitive
+          // columns needed for the peer directory are fetched.
+          .select("id, name, avatar_url, is_mentor, is_learner, last_active, last_seen")
           .neq("id", currentUserId)
           .order("name", { ascending: true })
           .limit(100);

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -15,7 +15,6 @@ const MarkdownRenderer = React.lazy(() =>
 type Profile = {
   id: string;
   name: string | null;
-  email: string | null;
   avatar_url?: string | null;
 };
 
@@ -100,7 +99,7 @@ const ChatBubble = memo(
 );
 
 const getDisplayName = (profile?: Profile | null) =>
-  profile?.name || profile?.email?.split("@")[0] || "Learner";
+  profile?.name?.trim() || "Learner";
 
 const getInitial = (profile?: Profile | null) =>
   getDisplayName(profile).charAt(0).toUpperCase();
@@ -137,7 +136,7 @@ const Chat = () => {
     if (!query) return users;
 
     return users.filter((user) =>
-      `${user.name ?? ""} ${user.email ?? ""}`.toLowerCase().includes(query)
+      `${user.name ?? ""}`.toLowerCase().includes(query)
     );
   }, [search, users]);
 
@@ -169,7 +168,9 @@ const Chat = () => {
 
       const { data: profileData } = await supabase
         .from("profiles")
-        .select("*")
+        // SECURITY (#1924): select only the non-sensitive columns rendered in
+        // the chat sidebar — never email.
+        .select("id, name, avatar_url")
         .neq("id", currentUser.id)
         .order("name", { ascending: true })
         .limit(100);

--- a/src/pages/EditProfile.tsx
+++ b/src/pages/EditProfile.tsx
@@ -31,7 +31,9 @@ const EditProfile = () => {
 
       const { data } = await supabase
         .from("profiles")
-        .select("*")
+        // SECURITY (#1924): select only the editable columns rendered here —
+        // never email.
+        .select("id, name, bio, skills")
         .eq("id", user.id)
         .maybeSingle();
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -52,7 +52,9 @@ const Profile = () => {
 
       const { data: rawProfileData, error: profileError } = await supabase
         .from("profiles")
-        .select("*")
+        // SECURITY (#1924): select only the columns rendered on this page —
+        // never email.
+        .select("id, name, bio, skills, avatar_url, streak, points")
         .eq("id", user.id)
         .single();
 

--- a/supabase/migrations/20260805000001_protect_profiles_email_rls.sql
+++ b/supabase/migrations/20260805000001_protect_profiles_email_rls.sql
@@ -1,0 +1,40 @@
+-- Protect user email addresses from bulk disclosure
+-- Issue: https://github.com/durdana3105/peer-learning/issues/1924
+--
+-- Problem: The profiles table SELECT policy ("authenticated_users_can_view_profiles"
+-- USING (true)) lets any authenticated user read the full profile of every other
+-- user, including the email column. The legacy public.users compat table
+-- (which also stores email) has an equally permissive SELECT policy. The app
+-- never needs another user's email: the only client code that fetched it was
+-- selecting "*" from profiles.
+--
+-- Fix:
+--   1. Revoke column-level SELECT on profiles.email from anon + authenticated.
+--      Only the row owner (via their own profile select) and the service role
+--      (backend) can read email addresses.
+--   2. Drop the permissive SELECT policy on the legacy public.users table and
+--      revoke table-level SELECT from anon + authenticated so it cannot be used
+--      as an alternative email-exposure path.
+--
+-- NOTE: Column-level REVOKE means client queries that SELECT "*" from profiles
+-- will fail, so the frontend was updated to select only the non-sensitive
+-- columns it renders (see useMessages.ts, Profile.tsx, EditProfile.tsx).
+
+-- 1. profiles.email is PII: only the row owner (own-row select) and
+--    service_role may read it.
+REVOKE SELECT (email) ON public.profiles FROM anon, authenticated;
+
+-- 2. Legacy public.users compat table: no client role has a legitimate reason
+--    to read it. Drop the permissive policy and revoke SELECT entirely.
+DROP POLICY IF EXISTS "Authenticated users can view users" ON public.users;
+DROP POLICY IF EXISTS "Users can insert own user row" ON public.users;
+DROP POLICY IF EXISTS "Users can update own user row" ON public.users;
+
+REVOKE ALL ON public.users FROM anon, authenticated;
+
+-- Document the security model on the profiles table.
+COMMENT ON TABLE public.profiles IS
+  'User profiles with personal information.
+   Security: Authenticated users can view profile rows, but the email column is
+   only readable by the row owner and the service role (REVOKE SELECT (email)).
+   Anonymous users cannot access any profile data.';


### PR DESCRIPTION
Fixes #1924

## Problem

The `profiles` SELECT policy allows any authenticated user to read every profile row, including the `email` column. The legacy `public.users` compat table (also storing `email`) has the same permissive policy. Client code was actively fetching other users' emails via `select("*")` in the chat directory.

## Changes

- **Migration** (`20260805000001_protect_profiles_email_rls.sql`):
  - `REVOKE SELECT (email) ON public.profiles FROM anon, authenticated;` — only the row owner and service role can read emails.
  - Drop the permissive SELECT/INSERT/UPDATE policies on `public.users` and `REVOKE ALL ... FROM anon, authenticated`.
- **Frontend** — replace `select("*")` with explicit non-sensitive columns in:
  - `src/hooks/useMessages.ts` (peer directory: `id, name, avatar_url, is_mentor, is_learner, last_active, last_seen`)
  - `src/pages/Chat.tsx`, `src/pages/Profile.tsx`, `src/pages/EditProfile.tsx`
  - `src/components/messages/Sidebar.tsx`, `src/components/messages/utils.ts` — drop email-based display/search fallbacks.

## Verification

- `npm run typecheck` — no new errors (only the pre-existing `App.tsx` / `useSessions.ts` errors that also exist on main).
- `npx vitest run` for chat-related test files — 28/28 pass.
- Admin email display in `Admin.tsx` is unaffected (served by the admin-gated `admin_get_all_profiles` SECURITY DEFINER RPC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation and people search by matching display names, roles, and message content rather than email addresses.
  * Updated profile displays to use names only, with “Learner” shown when no name is available.
  * Reduced exposure of sensitive profile information by limiting retrieved profile fields.
  * Strengthened access controls for profile email addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->