### PR TITLE
Feat: Implement a global Dark Mode toggle (fixes #1916)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -396,25 +396,29 @@ function AppContent() {
   );
 }
 
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <TooltipProvider>
-          <Toaster />
-          <Sonner />
+      <NextThemesProvider attribute="class" defaultTheme="dark">
+        <ThemeProvider>
+          <TooltipProvider>
+            <Toaster />
+            <Sonner />
 
-          <BrowserRouter>
-            <CookieConsentProvider>
-              <AuthProvider>
-                <RoleProvider>
-                  <AppContent />
-                </RoleProvider>
-              </AuthProvider>
-            </CookieConsentProvider>
-          </BrowserRouter>
-        </TooltipProvider>
-      </ThemeProvider>
+            <BrowserRouter>
+              <CookieConsentProvider>
+                <AuthProvider>
+                  <RoleProvider>
+                    <AppContent />
+                  </RoleProvider>
+                </AuthProvider>
+              </CookieConsentProvider>
+            </BrowserRouter>
+          </TooltipProvider>
+        </ThemeProvider>
+      </NextThemesProvider>
     </QueryClientProvider>
   );
 }

--- a/src/components/Navbar/DarkModeToggle.tsx
+++ b/src/components/Navbar/DarkModeToggle.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function DarkModeToggle() {
+  const { theme, setTheme } = useTheme();
+  
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="h-10 w-10 rounded-xl text-white hover:bg-white/10"
+      aria-label="Toggle dark mode"
+      title="Toggle dark mode"
+    >
+      <Sun className="h-5 w-5 dark:hidden" />
+      <Moon className="hidden h-5 w-5 dark:block text-cyan-400" />
+    </Button>
+  );
+}

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -5,6 +5,7 @@ import Logo from "@/components/Logo";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useNavbarProfile } from "@/hooks/useNavbarProfile";
 import { ThemeToggle } from "./ThemeToggle";
+import { DarkModeToggle } from "./DarkModeToggle";
 import { DesktopNav } from "./DesktopNav";
 import { MobileNav } from "./MobileNav";
 import { UserMenu } from "./UserMenu";
@@ -45,6 +46,7 @@ const Navbar = memo(function Navbar() {
 
         {/* RIGHT SECTION */}
         <div className="hidden items-center gap-4 md:flex">
+          <DarkModeToggle />
           <ThemeToggle setTheme={setTheme} />
           <UserMenu
             user={user}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -2,8 +2,9 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { motion } from "framer-motion";
-import { ArrowLeft, Bell, Mail, Smartphone, Save } from "lucide-react";
+import { ArrowLeft, Bell, Mail, Smartphone, Save, Moon, Sun } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
+import { useTheme } from "next-themes";
 
 type NotificationCategory = "messages" | "sessions" | "friends";
 type NotificationChannels = {
@@ -23,6 +24,7 @@ const Settings = () => {
   const [preferences, setPreferences] = useState<NotificationPreferences>(DEFAULT_PREFERENCES);
   const [isSaving, setIsSaving] = useState(false);
   const [userId, setUserId] = useState<string | null>(null);
+  const { theme, setTheme } = useTheme();
 
   useEffect(() => {
     const loadPreferences = async () => {
@@ -192,6 +194,35 @@ const Settings = () => {
                   <ToggleSwitch
                     checked={preferences.friends.inApp}
                     onChange={() => handleToggle("friends", "inApp")}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Appearance Section */}
+          <div className="mt-10">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="p-3 bg-cyan-500/10 rounded-2xl border border-cyan-400/20 text-cyan-400">
+                <Moon size={28} className="hidden dark:block" />
+                <Sun size={28} className="block dark:hidden" />
+              </div>
+              <div>
+                <h2 className="text-2xl font-bold">Appearance</h2>
+                <p className="text-gray-400 mt-1">Customize the visual theme of the platform.</p>
+              </div>
+            </div>
+            
+            <div className="bg-black/20 rounded-3xl border border-white/5 overflow-hidden">
+              <div className="grid grid-cols-12 gap-4 p-5 items-center hover:bg-white/5 transition">
+                <div className="col-span-8">
+                  <h3 className="font-semibold text-lg text-gray-200">Dark Mode</h3>
+                  <p className="text-sm text-gray-400 mt-1">Toggle between light and dark mode.</p>
+                </div>
+                <div className="col-span-4 flex justify-end">
+                  <ToggleSwitch
+                    checked={theme === "dark"}
+                    onChange={() => setTheme(theme === "dark" ? "light" : "dark")}
                   />
                 </div>
               </div>


### PR DESCRIPTION
This PR fixes #1916 by integrating next-themes to toggle a dark class on the root HTML element. It also adds a Dark Mode toggle to the Navbar and Settings page.