### PR TITLE
fix: pass reference_id to award_activity_xp for chat, upload, and hos…

### DIFF
--- a/src/components/resources/UploadDialog.tsx
+++ b/src/components/resources/UploadDialog.tsx
@@ -103,7 +103,7 @@ const UploadDialog = ({ open, onOpenChange, onSuccess }: UploadDialogProps) => {
     }
 
     toast.success("Resource uploaded successfully.");
-    awardXP.mutate({ activity: "resource_upload" });
+    awardXP.mutate({ activity: "resource_upload", referenceId: result.data.id });
     resetForm();
     onOpenChange(false);
     onSuccess();

--- a/src/hooks/useCreateSession.ts
+++ b/src/hooks/useCreateSession.ts
@@ -92,15 +92,19 @@ export function useCreateSession({ onSuccess, setOpen }: UseCreateSessionProps) 
       const durationMinutes = resolveDurationMinutes(values);
       const seatLimit = values.seatLimit && values.seatLimit.trim() !== "" ? parseInt(values.seatLimit, 10) : null;
 
-      const { error } = await supabase.from("sessions").insert({
-        title: values.title,
-        description: values.description,
-        scheduled_at: scheduledAt.toISOString(),
-        duration_minutes: durationMinutes,
-        status: "scheduled",
-        mentor_id: user.id,
-        seat_limit: seatLimit,
-      });
+      const { data, error } = await supabase
+        .from("sessions")
+        .insert({
+          title: values.title,
+          description: values.description,
+          scheduled_at: scheduledAt.toISOString(),
+          duration_minutes: durationMinutes,
+          status: "scheduled",
+          mentor_id: user.id,
+          seat_limit: seatLimit,
+        })
+        .select("id")
+        .single();
 
       if (error) throw error;
 
@@ -113,7 +117,7 @@ export function useCreateSession({ onSuccess, setOpen }: UseCreateSessionProps) 
       setSelectedPreset(60);
       setUseCustom(false);
       setOpen(false);
-      awardXP.mutate({ activity: "host_session" });
+      awardXP.mutate({ activity: "host_session", referenceId: data.id });
       onSuccess();
     } catch (error: unknown) {
       const msg =

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -604,7 +604,7 @@ export function useMessages(
         });
 
         upsertRawSummary(nextMessage, selectedUser.id, false);
-        awardXP.mutate({ activity: "chat_message" });
+        awardXP.mutate({ activity: "chat_message", referenceId: nextMessage.id });
       }
       return true;
     } catch (err: any) {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -403,18 +403,22 @@ const Chat = () => {
     setMessageText("");
     await sendTypingStatus(false);
 
-    const { error } = await supabase.from("messages").insert({
-      sender_id: currentUser.id,
-      receiver_id: selectedUser.id,
-      content,
-      text: content,
-    });
+    const { data, error } = await supabase
+      .from("messages")
+      .insert({
+        sender_id: currentUser.id,
+        receiver_id: selectedUser.id,
+        content,
+        text: content,
+      })
+      .select("id")
+      .single();
 
     if (error) {
       setMessageText(content);
       console.error("Failed to send message:", error.message);
     } else {
-      awardXP.mutate({ activity: "chat_message" });
+      awardXP.mutate({ activity: "chat_message", referenceId: data.id });
     }
   }, [currentUser?.id, messageText, selectedUser?.id, sendTypingStatus, awardXP]);
 


### PR DESCRIPTION
## Problem

Chat messages, resource uploads, and hosting a session are each supposed to award XP repeatably (up to a daily cap), but in practice they only ever award XP once per user, for the lifetime of the account.

`award_activity_xp()` logs every award to `user_activity_log` under a `UNIQUE NULLS NOT DISTINCT (user_id, activity_type, reference_id)` constraint. Three call sites never pass a `referenceId`:

- `chat_message` (`useMessages.ts`, `Chat.tsx`)
- `resource_upload` (`UploadDialog.tsx`)
- `host_session` (`useCreateSession.ts`)

The first call succeeds and inserts a row with `reference_id = NULL`. Because `NULLS NOT DISTINCT` treats every NULL as equal, every later attempt collides with that same row, hits the unique constraint, and the function's exception handler silently returns with no XP. The intended "10 per day" cap never actually gets reached.

## Fix

Pass the id of the row just created (the new message, resource, or session) as `referenceId` at each call site, mirroring what `session_join` already does correctly with `sessionId`. No SQL changes needed the RPC and the constraint already support this; the bug was purely that callers never passed a value.

Changed files:
- `src/hooks/useMessages.ts`
- `src/pages/Chat.tsx`
- `src/components/resources/UploadDialog.tsx`
- `src/hooks/useCreateSession.ts`

## Testing

Verified against a local Postgres instance running the real `award_activity_xp` function:
- Reproduced the bug: repeated `chat_message` calls with `reference_id = NULL` stop earning XP after the first
- Confirmed the fix: distinct `reference_id`s let XP accrue normally, correctly capped at 10/day
- Confirmed retry-safety: resending the same `reference_id` does not double-award
- Confirmed no regression to `session_join`'s existing idempotency behavior

Closes #1951 