### PR TITLE
feat: add RSVP option for study sessions

### DIFF
--- a/src/components/sessions/RsvpSection.tsx
+++ b/src/components/sessions/RsvpSection.tsx
@@ -1,0 +1,97 @@
+import { Check, HelpCircle, X } from "lucide-react";
+
+type RsvpStatus = "going" | "maybe" | "cant_attend";
+
+type RsvpSectionProps = {
+  sessionStatus: string;
+  myRsvp: RsvpStatus | null;
+  rsvpCounts: {
+    going: number;
+    maybe: number;
+    cant_attend: number;
+  };
+  rsvpLoading: boolean;
+  updateRsvp: (status: RsvpStatus) => void;
+};
+
+const options: {
+  status: RsvpStatus;
+  label: string;
+  icon: typeof Check;
+}[] = [
+  {
+    status: "going",
+    label: "Going",
+    icon: Check,
+  },
+  {
+    status: "maybe",
+    label: "Maybe",
+    icon: HelpCircle,
+  },
+  {
+    status: "cant_attend",
+    label: "Can't Attend",
+    icon: X,
+  },
+];
+
+export function RsvpSection({
+  sessionStatus,
+  myRsvp,
+  rsvpCounts,
+  rsvpLoading,
+  updateRsvp,
+}: RsvpSectionProps) {
+    if (sessionStatus !== "scheduled") {
+    return null;
+  }
+  return (
+    <div className="mt-4 bg-white/5 border border-white/10 rounded-2xl p-4">
+      <div className="mb-3">
+        <h3 className="font-semibold text-white">RSVP</h3>
+        <p className="text-xs text-gray-400 mt-1">
+          Let the host know if you plan to attend.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-3 gap-2">
+        {options.map(({ status, label, icon: Icon }) => {
+          const selected = myRsvp === status;
+          const count = rsvpCounts[status];
+
+          return (
+            <button
+              key={status}
+              type="button"
+              disabled={rsvpLoading}
+              onClick={() => updateRsvp(status)}
+              className={`flex flex-col items-center justify-center gap-1 rounded-xl border px-2 py-3 text-sm transition ${
+                selected
+                  ? "border-cyan-400 bg-cyan-400/10 text-cyan-300"
+                  : "border-white/10 bg-white/5 text-gray-300 hover:bg-white/10"
+              } ${rsvpLoading ? "opacity-60 cursor-not-allowed" : ""}`}
+            >
+              <Icon size={18} />
+              <span>{label}</span>
+              <span className="text-xs text-gray-400">{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {myRsvp && (
+        <p className="text-xs text-gray-400 mt-3">
+          Your response:{" "}
+          <span className="text-cyan-300 font-medium">
+            {myRsvp === "going"
+              ? "Going"
+              : myRsvp === "maybe"
+                ? "Maybe"
+                : "Can't Attend"}
+          </span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/sessions/SessionChat.tsx
+++ b/src/components/sessions/SessionChat.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect } from "react";
 import { Send, Video, Sparkles, BellOff, Bell, Download, Pin, PinOff } from "lucide-react";
 import { LiveCodeRunner } from "@/components/studyroom/LiveCodeRunner";
 import { MarkdownRenderer } from "@/components/MarkdownRenderer";
+import { RsvpSection } from "@/components/sessions/RsvpSection";
 
 type SessionChatProps = {
   selectedSession: any;
@@ -16,6 +17,14 @@ type SessionChatProps = {
   studyTime: number;
   isFocusMode: boolean;
   setIsFocusMode: (val: boolean) => void;
+  myRsvp: "going" | "maybe" | "cant_attend" | null;
+  rsvpCounts: {
+    going: number;
+    maybe: number;
+    cant_attend: number;
+  };
+  rsvpLoading: boolean;
+  updateRsvp: (status: "going" | "maybe" | "cant_attend") => void;
   sendMessage: (msg: string) => Promise<boolean>;
   togglePinMessage: (msgId: string, currentPinStatus: boolean) => void;
   sendTypingEvent: () => void;
@@ -37,6 +46,10 @@ export function SessionChat({
   studyTime,
   isFocusMode,
   setIsFocusMode,
+  myRsvp,
+  rsvpCounts,
+  rsvpLoading,
+  updateRsvp,
   sendMessage,
   togglePinMessage,
   sendTypingEvent,
@@ -164,6 +177,14 @@ export function SessionChat({
               </div>
             </div>
             
+            <RsvpSection
+              sessionStatus={selectedSession?.status}
+              myRsvp={myRsvp}
+              rsvpCounts={rsvpCounts}
+              rsvpLoading={rsvpLoading}
+              updateRsvp={updateRsvp}
+            />
+
             <button
               onClick={handleExport}
               title="Export Session Notes and Chat"

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -39,6 +39,17 @@ export function useSessions(user: any) {
   const [participantCount, setParticipantCount] = useState(1);
   const [isVideoActive, setIsVideoActive] = useState(false);
   const [sessionSummary, setSessionSummary] = useState<any>(null);
+  const [myRsvp, setMyRsvp] = useState<
+  "going" | "maybe" | "cant_attend" | null
+>(null);
+
+const [rsvpCounts, setRsvpCounts] = useState({
+  going: 0,
+  maybe: 0,
+  cant_attend: 0,
+});
+
+const [rsvpLoading, setRsvpLoading] = useState(false);
   const [summaryLoading, setSummaryLoading] = useState(false);
   const [studyTime, setStudyTime] = useState(60 * 60);
 
@@ -114,10 +125,17 @@ export function useSessions(user: any) {
   // - messages: without this, the previous session's thread stays rendered
   //   for the whole fetch round-trip after switching.
   useEffect(() => {
-    setParticipantCount(1);
-    setSessionSummary(null);
-    setMessages([]);
-  }, [selectedSession]);
+  setParticipantCount(1);
+  setSessionSummary(null);
+  setMessages([]);
+
+  setMyRsvp(null);
+  setRsvpCounts({
+    going: 0,
+    maybe: 0,
+    cant_attend: 0,
+  });
+}, [selectedSession]);
 
   useEffect(() => {
     if (!selectedSession) return;
@@ -267,7 +285,92 @@ export function useSessions(user: any) {
       window.removeEventListener("click", handleActivity);
     };
   }, []);
+const fetchRsvpData = useCallback(async () => {
+  if (!selectedSession || !user?.id) {
+    return;
+  }
 
+  try {
+    const { data, error } = await (supabase as any).rpc(
+      "get_session_rsvp_summary",
+      {
+        p_session_id: selectedSession.id,
+      }
+    );
+
+    if (error) {
+      throw error;
+    }
+
+    const summary = Array.isArray(data) ? data[0] : data;
+
+    setMyRsvp(summary?.my_status ?? null);
+
+    setRsvpCounts({
+      going: Number(summary?.going_count ?? 0),
+      maybe: Number(summary?.maybe_count ?? 0),
+      cant_attend: Number(summary?.cant_attend_count ?? 0),
+    });
+  } catch (error) {
+    console.error("Failed to fetch RSVP data:", error);
+
+    setMyRsvp(null);
+    setRsvpCounts({
+      going: 0,
+      maybe: 0,
+      cant_attend: 0,
+    });
+  }
+}, [selectedSession, user]);
+
+useEffect(() => {
+  fetchRsvpData();
+}, [fetchRsvpData]);
+
+const updateRsvp = useCallback(
+  async (status: "going" | "maybe" | "cant_attend") => {
+    if (!selectedSession || !user?.id) return;
+
+    setRsvpLoading(true);
+
+    try {
+      const { error } = await (supabase as any).rpc(
+        "set_session_rsvp",
+        {
+          p_session_id: selectedSession.id,
+          p_status: status,
+        }
+      );
+
+      if (error) {
+        throw error;
+      }
+
+      setMyRsvp(status);
+
+      toast({
+        title: "RSVP updated",
+        description:
+          status === "going"
+            ? "You're marked as going."
+            : status === "maybe"
+              ? "You're marked as maybe."
+              : "You're marked as unable to attend.",
+      });
+
+      await fetchRsvpData();
+    } catch (error: any) {
+      toast({
+        title: "Unable to update RSVP",
+        description: error.message || "Failed to update RSVP.",
+        variant: "destructive",
+      });
+    } finally {
+      setRsvpLoading(false);
+    }
+  },
+  [selectedSession, user, fetchRsvpData, toast]
+);
   const handleJoinSession = useCallback(async (e: React.MouseEvent, sessionId: string) => {
     e.stopPropagation();
     try {
@@ -439,6 +542,10 @@ export function useSessions(user: any) {
     studyTime,
     isFocusMode,
     setIsFocusMode,
+    myRsvp,
+    rsvpCounts,
+    rsvpLoading,
+    updateRsvp,
     handleJoinSession,
     sendMessage,
     togglePinMessage,

--- a/src/pages/Sessions.tsx
+++ b/src/pages/Sessions.tsx
@@ -30,6 +30,10 @@ export default function Sessions() {
     studyTime,
     isFocusMode,
     setIsFocusMode,
+    myRsvp,
+    rsvpCounts,
+    rsvpLoading,
+    updateRsvp,
     handleJoinSession,
     sendMessage,
     sendTypingEvent,
@@ -99,6 +103,10 @@ export default function Sessions() {
               studyTime={studyTime}
               isFocusMode={isFocusMode}
               setIsFocusMode={setIsFocusMode}
+              myRsvp={myRsvp}
+              rsvpCounts={rsvpCounts}
+              rsvpLoading={rsvpLoading}
+              updateRsvp={updateRsvp}
               togglePinMessage={togglePinMessage}
               sendMessage={sendMessage}
               sendTypingEvent={sendTypingEvent}

--- a/supabase/migrations/20260809000001_add_session_rsvps.sql
+++ b/supabase/migrations/20260809000001_add_session_rsvps.sql
@@ -1,0 +1,208 @@
+-- ============================================================
+-- Study Session RSVP
+-- Issue: #1921
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.session_rsvps (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  session_id UUID NOT NULL
+    REFERENCES public.sessions(id)
+    ON DELETE CASCADE,
+
+  user_id UUID NOT NULL
+    REFERENCES auth.users(id)
+    ON DELETE CASCADE,
+
+  status TEXT NOT NULL
+    CHECK (status IN ('going', 'maybe', 'cant_attend')),
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT session_rsvps_session_user_unique
+    UNIQUE (session_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS session_rsvps_session_id_idx
+  ON public.session_rsvps (session_id);
+
+CREATE INDEX IF NOT EXISTS session_rsvps_user_id_idx
+  ON public.session_rsvps (user_id);
+
+ALTER TABLE public.session_rsvps ENABLE ROW LEVEL SECURITY;
+
+
+-- ============================================================
+-- Row Level Security
+--
+-- Users can read only their own RSVP.
+-- RSVP writes are handled through the secure RPC below so that
+-- the "upcoming sessions only" rule cannot be bypassed.
+-- ============================================================
+
+DROP POLICY IF EXISTS "Users can view own session RSVP"
+  ON public.session_rsvps;
+
+CREATE POLICY "Users can view own session RSVP"
+  ON public.session_rsvps
+  FOR SELECT
+  TO authenticated
+  USING (user_id = auth.uid());
+
+
+DROP POLICY IF EXISTS "Users can create own session RSVP"
+  ON public.session_rsvps;
+
+DROP POLICY IF EXISTS "Users can update own session RSVP"
+  ON public.session_rsvps;
+
+DROP POLICY IF EXISTS "Users can delete own session RSVP"
+  ON public.session_rsvps;
+
+
+-- ============================================================
+-- Secure RSVP update
+--
+-- Users can only RSVP to upcoming/scheduled sessions.
+-- The unique constraint ensures one RSVP per user/session.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.set_session_rsvp(
+  p_session_id UUID,
+  p_status TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_session_status TEXT;
+  v_user_id UUID;
+BEGIN
+  v_user_id := auth.uid();
+
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF p_status NOT IN ('going', 'maybe', 'cant_attend') THEN
+    RAISE EXCEPTION 'Invalid RSVP status';
+  END IF;
+
+  SELECT status
+  INTO v_session_status
+  FROM public.sessions
+  WHERE id = p_session_id;
+
+  IF v_session_status IS NULL THEN
+    RAISE EXCEPTION 'Session not found';
+  END IF;
+
+  IF v_session_status <> 'scheduled' THEN
+    RAISE EXCEPTION 'RSVP is only available for upcoming sessions';
+  END IF;
+
+  INSERT INTO public.session_rsvps (
+    session_id,
+    user_id,
+    status,
+    updated_at
+  )
+  VALUES (
+    p_session_id,
+    v_user_id,
+    p_status,
+    now()
+  )
+  ON CONFLICT (session_id, user_id)
+  DO UPDATE SET
+    status = EXCLUDED.status,
+    updated_at = now();
+
+  RETURN p_status;
+END;
+$$;
+
+
+-- ============================================================
+-- RSVP summary
+--
+-- Returns aggregate counts and the current user's RSVP.
+-- Individual RSVP rows remain protected by RLS.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.get_session_rsvp_summary(
+  p_session_id UUID
+)
+RETURNS TABLE (
+  my_status TEXT,
+  going_count BIGINT,
+  maybe_count BIGINT,
+  cant_attend_count BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.sessions
+    WHERE id = p_session_id
+  ) THEN
+    RAISE EXCEPTION 'Session not found';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    (
+      SELECT r.status
+      FROM public.session_rsvps r
+      WHERE r.session_id = p_session_id
+        AND r.user_id = auth.uid()
+    ) AS my_status,
+
+    COUNT(*) FILTER (
+      WHERE r.status = 'going'
+    ) AS going_count,
+
+    COUNT(*) FILTER (
+      WHERE r.status = 'maybe'
+    ) AS maybe_count,
+
+    COUNT(*) FILTER (
+      WHERE r.status = 'cant_attend'
+    ) AS cant_attend_count
+
+  FROM public.session_rsvps r
+  WHERE r.session_id = p_session_id;
+END;
+$$;
+
+
+-- ============================================================
+-- Function permissions
+-- ============================================================
+
+REVOKE ALL
+  ON FUNCTION public.set_session_rsvp(UUID, TEXT)
+  FROM PUBLIC;
+
+GRANT EXECUTE
+  ON FUNCTION public.set_session_rsvp(UUID, TEXT)
+  TO authenticated;
+
+
+REVOKE ALL
+  ON FUNCTION public.get_session_rsvp_summary(UUID)
+  FROM PUBLIC;
+
+GRANT EXECUTE
+  ON FUNCTION public.get_session_rsvp_summary(UUID)
+  TO authenticated;


### PR DESCRIPTION
## Description

Closes #1921

This PR adds an RSVP feature for upcoming study sessions so participants can indicate whether they plan to attend.

### Changes

- Added an RSVP section to the Study Session details.
- Added three RSVP options:
  - ✅ Going
  - 🤔 Maybe
  - ❌ Can't Attend
- Users can change their RSVP before the session starts.
- Displays the total RSVP count for each option.
- Displays the current user's selected RSVP.
- RSVP controls are hidden once a session is no longer scheduled.
- Added a unique constraint to ensure one RSVP per user per session.
- Added secure Supabase RPCs for creating/updating RSVPs and retrieving RSVP summaries.
- Added Row Level Security for RSVP records.
- Session hosts can view the RSVP summary.

### Testing

- `npx tsc --noEmit` ✅
- `git diff --check` ✅

### Notes

The existing session creation and joining workflow is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RSVP controls to scheduled sessions, including “Going,” “Maybe,” and “Can’t attend” options.
  * Displays RSVP counts and the current user’s response.
  * Added loading feedback while RSVP updates are processed.
  * RSVP selections refresh automatically when the session changes.
  * Added validation to allow RSVPs only for scheduled sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->