### PR TITLE
fix: leaderboard score-immutability policy fails to apply (OLD/NEW in…

### DIFF
--- a/supabase/migrations/20260808000000_fix_leaderboard_score_immutability_policy.sql
+++ b/supabase/migrations/20260808000000_fix_leaderboard_score_immutability_policy.sql
@@ -1,0 +1,18 @@
+-- Replaces the still-permissive UPDATE policy: 20260730000001 and
+-- 20260803000002 both fail to apply because they reference OLD/NEW
+-- inside CREATE POLICY, which Postgres only allows in triggers.
+
+DROP POLICY IF EXISTS "Users can update leaderboard entry" ON public.leaderboard;
+DROP POLICY IF EXISTS "Users can update own profile fields" ON public.leaderboard;
+DROP POLICY IF EXISTS "users_can_update_profile_only" ON public.leaderboard;
+
+CREATE POLICY "Users can update own profile fields" ON public.leaderboard
+  FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (
+    user_id = auth.uid()
+    AND xp = (SELECT xp FROM public.leaderboard WHERE user_id = auth.uid())
+    AND streak = (SELECT streak FROM public.leaderboard WHERE user_id = auth.uid())
+    AND sessions_joined = (SELECT sessions_joined FROM public.leaderboard WHERE user_id = auth.uid())
+    AND badges = (SELECT badges FROM public.leaderboard WHERE user_id = auth.uid())
+  );


### PR DESCRIPTION
## Problem

The leaderboard `xp`/`streak`/`badges`/`sessions_joined` columns are supposed to be locked down so only server-side functions can change them. Two prior migrations tried to enforce this but both fail to apply:

- `20260730000001_secure_leaderboard_updates.sql`
- `20260803000002_enforce_leaderboard_score_immutability.sql`

Both reference `OLD`/`NEW` inside a `CREATE POLICY ... WITH CHECK (...)` clause. Postgres only exposes `OLD`/`NEW` inside trigger functions, not policies, so both statements fail with `missing FROM-clause entry for table "old"` and roll back entirely. The table is still governed by the original, fully permissive UPDATE policy any authenticated user can set their own `xp` directly.

## Fix

Adds one new migration that replaces the UPDATE policy correctly, using a same-table subquery to compare against the pre-update row instead of `OLD`:

```sql
AND xp = (SELECT xp FROM public.leaderboard WHERE user_id = auth.uid())
```

This is the same pattern already used elsewhere in this codebase (`profiles` table RLS).

## Testing

Verified against a local Postgres instance:
- Confirmed the two existing migrations fail exactly as described above
- Confirmed this migration applies cleanly
- Confirmed direct `xp`/`badges` forgery is rejected
- Confirmed legitimate `username`/`avatar_url` updates still work
- Confirmed the server-side XP-award path (`increment_user_xp`) is unaffected

Closes #1952 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard data protection by ensuring users can update only their own leaderboard entry.
  * Prevented changes to scores, streaks, session counts, and badges during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->