### PR TITLE
fix(ci): update api.md and uploadPhoto tests to fix CI test failures

### DIFF
--- a/backend/tests/uploadPhoto.test.js
+++ b/backend/tests/uploadPhoto.test.js
@@ -167,7 +167,7 @@ describe("POST /api/users/upload-photo", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     // Filename must contain the authenticated user's ID
-    expect(res.body.fileUrl).toMatch(new RegExp(`profile-${TEST_USER_ID}-`));
+    expect(res.body.fileUrl).toContain(TEST_USER_ID);
   });
 
   it("returns 200 when a valid JWT is supplied via HttpOnly cookie", async () => {
@@ -221,9 +221,9 @@ describe("POST /api/users/upload-photo", () => {
     expect(res.body.error).toMatch(/no file/i);
   });
 
-  it("returns 413 when the uploaded file exceeds the 5MB size limit", async () => {
+  it("returns 413 when the uploaded file exceeds the 2MB size limit", async () => {
     const token = makeToken();
-    const oversized = Buffer.alloc(6 * 1024 * 1024, 0xff); // 6 MB of 0xFF bytes
+    const oversized = Buffer.alloc(3 * 1024 * 1024, 0xff); // 3 MB of 0xFF bytes
     const res = await request(app)
       .post("/api/users/upload-photo")
       .set("Authorization", `Bearer ${token}`)
@@ -233,7 +233,7 @@ describe("POST /api/users/upload-photo", () => {
       });
 
     expect(res.status).toBe(413);
-    expect(res.body.error).toMatch(/5mb/i);
+    expect(res.body.error).toMatch(/2mb/i);
   });
 });
 

--- a/backend/tests/uploadPhoto.test.js
+++ b/backend/tests/uploadPhoto.test.js
@@ -166,8 +166,10 @@ describe("POST /api/users/upload-photo", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
-    // Filename must contain the authenticated user's ID
+    // Filename/path must contain the authenticated user's ID
     expect(res.body.fileUrl).toContain(TEST_USER_ID);
+    const pathSegments = new URL(res.body.fileUrl).pathname.split("/").filter(Boolean);
+    expect(pathSegments).toContain(TEST_USER_ID);
   });
 
   it("returns 200 when a valid JWT is supplied via HttpOnly cookie", async () => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -131,10 +131,42 @@ Sends a browser push notification to all subscribed devices for a given `user_id
 
 **Security**: Standard users may only send push notifications to themselves (IDOR prevention). Webhook callers authenticated via `WEBHOOK_SECRET` may send to any user.
 
+## Upload Routes (`/api/upload` & `/api/users/upload-photo`)
+
 ### `POST /api/upload`
 
-Uploads generic project resources with magic byte validation (accepted types: avatars, resources).
+Uploads generic project resources with magic byte validation.
+
+**Auth**: Requires a valid Supabase JWT token in `Authorization: Bearer <token>` or `access_token` cookie.  
+**Content-Type**: `multipart/form-data`  
+**Form Fields**:
+- `file` (File, required): The file to upload.
+- `folder` (string, required): Permitted values are `avatars` or `resources`.
+
+**Response** (`200 OK`):
+```json
+{
+  "success": true,
+  "data": {
+    "url": "https://<supabase-url>/storage/v1/object/public/resources/user-id/filename.pdf"
+  }
+}
+```
 
 ### `POST /api/users/upload-photo`
 
 Uploads user profile photos (avatars) with magic byte validation.
+
+**Auth**: Requires a valid Supabase JWT token in `Authorization: Bearer <token>` or `access_token` cookie.  
+**Content-Type**: `multipart/form-data`  
+**Form Fields**:
+- `profilePhoto` (File, required): The profile image file (max size: 2 MiB).
+
+**Response** (`200 OK`):
+```json
+{
+  "success": true,
+  "fileUrl": "https://<supabase-url>/storage/v1/object/public/avatars/user-id/filename.png"
+}
+```
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -130,3 +130,11 @@ Sends a browser push notification to all subscribed devices for a given `user_id
 ```
 
 **Security**: Standard users may only send push notifications to themselves (IDOR prevention). Webhook callers authenticated via `WEBHOOK_SECRET` may send to any user.
+
+### `POST /api/upload`
+
+Uploads generic project resources with magic byte validation (accepted types: avatars, resources).
+
+### `POST /api/users/upload-photo`
+
+Uploads user profile photos (avatars) with magic byte validation.


### PR DESCRIPTION
## Description

This PR fixes #1940 the failing CI tests on GitHub Actions.

### What caused the test failures?

1. **Missing documentation (`docs/api.md`)**:
   The test file `docs.test.js` checks if backend routes are documented. It was failing because the `/api/upload` and `/api/users/upload-photo` endpoints were missing from `docs/api.md`.

2. **Outdated test rules (`uploadPhoto.test.js`)**:
   - The test was checking for an old 5MB file upload limit, but the backend limit was updated to 2MB.
   - The test was also checking for an old filename structure that didn't match the actual uploaded file path returned by the server.

## Changes Made

- Added documentation for `/api/upload` and `/api/users/upload-photo` in `docs/api.md`.
- Updated `uploadPhoto.test.js` to match the correct 2MB limit and correct user file URL format.

## Verification

Ran both CI test commands locally:

1. **Full Suite with Coverage**:

   ```bash
   npx vitest run --coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added API documentation for photo and file upload endpoints.
- Documented authentication, multipart fields, supported folders, response formats, file-size limits, and file validation.

## Tests
- Expanded upload coverage to verify returned URLs include the authenticated user’s ID.
- Retained checks for URL scoping and successful storage uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->