### PR TITLE
fix(gamification): unlock activity badges from real criteria

### DIFF
--- a/src/components/dashboard/BadgesGridWidget.tsx
+++ b/src/components/dashboard/BadgesGridWidget.tsx
@@ -8,7 +8,13 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { getStreakData } from "@/lib/streakSystem";
-import { ALL_ACHIEVEMENTS } from "@/lib/gamification";
+import {
+  ALL_ACHIEVEMENTS,
+  isAchievementUnlocked,
+  type AchievementStats,
+} from "@/lib/gamification";
+import { supabase } from "@/integrations/supabase/client";
+import { useAuth } from "@/contexts/useAuth";
 
 interface Badge {
   id: string;
@@ -19,34 +25,69 @@ interface Badge {
   unlockedAt?: string;
 }
 
+async function loadAchievementStats(userId: string): Promise<AchievementStats> {
+  const [streakData, activityResult, rankResult] = await Promise.all([
+    getStreakData(),
+    supabase.from("user_activity_log").select("activity_type").eq("user_id", userId),
+    supabase.rpc("get_user_rank", { p_user_id: userId }),
+  ]);
+
+  const activityCounts: Record<string, number> = {};
+  for (const row of activityResult.data ?? []) {
+    const type = row.activity_type as string;
+    if (!type) continue;
+    activityCounts[type] = (activityCounts[type] ?? 0) + 1;
+  }
+
+  const rank =
+    typeof rankResult.data === "number"
+      ? rankResult.data
+      : Number.isFinite(Number(rankResult.data))
+        ? Number(rankResult.data)
+        : null;
+
+  return {
+    totalXP: streakData.totalXP || 0,
+    streak: streakData.streak || 0,
+    activityCounts,
+    rank,
+  };
+}
+
 export default function BadgesGridWidget() {
+  const { user } = useAuth();
   const [badges, setBadges] = useState<Badge[]>([]);
 
   useEffect(() => {
     let mounted = true;
     async function loadBadges() {
+      if (!user) {
+        if (mounted) setBadges([]);
+        return;
+      }
+
       try {
-        const data = await getStreakData();
+        const stats = await loadAchievementStats(user.id);
         if (!mounted) return;
-        const totalXP = data.totalXP || 0;
-        
-        // Map first 5 achievements for the grid
+
         const mappedBadges = ALL_ACHIEVEMENTS.slice(0, 5).map((achievement) => ({
           id: achievement.id,
           name: achievement.name,
           description: achievement.description,
           icon: achievement.icon,
-          unlocked: totalXP >= achievement.xpRequired,
+          unlocked: isAchievementUnlocked(achievement, stats),
         }));
-        
+
         setBadges(mappedBadges);
       } catch (error) {
         console.error("Failed to load badges data:", error);
       }
     }
     loadBadges();
-    return () => { mounted = false; };
-  }, []);
+    return () => {
+      mounted = false;
+    };
+  }, [user]);
 
   const unlockedCount = badges.filter((b) => b.unlocked).length;
 

--- a/src/lib/gamification.test.ts
+++ b/src/lib/gamification.test.ts
@@ -5,7 +5,18 @@ import {
   getBadgeByXP,
   getAchievements,
   getXPForActivity,
+  isAchievementUnlocked,
+  ALL_ACHIEVEMENTS,
+  type AchievementStats,
 } from "./gamification";
+
+const baseStats = (overrides: Partial<AchievementStats> = {}): AchievementStats => ({
+  totalXP: 0,
+  streak: 0,
+  activityCounts: {},
+  rank: null,
+  ...overrides,
+});
 
 describe("Gamification Utility Functions", () => {
   describe("calculateLevel", () => {
@@ -48,21 +59,65 @@ describe("Gamification Utility Functions", () => {
     });
   });
 
+  describe("isAchievementUnlocked", () => {
+    it("unlocks XP badges from totalXP alone", () => {
+      const firstSteps = ALL_ACHIEVEMENTS.find((a) => a.id === "first_steps")!;
+      expect(isAchievementUnlocked(firstSteps, baseStats({ totalXP: 49 }))).toBe(false);
+      expect(isAchievementUnlocked(firstSteps, baseStats({ totalXP: 50 }))).toBe(true);
+    });
+
+    it("does not unlock activity badges from XP alone", () => {
+      const activeLearner = ALL_ACHIEVEMENTS.find((a) => a.id === "active_learner")!;
+      const sessionHost = ALL_ACHIEVEMENTS.find((a) => a.id === "session_host")!;
+      const communityMentor = ALL_ACHIEVEMENTS.find((a) => a.id === "community_mentor")!;
+
+      const highXpNoActivity = baseStats({ totalXP: 5000 });
+      expect(isAchievementUnlocked(activeLearner, highXpNoActivity)).toBe(false);
+      expect(isAchievementUnlocked(sessionHost, highXpNoActivity)).toBe(false);
+      expect(isAchievementUnlocked(communityMentor, highXpNoActivity)).toBe(false);
+    });
+
+    it("unlocks activity badges when the required activity count is met", () => {
+      const activeLearner = ALL_ACHIEVEMENTS.find((a) => a.id === "active_learner")!;
+      const sessionHost = ALL_ACHIEVEMENTS.find((a) => a.id === "session_host")!;
+
+      expect(
+        isAchievementUnlocked(
+          activeLearner,
+          baseStats({ activityCounts: { session_join: 1 } })
+        )
+      ).toBe(true);
+
+      expect(
+        isAchievementUnlocked(
+          sessionHost,
+          baseStats({ activityCounts: { host_session: 1 } })
+        )
+      ).toBe(false);
+
+      expect(
+        isAchievementUnlocked(
+          sessionHost,
+          baseStats({ activityCounts: { host_session: 2 } })
+        )
+      ).toBe(true);
+    });
+  });
+
   describe("getAchievements", () => {
-    it("should return no achievements if below 50 XP", () => {
-      expect(getAchievements(49)).toEqual([]);
+    it("should return no achievements if below 50 XP and without activity", () => {
+      expect(getAchievements(baseStats({ totalXP: 49 }))).toEqual([]);
     });
 
     it("should return First Steps for 50 XP", () => {
-      expect(getAchievements(50)).toEqual(["First Steps"]);
+      expect(getAchievements(baseStats({ totalXP: 50 }))).toEqual(["First Steps"]);
     });
 
-    it("should return multiple achievements as XP grows", () => {
-      const achievements = getAchievements(550);
+    it("should require activity for Active Learner even with high XP", () => {
+      const achievements = getAchievements(baseStats({ totalXP: 550 }));
       expect(achievements).toContain("First Steps");
-      expect(achievements).toContain("Active Learner");
-      expect(achievements).toContain("Knowledge Explorer");
-      expect(achievements).not.toContain("Consistency King");
+      expect(achievements).not.toContain("Active Learner");
+      expect(achievements).not.toContain("Knowledge Explorer");
     });
   });
 

--- a/src/lib/gamification.ts
+++ b/src/lib/gamification.ts
@@ -15,16 +15,115 @@ export const ALL_BADGES = [
   { id: "grandmaster", name: "🏆 Grandmaster", xpRequired: 5000, description: "Earned 5000 XP" },
 ];
 
-export const ALL_ACHIEVEMENTS = [
-  { id: "first_steps", name: "First Steps", xpRequired: 50, icon: "👣", description: "Earned your first 50 XP" },
-  { id: "active_learner", name: "Active Learner", xpRequired: 200, icon: "📚", description: "Participated in sessions" },
-  { id: "knowledge_explorer", name: "Knowledge Explorer", xpRequired: 500, icon: "🧭", description: "Consistently learning" },
-  { id: "consistency_king", name: "Consistency King", xpRequired: 750, icon: "👑", description: "Earned for high activity" },
-  { id: "community_mentor", name: "Community Mentor", xpRequired: 1000, icon: "🤝", description: "Helped others grow" },
-  { id: "session_host", name: "Session Host", xpRequired: 1500, icon: "🎙️", description: "Hosted multiple sessions" },
-  { id: "top_mentor", name: "Top Mentor", xpRequired: 2500, icon: "🥇", description: "Outstanding guidance" },
-  { id: "top_contributor", name: "Top 10 Contributor", xpRequired: 3000, icon: "🌟", description: "Reached the top 10" },
+export type AchievementCriterion =
+  | { type: "xp"; min: number }
+  | { type: "streak"; min: number }
+  | { type: "activity"; activity: string; min: number }
+  | { type: "rank"; max: number };
+
+export type Achievement = {
+  id: string;
+  name: string;
+  /** Soft XP hint for UI only; unlock is driven by `criteria`. */
+  xpRequired: number;
+  icon: string;
+  description: string;
+  criteria: AchievementCriterion;
+};
+
+export type AchievementStats = {
+  totalXP: number;
+  streak: number;
+  activityCounts: Record<string, number>;
+  rank: number | null;
+};
+
+export const ALL_ACHIEVEMENTS: Achievement[] = [
+  {
+    id: "first_steps",
+    name: "First Steps",
+    xpRequired: 50,
+    icon: "👣",
+    description: "Earned your first 50 XP",
+    criteria: { type: "xp", min: 50 },
+  },
+  {
+    id: "active_learner",
+    name: "Active Learner",
+    xpRequired: 200,
+    icon: "📚",
+    description: "Participated in sessions",
+    criteria: { type: "activity", activity: "session_join", min: 1 },
+  },
+  {
+    id: "knowledge_explorer",
+    name: "Knowledge Explorer",
+    xpRequired: 500,
+    icon: "🧭",
+    description: "Maintained a 7-day learning streak",
+    criteria: { type: "streak", min: 7 },
+  },
+  {
+    id: "consistency_king",
+    name: "Consistency King",
+    xpRequired: 750,
+    icon: "👑",
+    description: "Maintained a 14-day learning streak",
+    criteria: { type: "streak", min: 14 },
+  },
+  {
+    id: "community_mentor",
+    name: "Community Mentor",
+    xpRequired: 1000,
+    icon: "🤝",
+    description: "Helped others grow",
+    criteria: { type: "activity", activity: "mentor_help", min: 1 },
+  },
+  {
+    id: "session_host",
+    name: "Session Host",
+    xpRequired: 1500,
+    icon: "🎙️",
+    description: "Hosted multiple sessions",
+    criteria: { type: "activity", activity: "host_session", min: 2 },
+  },
+  {
+    id: "top_mentor",
+    name: "Top Mentor",
+    xpRequired: 2500,
+    icon: "🥇",
+    description: "Hosted five or more mentorship sessions",
+    criteria: { type: "activity", activity: "host_session", min: 5 },
+  },
+  {
+    id: "top_contributor",
+    name: "Top 10 Contributor",
+    xpRequired: 3000,
+    icon: "🌟",
+    description: "Reached the top 10",
+    criteria: { type: "rank", max: 10 },
+  },
 ];
+
+export const isAchievementUnlocked = (
+  achievement: Achievement,
+  stats: AchievementStats
+): boolean => {
+  const { criteria } = achievement;
+
+  switch (criteria.type) {
+    case "xp":
+      return stats.totalXP >= criteria.min;
+    case "streak":
+      return stats.streak >= criteria.min;
+    case "activity":
+      return (stats.activityCounts[criteria.activity] ?? 0) >= criteria.min;
+    case "rank":
+      return stats.rank != null && stats.rank > 0 && stats.rank <= criteria.max;
+    default:
+      return false;
+  }
+};
 
 export const getBadgeByXP = (xp: number) => {
   // Return highest achieved badge string for backwards compatibility, or empty string if none.
@@ -32,9 +131,8 @@ export const getBadgeByXP = (xp: number) => {
   return earned.length > 0 ? earned[0].name : "🌱 Beginner";
 };
 
-export const getAchievements = (xp: number) => {
-  // Return array of strings for backwards compatibility.
-  return ALL_ACHIEVEMENTS.filter(a => xp >= a.xpRequired).map(a => a.name);
+export const getAchievements = (stats: AchievementStats) => {
+  return ALL_ACHIEVEMENTS.filter((a) => isAchievementUnlocked(a, stats)).map((a) => a.name);
 };
 
 export const getXPForActivity = (activity: string) => {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -12,8 +12,10 @@ import {
   calculateLevel,
   getBadgeByXP,
   getAchievements,
+  isAchievementUnlocked,
   ALL_BADGES,
-  ALL_ACHIEVEMENTS
+  ALL_ACHIEVEMENTS,
+  type AchievementStats,
 } from "../lib/gamification";
 
 const avatars = [
@@ -25,6 +27,13 @@ const avatars = [
   "https://api.dicebear.com/7.x/adventurer/svg?seed=Sophia",
 ];
 const MAX_BIO_CHARS = 300;
+const emptyAchievementStats: AchievementStats = {
+  totalXP: 0,
+  streak: 0,
+  activityCounts: {},
+  rank: null,
+};
+
 const Profile = () => {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
@@ -39,6 +48,7 @@ const Profile = () => {
     level: 1,
     badge: "",
     achievements: [],
+    achievementStats: emptyAchievementStats,
   });
 
   // FETCH PROFILE
@@ -50,11 +60,15 @@ const Profile = () => {
 
       if (!user) return;
 
-      const { data: rawProfileData, error: profileError } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("id", user.id)
-        .single();
+      const [
+        { data: rawProfileData, error: profileError },
+        { data: activityRows },
+        { data: rankData },
+      ] = await Promise.all([
+        supabase.from("profiles").select("*").eq("id", user.id).single(),
+        supabase.from("user_activity_log").select("activity_type").eq("user_id", user.id),
+        supabase.rpc("get_user_rank", { p_user_id: user.id }),
+      ]);
 
       if (profileError) {
         console.error("Failed to fetch profile:", profileError);
@@ -65,6 +79,27 @@ const Profile = () => {
       const profileData = rawProfileData as any;
 
       if (profileData) {
+        const activityCounts: Record<string, number> = {};
+        for (const row of activityRows ?? []) {
+          const type = row.activity_type as string;
+          if (!type) continue;
+          activityCounts[type] = (activityCounts[type] ?? 0) + 1;
+        }
+
+        const rank =
+          typeof rankData === "number"
+            ? rankData
+            : Number.isFinite(Number(rankData))
+              ? Number(rankData)
+              : null;
+
+        const achievementStats: AchievementStats = {
+          totalXP: profileData.points || 0,
+          streak: profileData.streak || 0,
+          activityCounts,
+          rank,
+        };
+
         setProfile({
           name: profileData.name || "",
           bio: profileData.bio || "",
@@ -74,7 +109,8 @@ const Profile = () => {
           xp: profileData.points || 0,
           level: calculateLevel(profileData.points || 0),
           badge: getBadgeByXP(profileData.points || 0),
-          achievements: getAchievements(profileData.points || 0),
+          achievements: getAchievements(achievementStats),
+          achievementStats,
         });
       }
     };
@@ -381,7 +417,10 @@ if (profile.bio.length > MAX_BIO_CHARS) {
                 <h3 className="text-xl font-semibold mb-4 text-gray-300">Achievements</h3>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                   {ALL_ACHIEVEMENTS.map((achievement) => {
-                    const isUnlocked = profile.xp >= achievement.xpRequired;
+                    const isUnlocked = isAchievementUnlocked(
+                      achievement,
+                      profile.achievementStats ?? emptyAchievementStats
+                    );
                     return (
                       <motion.div
                         key={achievement.id}
@@ -397,7 +436,7 @@ if (profile.bio.length > MAX_BIO_CHARS) {
                         </h4>
                         {!isUnlocked && (
                           <div className="flex items-center gap-1 mt-2 text-[10px] text-gray-500 bg-black/30 px-2 py-1 rounded-md">
-                            <Lock size={10} /> {achievement.xpRequired} XP
+                            <Lock size={10} /> {achievement.description}
                           </div>
                         )}
                       </motion.div>


### PR DESCRIPTION
## Summary

Earned Badges treated every achievement as XP-gated, so high-XP accounts unlocked Session Host / Community Mentor without hosting or mentoring.

Achievements now declare criteria (XP, streak, `user_activity_log` counts, or leaderboard rank). The dashboard widget and Profile both evaluate those instead of `totalXP >= xpRequired`.

## Testing

- `npx vitest run src/lib/gamification.test.ts`
- `npx eslint` on touched files

Fixes #1904

Made with [Cursor](https://cursor.com)