### PR TITLE
Fix: Allow advanced markdown syntax in MarkdownRenderer (fixes #1912)

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -12,9 +12,18 @@ interface MarkdownRendererProps {
 const remarkPlugins: PluggableList = [remarkGfm];
 const strictSchema = {
   ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []),
+    'input',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td'
+  ],
   attributes: {
     ...defaultSchema.attributes,
+    '*': ['className', 'style'],
     a: ['href', 'title', 'target', 'rel'],
+    input: ['type', 'checked', 'disabled'],
+    th: ['align', 'colSpan', 'rowSpan'],
+    td: ['align', 'colSpan', 'rowSpan'],
   },
   protocols: {
     ...defaultSchema.protocols,


### PR DESCRIPTION
This PR fixes #1912 by configuring rehype-sanitize to allow className, style, and table/input tags. This ensures that remark-gfm can properly render nested code blocks and complex tables without stripping their styling and alignment attributes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown rendering so more table and form-related content displays correctly.
  * Preserved common formatting and styling attributes, helping content appear more accurate and consistent.
  * Enabled support for additional table alignment and spanning options in rendered Markdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->